### PR TITLE
Add slack integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ All job configs are located in [`config/jobs`](config/jobs).
    $ kubectl apply -f config/prow/cluster/build
    ```   
 1. Create the required secrets (mainly in the prow cluster):
-    - `github-token` (Personal Access Token for [@gardener-ci-robot](https://github.com/gardener-ci-robot) with scopes `public_repo, read:org, repo:status`, needs to be present in the `prow` and `test-pods` namespace of the prow cluster)
     - `gardener-prow-storage` (Service account with `Storage Admin` permissions for GCS bucket, according to [test-infra guide](https://github.com/kubernetes/test-infra/blob/f8021394c8e493af2d3ec336a87888368d92e0c8/prow/getting_started_deploy.md#configure-a-gcs-bucket), needs to be present in the `prow` namespace and in the `test-pods` namespace in both clusters)
     - `github-app` (according to [test-infra guide](https://github.com/kubernetes/test-infra/blob/f8021394c8e493af2d3ec336a87888368d92e0c8/prow/getting_started_deploy.md#github-app))
+    - `github-token` (Personal Access Token for [@gardener-ci-robot](https://github.com/gardener-ci-robot) with scopes `public_repo, read:org, repo:status`, needs to be present in the `prow` and `test-pods` namespace of the prow cluster)
     - `github-oauth-config` (according to [test-infra guide](https://github.com/kubernetes/test-infra/blob/f8021394c8e493af2d3ec336a87888368d92e0c8/prow/cmd/deck/github_oauth_setup.md))
     - `hmac-token`
       ```bash
@@ -75,6 +75,7 @@ All job configs are located in [`config/jobs`](config/jobs).
           user:
             token: <<service-account-token-with-cluster-admin-permissions>> # generated via gencred
         ```
+    - `slack-token` (according to [test-infra guide](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/crier/README.md#slack-reporter))
 1. Deploy Prow components. The initial deployment has to be done manually, later on changes to the components will be automatically deployed once merged into master.
    ```bash
    $ ./config/prow/deploy.sh

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ This is currently under construction / in evaluation phase.
 
 ## CI Job Management
 
