### PR TITLE
Fix deployer RBAC permissions for monitoring components

### DIFF
--- a/config/prow/cluster/trusted_serviceaccounts.yaml
+++ b/config/prow/cluster/trusted_serviceaccounts.yaml
@@ -1,4 +1,7 @@
 # RBAC used by post-ci-infra-deploy-prow
+# Note: adding permissions here requires a manual deployment using cluster-admin access, because the deployer
+# ServiceAccount is not allowed to grant access to resources which it currently does not hold:
+# `user "system:serviceaccount:test-pods:deployer" (groups=...) is attempting to grant RBAC permissions not currently held`
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -19,6 +22,8 @@ rules:
   - serviceaccounts
   - limitranges
   - persistentvolumeclaims
+  - configmaps
+  - secrets
   verbs:
   - create
   - get
@@ -62,6 +67,17 @@ rules:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - patch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagers
+  - prometheuses
+  - prometheusrules
+  - servicemonitors
   verbs:
   - create
   - get


### PR DESCRIPTION
**What this PR does / why we need it**:
/kind bug

Fix deployer RBAC permissions for monitoring components

**Which issue(s) this PR fixes**:
Fixes https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-ci-infra-deploy-prow/1480823969979305984#1:build-log.txt%3A105 and following

<details>
<pre>
Error from server (Forbidden): configmaps "blackbox-exporter-config" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "configmaps" in API group "" in the namespace "prow-monitoring"
Error from server (Forbidden): configmaps "grafana-config" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "configmaps" in API group "" in the namespace "prow-monitoring"
Error from server (Forbidden): configmaps "grafana-dashboard-sources" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "configmaps" in API group "" in the namespace "prow-monitoring"
Error from server (Forbidden): configmaps "grafana-dashboards" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "configmaps" in API group "" in the namespace "prow-monitoring"
Error from server (Forbidden): configmaps "grafana-datasources" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "configmaps" in API group "" in the namespace "prow-monitoring"
Error from server (Forbidden): secrets "alertmanager-prow" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "secrets" in API group "" in the namespace "prow-monitoring"
Error from server (Forbidden): secrets "prometheus-prow-additional-scrape-configs" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "secrets" in API group "" in the namespace "prow-monitoring"
Error from server (Forbidden): alertmanagers.monitoring.coreos.com "prow" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "alertmanagers" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
Error from server (Forbidden): prometheuses.monitoring.coreos.com "prow" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "prometheuses" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
Error from server (Forbidden): prometheusrules.monitoring.coreos.com "prometheus-prow-rules" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "prometheusrules" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
Error from server (Forbidden): servicemonitors.monitoring.coreos.com "alertmanager" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "servicemonitors" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
Error from server (Forbidden): servicemonitors.monitoring.coreos.com "crier" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "servicemonitors" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
Error from server (Forbidden): servicemonitors.monitoring.coreos.com "deck" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "servicemonitors" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
Error from server (Forbidden): servicemonitors.monitoring.coreos.com "ghproxy" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "servicemonitors" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
Error from server (Forbidden): servicemonitors.monitoring.coreos.com "grafana" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "servicemonitors" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
Error from server (Forbidden): servicemonitors.monitoring.coreos.com "hook" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "servicemonitors" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
Error from server (Forbidden): servicemonitors.monitoring.coreos.com "horologium" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "servicemonitors" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
Error from server (Forbidden): servicemonitors.monitoring.coreos.com "kube-state-metrics" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "servicemonitors" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
Error from server (Forbidden): servicemonitors.monitoring.coreos.com "plank" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "servicemonitors" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
Error from server (Forbidden): servicemonitors.monitoring.coreos.com "prometheus" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "servicemonitors" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
Error from server (Forbidden): servicemonitors.monitoring.coreos.com "sinker" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "servicemonitors" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
Error from server (Forbidden): servicemonitors.monitoring.coreos.com "tide" is forbidden: User "system:serviceaccount:test-pods:deployer" cannot patch resource "servicemonitors" in API group "monitoring.coreos.com" in the namespace "prow-monitoring"
</pre>
</details>

**Special notes for your reviewer**:

I have already done the required manual deployment.
