### PR TITLE
Add gardener-e2e-kind presubmit and periodic

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -1,13 +1,10 @@
-postsubmits:
+presubmits:
   gardener/gardener:
-  - name: post-gardener-e2e-kind
+  - name: pull-gardener-e2e-kind
     cluster: gardener-prow-build
-    always_run: true
-    # skip_if_only_changed: "^docs/|\\.md$"
-    branches:
-    # for now, we execute this as postsubmit to our development branch, later on we can add a presubmit + periodic job
-    # on master
-    - local-extension
+    skip_if_only_changed: "^docs/|\\.md$"
+    skip_branches:
+    - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true
     decoration_config:
       timeout: 120m
@@ -57,3 +54,60 @@ postsubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
+periodics:
+- name: ci-gardener-e2e-kind
+  cluster: gardener-prow-build
+  interval: 4h
+  extra_refs:
+  - org: gardener
+    repo: gardener
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 120m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20211217-ea95cec1d4-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - |
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+
+        # https://github.com/kubernetes/test-infra/issues/23741
+        iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
+        # install kind
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+        chmod +x ./kind
+        mv ./kind /usr/local/bin
+
+        # test setup
+        make kind-up
+        export KUBECONFIG=$PWD/example/provider-local/base/kubeconfig
+        make gardener-up
+
+        # run test
+        make test-e2e-local
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          cpu: 7
+          memory: 9000Mi
+        requests:
+          cpu: 7
+          memory: 9000Mi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"


### PR DESCRIPTION
**What this PR does / why we need it**:

Transforms postsubmit `post-gardener-e2e-kind` on `local-extension` into presubmit `pull-gardener-e2e-kind` (not required for merge currently) and `ci-gardener-e2e-kind` (on `master` every 4 hours).

Test run on `master` is at: https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind/1472942458718392320

/kind enhancement