### PR TITLE
Update github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,14 @@
 ---
 name: Bug Report
 about: Report a bug
-labels: kind/bug
 
 ---
+
+<!--
+Please select the kind of this issue.
+"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
+-->
+/kind bug
 
 **What happened**:
 

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -1,9 +1,14 @@
 ---
 name: Enhancement Request
 about: Suggest an enhancement
-labels: kind/enhancement
 
 ---
+
+<!--
+Please select the kind of this issue.
+"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
+-->
+/kind enhancement
 
 **What would you like to be added**:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,14 @@
+<!--
+Please select the kind of this pull request, e.g.:
+/kind enhancement
+
+Tide will not merge your PR, if it is missing a `kind/*` label.
+"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
+-->
+
 **What this PR does / why we need it**:
 
 **Which issue(s) this PR fixes**:
 Fixes #
 
 **Special notes for your reviewer**:
-
-**Release note**:
-<!--  Write your release note:
-1. Enter your release note in the below block.
-2. If no release note is required, just write "NONE" within the block.
-
-Format of block header: <category> <target_group>
-Possible values:
-- category:       breaking|feature|bugfix|doc|other
-- target_group:   user|operator|developer|dependency
--->
-```feature user
-
-```


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Update the github templates:
- add hint to PR template, that kind is required
- remove release note section, as this repo doesn't produce any release notes
- remove labels from issue templates and instead ask the author to add a fitting kind via a `/kind` command