-Gardener uses a [`prow`](https://github.com/kubernetes/test-infra/blob/master/prow) instance at [prow.gardener.cloud] to handle CI and
-automation for parts of the project. Everyone can participate in a
-self-service PR-based workflow, where changes are automatically deployed
-after they have been reviewed. All job configs are located in [`config/jobs`].
+Gardener uses a [`prow`](https://github.com/kubernetes/test-infra/blob/master/prow) instance at [prow.gardener.cloud](https://prow.gardener.cloud) to handle CI and automation for parts of the project.
+Everyone can participate in a self-service PR-based workflow, where changes are automatically deployed after they have been reviewed and merge.
+All job configs are located in [`config/jobs`](config/jobs).
 
 ## How to setup
 

--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -9,6 +9,9 @@ periodics:
   - org: gardener
     repo: ci-infra
     base_ref: master
+  reporter_config:
+    slack:
+      channel: "gardener-prow-alerts"
   spec:
     containers:
     - image: gcr.io/k8s-prow/label_sync:v20211201-aa97daa0b4
@@ -41,6 +44,9 @@ periodics:
   - org: gardener
     repo: ci-infra
     base_ref: master
+  reporter_config:
+    slack:
+      channel: "gardener-prow-alerts"
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20211201-aa97daa0b4
@@ -65,6 +71,9 @@ periodics:
   - org: gardener
     repo: ci-infra
     base_ref: master
+  reporter_config:
+    slack:
+      channel: "gardener-prow-alerts"
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20211201-aa97daa0b4

--- a/config/jobs/ci-infra/ci-infra-postsubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-postsubmits.yaml
@@ -7,15 +7,20 @@ postsubmits:
     branches:
     - ^master$
     max_concurrency: 1
-#    reporter_config:
-#      slack:
-#        channel: "prow-alerts"
-#        job_states_to_report:
-#        - success
-#        - failure
-#        - aborted
-#        - error
-#        report_template: 'Deploying prow: {{.Status.State}}. Commit: <{{.Spec.Refs.BaseLink}}|{{printf "%.7s" .Spec.Refs.BaseSHA}}> | <{{.Status.URL}}|Spyglass> | <https://testgrid.k8s.io/sig-testing-prow#deploy-prow|Testgrid> | <https://prow.k8s.io/?job={{.Spec.Job}}|Deck>'
+    reporter_config:
+      slack:
+        channel: "gardener-prow-alerts"
+        job_states_to_report:
+        - success
+        - failure
+        - aborted
+        - error
+        report_template: |
+          *Deploying prow*
+          *Job:* {{.Spec.Job}} ({{.Spec.Type}})
+          *Status:* {{.Status.State}}
+          *Commit:* <{{.BaseLink}}|{{printf "%.7s" .BaseSHA}}>
+          *<{{.Status.URL}}|Spyglass> | <https://prow.gardener.cloud/?job={{.Spec.Job}}|Deck>*
     spec:
       serviceAccountName: deployer
       containers:

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -21,16 +21,16 @@ spec:
       - name: crier
         image: gcr.io/k8s-prow/crier:v20211201-aa97daa0b4
         args:
-        - --blob-storage-workers=1
+        - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml
         - --gcs-credentials-file=/etc/gcs-credentials/service-account.json
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
-        - --github-workers=5
+        - --github-workers=10
         - --job-config-path=/etc/job-config
-        - --kubernetes-blob-storage-workers=1
-#        - --slack-token-file=/etc/slack/token
-#        - --slack-workers=1
+        - --kubernetes-blob-storage-workers=10
+        - --slack-token-file=/etc/slack/token
+        - --slack-workers=10
         - --github-app-id=$(GITHUB_APP_ID)
         - --github-app-private-key-path=/etc/github/cert
         env:
@@ -49,21 +49,21 @@ spec:
         - name: github-app
           mountPath: /etc/github
           readOnly: true
-        - mountPath: /etc/kubeconfig
-          name: kubeconfig
-          readOnly: true
         - name: config
           mountPath: /etc/config
           readOnly: true
         - name: job-config
           mountPath: /etc/job-config
           readOnly: true
+        - name: slack
+          mountPath: /etc/slack
+          readOnly: true
+        - mountPath: /etc/kubeconfig
+          name: kubeconfig
+          readOnly: true
         - name: gcs-credentials
           mountPath: /etc/gcs-credentials
           readOnly: true
-#        - name: slack
-#          mountPath: /etc/slack
-#          readOnly: true
       volumes:
       - name: github-app
         secret:
@@ -74,9 +74,9 @@ spec:
       - name: job-config
         configMap:
           name: job-config
-#      - name: slack
-#        secret:
-#          secretName: slack-token
+      - name: slack
+        secret:
+          secretName: slack-token
       - name: kubeconfig
         secret:
           defaultMode: 420

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -28,11 +28,11 @@ spec:
         imagePullPolicy: Always
         args:
         - --dry-run=false
-#        - --slack-token-file=/etc/slack/token
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
+        - --slack-token-file=/etc/slack/token
         - --github-app-id=$(GITHUB_APP_ID)
         - --github-app-private-key-path=/etc/github/cert
         env:
@@ -53,8 +53,8 @@ spec:
         - name: github-app
           mountPath: /etc/github
           readOnly: true
-#        - name: slack
-#          mountPath: /etc/slack
+        - name: slack
+          mountPath: /etc/slack
         - name: hmac
           mountPath: /etc/webhook
           readOnly: true
@@ -67,12 +67,6 @@ spec:
         - name: plugins
           mountPath: /etc/plugins
           readOnly: true
-#        - name: cat-api
-#          mountPath: /etc/cat-api
-#          readOnly: true
-#        - name: unsplash-api
-#          mountPath: /etc/unsplash-api
-#          readOnly: true
         - name: kubeconfig
           mountPath: /etc/kubeconfig
           readOnly: true
@@ -93,9 +87,9 @@ spec:
       - name: github-app
         secret:
           secretName: github-app
-#      - name: slack
-#        secret:
-#          secretName: slack-token
+      - name: slack
+        secret:
+          secretName: slack-token
       - name: hmac
         secret:
           secretName: hmac-token
@@ -108,12 +102,6 @@ spec:
       - name: plugins
         configMap:
           name: plugins
-#      - name: cat-api
-#        configMap:
-#          name: cat-api-key
-#      - name: unsplash-api
-#        secret:
-#          secretName: unsplash-api-key
       - name: kubeconfig
         secret:
           defaultMode: 420

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -95,28 +95,6 @@ prowjob_namespace: prow
 pod_namespace: test-pods
 log_level: debug
 
-#managed_webhooks:
-#  # This has to be true if any of the managed repo/org is using the legacy global token that is manually created.
-#  respect_legacy_global_token: true
-#  # Config for orgs and repos that have been onboarded to this Prow instance.
-#  org_repo_config:
-#    bazelbuild/rules_k8s:
-#      token_created_after: 2020-06-24T00:10:00Z
-#    kubernetes:
-#      token_created_after: 2020-08-12T00:00:00Z
-#    kubernetes-client:
-#      token_created_after: 2020-07-24T00:00:00Z
-#    kubernetes-csi:
-#      token_created_after: 2020-08-12T00:00:00Z
-#    kubernetes-security:
-#      token_created_after: 2021-05-19T00:00:00Z
-#    kubernetes-sigs:
-#      token_created_after: 2020-08-12T00:00:00Z
-#    containerd/containerd:
-#      token_created_after: 2020-09-17T00:00:00Z
-#    cncf/apisnoop:
-#      token_created_after: 2020-09-22T00:00:00Z
-
 slack_reporter_configs:
   '*':
     job_types_to_report:
@@ -501,12 +479,12 @@ tide:
     - lgtm
     - approved
     missingLabels:
-    - do-not-merge
     - do-not-merge/blocked-paths
     - do-not-merge/contains-merge-commits
     - do-not-merge/hold
     - do-not-merge/invalid-commit-message
     - do-not-merge/invalid-owners-file
+    - do-not-merge/needs-kind
     - do-not-merge/release-note-label-needed
     - do-not-merge/work-in-progress
     - needs-rebase

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -126,9 +126,13 @@ slack_reporter_configs:
     job_states_to_report:
       - failure
       - error
-    channel: test-failures
-    # The template shown below is the default
-    report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <{{.Status.URL}}|View logs>'
+    channel: gardener-test-failures
+    report_template: |
+      *Job:* {{.Spec.Job}} ({{.Spec.Type}})
+      *Status:* {{.Status.State}}
+      {{ with .Spec.Refs}}*Repository:* {{.Org}}/{{.Repo}}
+      *Commit:* <{{.BaseLink}}|{{printf "%.7s" .BaseSHA}}>
+      {{ end}}*<{{.Status.URL}}|View logs>*
 
 #branch-protection:
 #  orgs:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -52,102 +52,15 @@ blunderbuss:
 heart:
   commentregexp: ".*"
 
-#slack:
-#  mergewarnings:
-#  - repos:
-#    - kubernetes/community
-#    - kubernetes/org
-#    channels:
-#    - sig-contribex
-#    exempt_users:
-#    - k8s-ci-robot
-#  - repos:
-#    - kubernetes/enhancements
-#    channels:
-#    - enhancements
-#    exempt_users:
-#    - k8s-ci-robot
-#  - repos:
-#    - kubernetes/utils
-#    - kubernetes/component-helpers
-#    channels:
-#    - sig-architecture
-#    exempt_users:
-#    - k8s-ci-robot
-#    - k8s-publishing-bot
-#  - repos:
-#    - kubernetes/api
-#    - kubernetes/apiextensions-apiserver
-#    - kubernetes/apimachinery
-#    - kubernetes/apiserver
-#    - kubernetes/client-go
-#    - kubernetes/code-generator
-#    - kubernetes/component-base
-#    - kubernetes/controller-manager
-#    - kubernetes/kube-aggregator
-#    - kubernetes/kube-controller-manager
-#    - kubernetes/sample-apiserver
-#    - kubernetes/sample-controller
-#    channels:
-#    - sig-api-machinery
-#    exempt_users:
-#    - k8s-publishing-bot
-#  - repos:
-#    - kubernetes/pod-security-admission
-#    channels:
-#    - sig-auth
-#    exempt_users:
-#    - k8s-publishing-bot
-#  - repos:
-#    - kubernetes/kubernetes
-#    channels:
-#    - github-management
-#    exempt_users:
-#    - k8s-ci-robot # future home of tide
-#    - k8s-release-robot # anago
-#    exempt_branches:
-#        feature-serverside-apply:
-#            - lavalamp # feature-serverside-apply "branch manager"
-#            - apelisse # feature-serverside-apply "branch manager"
-#        feature-rate-limiting:
-#            - lavalamp # feature-rate-limiting "branch manager"
-#            - deads2k # feature-rate-limiting "branch manager"
-#  - repos:
-#    - kubernetes/test-infra
-#    channels:
-#    - testing-ops
-#    exempt_users:
-#    - k8s-ci-robot
-#  - repos:
-#    - kubernetes/sig-release
-#    channels:
-#    - release-management
-#    exempt_users:
-#    - k8s-ci-robot
-#  - repos:
-#    - kubernetes/release
-#    channels:
-#    - release-management
-#    exempt_users:
-#    - k8s-ci-robot
-#  - repos:
-#    - kubernetes/k8s.io
-#    channels:
-#    - sig-k8s-infra
-#    exempt_users:
-#    - k8s-ci-robot
-#  - repos:
-#    - kubernetes/kops
-#    channels:
-#    - kops-dev
-#    exempt_users:
-#    - k8s-ci-robot
-#  - repos:
-#    - kubernetes/cluster-api-provider-aws
-#    channels:
-#    - cluster-api-aws
-#    exempt_users:
-#    - k8s-ci-robot
+slack:
+  # warn about manual merges
+  mergewarnings:
+  - repos:
+    - gardener/ci-infra
+    channels:
+    - gardener-prow-alerts
+    exempt_users:
+    - gardener-prow[bot]
 
 #milestone_applier:
 #  kubernetes/enhancements:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -4,19 +4,14 @@ triggers:
 - repos:
   - gardener/ci-infra
   only_org_members: true
-#  join_org_url: "https://git.k8s.io/community/community-membership.md#member"
-
-#owners:
-#  mdyamlrepos:
-#  - kubernetes/website
-#  skip_collaborators:
-#  - kubernetes-sigs/contributor-playground
 
 approve:
 - repos:
   - gardener/ci-infra
-  require_self_approval: false
   lgtm_acts_as_approve: true
+  require_self_approval: true
+  commandHelpLink: "https://prow.gardener.cloud/command-help"
+  pr_process_link: "https://gardener.cloud/docs/contribute/#pull-request-checklist"
 
 # Lower bounds in number of lines changed; XS is assumed to be zero.
 size:
@@ -38,13 +33,6 @@ lgtm:
   - gardener/ci-infra
   review_acts_as_lgtm: true
 
-#blockades:
-#- repos:
-#  - kubernetes/kubernetes
-#  blockregexps:
-#  - ^examples/
-#  explanation: "examples/ has moved to https://github.com/kubernetes/examples/"
-
 blunderbuss:
   max_request_count: 2
   use_status_availability: true
@@ -62,153 +50,14 @@ slack:
     exempt_users:
     - gardener-prow[bot]
 
-#milestone_applier:
-#  kubernetes/enhancements:
-#    master: v1.23
-#  kubernetes/kubernetes:
-#    master: v1.23
-#    release-1.22: v1.22
-#    release-1.21: v1.21
-#    release-1.20: v1.20
-#    release-1.19: v1.19
-#  kubernetes/org:
-#    main: v1.23
-#  kubernetes/release:
-#    master: v1.23
-#  kubernetes/sig-release:
-#    master: v1.23
-#  kubernetes/test-infra:
-#    master: v1.23
-#  kubernetes/k8s.io:
-#    main: v1.23
-#  kubernetes/kops:
-#    master: v1.23
-#    release-1.22: v1.22
-#    release-1.21: v1.21
-#    release-1.20: v1.20
-#    release-1.19: v1.19
-#    release-1.18: v1.18
-#    release-1.17: v1.17
-#    release-1.16: v1.16
-#  kubernetes-sigs/cluster-api:
-#    main: v0.4
-#    release-0.4: v0.4
-#    operator-0.4: v0.4 # Remove this when it gets merged back.
-#    release-0.3: v0.3
-#  kubernetes-sigs/cluster-api-provider-aws:
-#    main: v0.7.0
-#    release-0.6: v0.6.x
-#  kubernetes-sigs/cluster-api-provider-azure:
-#    main: v0.5
-#    release-0.4: v0.4.16
-#  kubernetes-sigs/cluster-api-provider-digitalocean:
-#    main: v0.5.0
-#    release-0.4: v0.4.3
-#  kubernetes-sigs/cluster-api-provider-gcp:
-#    main: v0.4
-#    release-0.4: v0.4
-#    release-0.3: v0.3
-#  kubernetes-sigs/boskos:
-#    master: v1.23
-#  kubernetes-sigs/controller-runtime:
-#    master: v0.10.x
-#    release-0.9: v0.9.x
-#    release-0.8: v0.8.x
-#    release-0.7: v0.7.x
-#    release-0.6: v0.6.x
-#    release-0.5: v0.5.x
-#  kubernetes/website:
-#    dev-1.23: 1.23
-
-#repo_milestone:
-#  # Default maintainer
-#  '':
-#    # You can curl the following endpoint in order to determine the github ID of your team
-#    # responsible for maintaining the milestones. You may need to specify the page number.
-#    # curl -H "Authorization: token <token>" "https://api.github.com/orgs/<org-name>/teams?page=N"
-#    maintainers_id: 2460384
-#    maintainers_team: milestone-maintainers
-#  kubernetes-sigs/controller-runtime:
-#    maintainers_id: 2785806
-#    maintainers_team: controller-runtime-maintainers
-#    maintainers_friendly_name: Controller Runtime Maintainers
-#  kubernetes-sigs/cluster-api:
-#    maintainers_id: 3058957
-#    maintainers_team: cluster-api-maintainers
-#    maintainers_friendly_name: Cluster API Maintainers
-#  kubernetes-sigs/cluster-api-provider-aws:
-#    maintainers_id: 2830895
-#    maintainers_team: cluster-api-provider-aws-maintainers
-#    maintainers_friendly_name: Cluster API Provider AWS Maintainers
-#  kubernetes-sigs/cluster-api-provider-azure:
-#    maintainers_id: 3063852
-#    maintainers_team: cluster-api-provider-azure-maintainers
-#    maintainers_friendly_name: Cluster API Provider Azure Maintainers
-#  kubernetes-sigs/cluster-api-provider-digitalocean:
-#    maintainers_id: 2978501
-#    maintainers_team: cluster-api-provider-digitalocean-maintainers
-#    maintainers_friendly_name: Cluster API Provider DigitalOcean Maintainers
-#  kubernetes-sigs/cluster-api-provider-gcp:
-#    maintainers_id: 2829767
-#    maintainers_team: cluster-api-provider-gcp-maintainers
-#    maintainers_friendly_name: Cluster API Provider GCP Maintainers
-#  kubernetes-sigs/cluster-api-provider-nested:
-#    maintainers_id: 4158805
-#    maintainers_team: cluster-api-provider-nested-maintainers
-#    maintainers_friendly_name: Cluster API Provider Nested Maintainers
-#  kubernetes-sigs/cluster-api-provider-vsphere:
-#    maintainers_id: 2850058
-#    maintainers_team: cluster-api-provider-vsphere-maintainers
-#    maintainers_friendly_name: Cluster API Provider vSphere Maintainers
-#  kubernetes/community:
-#    maintainers_id: 3169231
-#    maintainers_team: community-milestone-maintainers
-#    maintainers_friendly_name: Community Milestone Maintainers
-#  kubernetes/kops:
-#    maintainers_id: 2060651
-#    maintainers_team: kops-maintainers
-#    maintainers_friendly_name: Kops Maintainers
-#  kubernetes/org:
-#    maintainers_id: 2842373
-#    maintainers_team: owners
-#    maintainers_friendly_name: GitHub Admin Team
-#  kubernetes/website:
-#    maintainers_id: 3175912
-#    maintainers_team: website-milestone-maintainers
-#    maintainers_friendly_name: Website milestone maintainers
-#  kubernetes/kubeadm:
-#    maintainers_id: 2195382
-#    maintainers_team: kubeadm-maintainers
-#    maintainers_friendly_name: Kubeadm maintainers
-#  kubernetes-sigs/kubebuilder:
-#    maintainers_id: 2688053
-#    maintainers_team: kubebuilder-maintainers
-#    maintainers_friendly_name: Kubebuilder Maintainers
-
-#project_config:
-#  project_org_configs:
-#    kubernetes:
-#      org_maintainers_team_id: 3162587 # sig-testing-dummy-project-team
-#      org_default_column_map:
-#        test-infra-dummy-testing-project-plugin:
-#          To do
-#        KEP Implementation Tracking:
-#          To do
-#      project_repo_configs:
-#        kubernetes:
-#          repo_maintainers_team_id: 2460384 # milestone-maintainers
-#          repo_default_column_map:
-#            component-base:
-#              To do
-#            Workloads:
-#              Backlog
-#        website:
-#          repo_maintainers_team_id: 3175912 # website-milestone-maintainers
-#          repo_default_column_map:
-#            component-base:
-#              To do
-#            Doc Writing and Editing:
-#              To do
+repo_milestone:
+  # Default maintainer
+  '':
+    # You can curl the following endpoint in order to determine the github ID of your team
+    # responsible for maintaining the milestones. You may need to specify the page number.
+    # curl -H "Authorization: token <token>" "https://api.github.com/orgs/<org-name>/teams?page=N"
+    maintainers_id: 5415312
+    maintainers_team: ci-infra-maintainers
 
 config_updater:
   maps:
@@ -229,13 +78,10 @@ config_updater:
         gardener-prow-trusted:
         - prow
 
-#welcome:
-#- repos:
-#  - kubernetes
-#  - kubernetes-client
-#  - kubernetes-csi
-#  - kubernetes-sigs
-#  message_template: "Welcome @{{.AuthorLogin}}! <br><br>It looks like this is your first PR to <a href='https://github.com/{{.Org}}/{{.Repo}}'>{{.Org}}/{{.Repo}}</a> 🎉. Please refer to our [pull request process documentation](https://git.k8s.io/community/contributors/guide/pull-requests.md) to help your PR have a smooth ride to approval. <br><br>You will be prompted by a bot to use commands during the review process. Do not be afraid to follow the prompts! It is okay to experiment. [Here is the bot commands documentation](https://go.k8s.io/bot-commands). <br><br>You can also check if {{.Org}}/{{.Repo}} has [its own contribution guidelines](https://github.com/{{.Org}}/{{.Repo}}/tree/master/CONTRIBUTING.md). <br><br>You may want to refer to our [testing guide](https://git.k8s.io/community/contributors/devel/sig-testing/testing.md) if you run into trouble with your tests not passing. <br><br>If you are having difficulty getting your pull request seen, please follow the [recommended escalation practices](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#why-is-my-pull-request-not-getting-reviewed). Also, for tips and tricks in the contribution process you may want to read the [Kubernetes contributor cheat sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet/README.md). We want to make sure your contribution gets all the attention it needs! <br><br>Thank you, and welcome to Kubernetes. :smiley:"
+welcome:
+- repos:
+  - gardener/ci-infra
+  message_template: "Welcome @{{.AuthorLogin}}! <br><br>It looks like this is your first PR to <a href='https://github.com/{{.Org}}/{{.Repo}}'>{{.Org}}/{{.Repo}}</a> 🎉. Please refer to our [pull request process documentation](https://gardener.cloud/docs/contribute/#pull-request-checklist) to help your PR have a smooth ride to approval. <br><br>You will be prompted by a bot to use commands during the review process. Do not be afraid to follow the prompts! It is okay to experiment. [Here is the bot commands documentation](https://prow.k8s.io/command-help). <br><br>You can also check if {{.Org}}/{{.Repo}} has [its own contribution guidelines](https://github.com/{{.Org}}/{{.Repo}}/tree/master/CONTRIBUTING.md). <br><br>Thank you, and welcome to Gardener. :smiley:"
 
 require_matching_label:
 - missing_label: do-not-merge/needs-kind
@@ -247,17 +93,6 @@ require_matching_label:
 retitle:
   allow_closed_issues: true
 
-#cherry_pick_unapproved:
-#  comment: |
-#    This cherry pick PR is for a release branch and has not yet been approved by [Release Managers](https://git.k8s.io/sig-release/release-managers.md).
-#    Adding the `do-not-merge/cherry-pick-not-approved` label.
-#
-#    To merge this cherry pick, it must first be approved (`/lgtm` + `/approve`) by the relevant OWNERS.
-#
-#    **AFTER** it has been approved by code owners, please ping the **kubernetes/release-managers** team in a comment to request a cherry pick review.
-#
-#    (For details on the patch release process and schedule, see the [Patch Releases](https://git.k8s.io/sig-release/releases/patch-releases.md) page.)
-
 # Enabled plugins per repo.
 # Keys: Full repo name: "org/repo".
 # Values: List of plugins to run against the repo.
@@ -266,7 +101,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blockade
     - blunderbuss
     - config-updater
     - dog
@@ -282,6 +116,7 @@ plugins:
     - milestone
     - override
     - owners-label
+    - require-matching-label
     - retitle
     - shrug
     - size
@@ -290,6 +125,7 @@ plugins:
     - trick-or-treat
     - trigger
     - verify-owners
+    - welcome
     - wip
     - yuks
 


### PR DESCRIPTION
Adds slack integration for important jobs (e.g. prow deploy, autobump), and failing postsubmit/periodic/batch jobs.
Also removes unused config and adapts some more config to our project.