### PR TITLE
Add gardener e2e test (postsubmit)

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -1,0 +1,59 @@
+postsubmits:
+  gardener/gardener:
+  - name: post-gardener-e2e-kind
+    cluster: gardener-prow-build
+    always_run: true
+    # skip_if_only_changed: "^docs/|\\.md$"
+    branches:
+    # for now, we execute this as postsubmit to our development branch, later on we can add a presubmit + periodic job
+    # on master
+    - local-extension
+    decorate: true
+    decoration_config:
+      timeout: 120m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20211124-2ed05120f3-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - |
+          set -o nounset
+          set -o pipefail
+          set -o errexit
+
+          # https://github.com/kubernetes/test-infra/issues/23741
+          iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
+          # install kind
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+          chmod +x ./kind
+          mv ./kind /usr/local/bin
+
+          # test setup
+          make kind-up
+          export KUBECONFIG=$PWD/example/provider-local/base/kubeconfig
+          make gardener-up
+
+          # run test
+          make test-e2e-local
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: 7
+            memory: 9000Mi
+          requests:
+            cpu: 7
+            memory: 9000Mi
+        env:
+        - name: SKAFFOLD_UPDATE_CHECK
+          value: "false"
+        - name: SKAFFOLD_INTERACTIVE
+          value: "false"

--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -234,3 +234,17 @@ repos:
         target: both
         prowPlugin: shrug
         addedBy: humans
+  gardener/gardener:
+    labels:
+      - color: b60205
+        description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
+        name: needs-ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow
+      - color: 15dd18
+        description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
+        name: ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -3,6 +3,7 @@
 triggers:
 - repos:
   - gardener/ci-infra
+  - gardener/gardener
   only_org_members: true
 
 approve:
@@ -128,6 +129,11 @@ plugins:
     - welcome
     - wip
     - yuks
+  gardener/gardener:
+    plugins:
+    - override
+    - skip
+    - trigger
 
 external_plugins:
   gardener/ci-infra:


### PR DESCRIPTION
/kind enhancement
Adds a job (postsubmit for now), that runs the new e2e test with provider-local, ref https://github.com/gardener/gardener/issues/5024