### PR TITLE
Simplify prow trusted cluster setup

### DIFF
--- a/config/clusters/shoot-workload.yaml
+++ b/config/clusters/shoot-workload.yaml
@@ -56,6 +56,8 @@ spec:
       maxUnavailable: 0
       systemComponents:
         allow: true
+      cri:
+        name: containerd
       volume:
         size: 100Gi
         type: pd-ssd

--- a/config/clusters/shoot.yaml
+++ b/config/clusters/shoot.yaml
@@ -57,38 +57,22 @@ spec:
       kind: ControlPlaneConfig
       zone: europe-west1-c
     workers:
-    - name: controlplane
-      machine:
-        image:
-          name: gardenlinux
-          version: 576.1.0
-        type: e2-standard-4
-      minimum: 1
-      maximum: 3
-      maxSurge: 1
-      maxUnavailable: 0
-      # TODO: add taints to repel test-pods
-      systemComponents:
-        allow: true
-      volume:
-        size: 50Gi
-        type: pd-ssd
-      zones:
-      - europe-west1-c
     - name: worker
       machine:
         image:
           name: gardenlinux
           version: 576.1.0
-        type: e2-standard-16
-      minimum: 1
+        type: e2-standard-4
+      minimum: 2
       maximum: 5
       maxSurge: 1
       maxUnavailable: 0
       systemComponents:
-        allow: false
+        allow: true
+      cri:
+        name: containerd
       volume:
-        size: 100Gi
+        size: 50Gi
         type: pd-ssd
       zones:
       - europe-west1-c

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -91,6 +91,18 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 3
           timeoutSeconds: 600
+      affinity: 
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - deck
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       volumes:
       - name: github-token
         secret:

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -83,6 +83,18 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 3
           timeoutSeconds: 600
+      affinity: 
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - hook
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       volumes:
       - name: github-app
         secret:

--- a/config/prow/cluster/ingress-nginx/helm/values.yaml
+++ b/config/prow/cluster/ingress-nginx/helm/values.yaml
@@ -9,14 +9,25 @@ controller:
       cpu: 1000m
       memory: 500Mi
   affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: worker.gardener.cloud/pool
-            operator: In
-            values:
-            - controlplane
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - ingress-nginx
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+              - ingress-nginx
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - controller
+          topologyKey: kubernetes.io/hostname
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -26,21 +37,8 @@ controller:
     name: nginx
     enabled: true
     default: true
-  admissionWebhooks:
-    patch:
-      nodeSelector:
-        worker.gardener.cloud/pool: controlplane
 defaultBackend:
   enabled: true
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: worker.gardener.cloud/pool
-            operator: In
-            values:
-            - controlplane
   resources:
     limits:
       cpu: 10m

--- a/config/prow/cluster/ingress-nginx/ingress-nginx-deployment.yaml
+++ b/config/prow/cluster/ingress-nginx/ingress-nginx-deployment.yaml
@@ -476,14 +476,25 @@ spec:
       nodeSelector: 
         kubernetes.io/os: linux
       affinity: 
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: worker.gardener.cloud/pool
-                operator: In
-                values:
-                - controlplane
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - ingress-nginx
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - ingress-nginx
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 300
       volumes:
@@ -566,15 +577,6 @@ spec:
       nodeSelector: 
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx-backend
-      affinity: 
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: worker.gardener.cloud/pool
-                operator: In
-                values:
-                - controlplane
       terminationGracePeriodSeconds: 60
 ---
 # Source: ingress-nginx/templates/controller-ingressclass.yaml
@@ -805,7 +807,6 @@ spec:
       serviceAccountName: ingress-nginx-admission
       nodeSelector: 
         kubernetes.io/os: linux
-        worker.gardener.cloud/pool: controlplane
       securityContext:
         runAsNonRoot: true
         runAsUser: 2000
@@ -862,7 +863,6 @@ spec:
       serviceAccountName: ingress-nginx-admission
       nodeSelector: 
         kubernetes.io/os: linux
-        worker.gardener.cloud/pool: controlplane
       securityContext:
         runAsNonRoot: true
         runAsUser: 2000

--- a/config/prow/cluster/monitoring/prow_alertmanager.yaml
+++ b/config/prow/cluster/monitoring/prow_alertmanager.yaml
@@ -29,3 +29,23 @@ spec:
         resources:
           requests:
             storage: 10Gi
+  affinity: 
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+              - prow
+            - key: app.kubernetes.io/managed-by
+              operator: In
+              values:
+              - prometheus-operator
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - alertmanager
+          topologyKey: kubernetes.io/hostname
+        weight: 100

--- a/config/prow/cluster/monitoring/prow_prometheus.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheus.yaml
@@ -45,3 +45,23 @@ spec:
   additionalScrapeConfigs:
     name: prometheus-prow-additional-scrape-configs
     key: additional-scrape-targets.yaml
+  affinity: 
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+              - prow
+            - key: app.kubernetes.io/managed-by
+              operator: In
+              values:
+              - prometheus-operator
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - prometheus
+          topologyKey: kubernetes.io/hostname
+        weight: 100


### PR DESCRIPTION
**What this PR does / why we need it**:
- Remove node type controlplane from prow-trusted cluster
- Resize worker nodes to `e2-standard-4`
- Increase the minimum number of worker nodes to 2
- Switch to containerd
- Add PodAntiAffinity rules of type `preferredDuringSchedulingIgnoredDuringExecution` to Pods with replica > 1 to spread them across multiple nodes

**Which issue(s) this PR fixes**:
Fixes #44 

**Special notes for your reviewer**:
Controlplane worker nodes are removed manually when the PR is merged. Otherwise, ingress could not be scheduled anymore in the meantime.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
