### PR TITLE
Provide a rolling update strategy for ghproxy

### DIFF
--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -10,6 +10,10 @@ spec:
     matchLabels:
       app: ghproxy
   replicas: 1  # TODO(fejta): this should be HA
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Current deployment of ghproxy leads to an update strategy like this
```yaml
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
```

This strategy prevents clean restarts of ghproxy. On restarts the new instance is not able to mount the PVC, because it is still attached to the old instance. Thus, the new instance is stuck in state `ContainerCreated`

This PR changes the update strategy in a way that it allows unavailable resources.
```yaml 
  strategy:
    rollingUpdate:
      maxSurge: 0
      maxUnavailable: 1
```
This leads to a small downtime, but ensures that ghproxy is able to restart.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
