### PR TITLE
Activate label sync for g/g

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -22,7 +22,7 @@ periodics:
       args:
       - --config=config/prow/labels.yaml
       - --confirm=true
-      - --only=gardener/ci-infra
+      - --only=gardener/ci-infra,gardener/gardener
       - --endpoint=http://ghproxy.prow.svc
       - --endpoint=https://api.github.com
       # TODO: switch to GitHub App Auth, once it's implemented in label_sync


### PR DESCRIPTION
**What this PR does / why we need it**:

Sync `needs-ok-to-test` and `ok-to-test` to g/g (used by the `trigger` plugin for non-org members).
Thereby, we make it possible to run the e2e test for more contributors.

/kind enhancement
