### PR TITLE
Add command help to report template

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -4,6 +4,7 @@ plank:
     '*': >-
       [Full PR test history](https://prow.gardener.cloud/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
       [Your PR dashboard](https://prow.gardener.cloud/pr?query=is%3Apr%20state%3Aopen%20author%3A{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
+      [Command help for this repository](https://prow.gardener.cloud/command-help?repo={{.Spec.Refs.Org}}%2F{{.Spec.Refs.Repo}}).
   job_url_prefix_config:
     '*': https://prow.gardener.cloud/view/
   pod_pending_timeout: 15m


### PR DESCRIPTION
**What this PR does / why we need it**:

The "details part" of prow's test report comment links to kube's prow instance, but is not customizable ([hard-coded](https://github.com/kubernetes/test-infra/blob/ba34d1f94e3f90574c4fd4e0f9ba43213bfc1f72/prow/plugins/respond.go#L26-L33)).
However, in order to avoid confusion, let's add a link to our prow's command help page to the report template.

/kind enhancement