### PR TITLE
Update ProwJob CRD to fix periodics with slack channel overwrite

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -93,6 +93,7 @@ periodics:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:
       - --config=config/prow/autobump-config/prow-component-autobump-config.yaml
+      - --labels-override=kind/enhancement
       volumeMounts:
       - name: github-token
         mountPath: /etc/github-token
@@ -122,6 +123,7 @@ periodics:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:
       - --config=config/prow/autobump-config/prow-job-autobump-config.yaml
+      - --labels-override=kind/enhancement
       volumeMounts:
       - name: github-token
         mountPath: /etc/github-token

--- a/config/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -1,4 +1,4 @@
-# from https://github.com/kubernetes/test-infra/blob/40d2900a41d5daeb84ba2e11d027e6d68b56403e/config/prow/cluster/prowjob_customresourcedefinition.yaml
+# from https://raw.githubusercontent.com/kubernetes/test-infra/68c18d9abb5c54b35848f54d9be9c16cada4af4d/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -19976,10 +19976,19 @@ spec:
                           description: ProwJobState specifies whether the job is running
                           type: string
                         type: array
+                      report:
+                        description: 'Report is derived from JobStatesToReport, it''s
+                          used for differentiating nil from empty slice, as yaml roundtrip
+                          by design can''t tell the difference when omitempty is supplied.
+                          See https://github.com/kubernetes/test-infra/pull/24168
+                          for details Priority-wise, it goes by following order: -
+                          `report: true/false`` in job config - `JobStatesToReport:
+                          <anything including empty slice>` in job config - `report:
+                          true/false`` in global config - `JobStatesToReport:` in
+                          global config'
+                        type: boolean
                       report_template:
                         type: string
-                    required:
-                    - job_states_to_report
                     type: object
                 type: object
               rerun_auth_config:


### PR DESCRIPTION
**What this PR does / why we need it**:

Update `ProwJob` CRD to get in https://github.com/kubernetes/test-infra/pull/24280, also see https://github.com/kubernetes/test-infra/pull/24168

**Which issue(s) this PR fixes**:
Without this update, horologium fails to create jobs for periodics that specify a slack channel overwrite (e.g. `ci-prow-label-sync` and `ci-prow-autobump`) without specifying `job_states_to_report`:

```
{"client":"cron","component":"horologium","file":"prow/cron/cron.go:157","func":"k8s.io/test-infra/prow/cron.(*Cron).addJob.func1","level":"info","msg":"Triggering cron job ci-prow-autobump.","severity":"info","time":"2021-12-13T13:30:00Z"}
{"component":"horologium","file":"prow/cmd/horologium/main.go:189","func":"main.sync","job":"ci-prow-autobump","level":"info","msg":"Triggering new run of cron periodic.","name":"dab016cc-5c18-11ec-90a6-9675eb69b6f2","previous-found":true,"severity":"info","should-trigger":true,"state":"triggered","time":"2021-12-13T13:30:35Z","type":"periodic"}
{"component":"horologium","error":"failed to create 1 prowjobs: [ProwJob.prow.k8s.io \"dab016cc-5c18-11ec-90a6-9675eb69b6f2\" is invalid: spec.reporter_config.slack.job_states_to_report: Required value]","file":"prow/cmd/horologium/main.go:137","func":"main.main.func3","level":"error","msg":"Error syncing periodic jobs.","severity":"error","time":"2021-12-13T13:30:35Z"}
```

/kind bug
