### PR TITLE
Enable slackevents plugin

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -121,6 +121,7 @@ plugins:
     - shrug
     - size
     - skip
+    - slackevents
     - transfer-issue
     - trick-or-treat
     - trigger


### PR DESCRIPTION
/kind bug
Hook didn't alert on manual merge of https://github.com/gardener/ci-infra/pull/7, because `slackevents` was not enabled.
Merging this PR manually to test things again.