### PR TITLE
Autodeploy updates for prow and prow jobs

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -103,6 +103,36 @@ periodics:
       secret:
         secretName: github-token
 
+- cron: "35 14-15 * * 1-5"
+  name: ci-prow-autobump-autodeploy
+  cluster: gardener-prow-trusted
+  decorate: true
+  extra_refs:
+  - org: gardener
+    repo: ci-infra
+    base_ref: master
+  reporter_config:
+    slack:
+      channel: "gardener-prow-alerts"
+  annotations:
+    description: Runs autobumper to create/update and auto-merge a PR that bumps prow images to the latest published version
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/generic-autobumper:v20220118-49cbff1954
+      command:
+      - /app/prow/cmd/generic-autobumper/app.binary
+      args:
+      - --config=config/prow/autobump-config/prow-component-autobump-config.yaml
+      - --labels-override=kind/enhancement,skip-review
+      volumeMounts:
+      - name: github-token
+        mountPath: /etc/github-token
+        readOnly: true
+    volumes:
+    - name: github-token
+      secret:
+        secretName: github-token
+
 - cron: "45 * * * 1-5"
   name: ci-prow-autobump-jobs
   cluster: gardener-prow-trusted
@@ -124,6 +154,36 @@ periodics:
       args:
       - --config=config/prow/autobump-config/prow-job-autobump-config.yaml
       - --labels-override=kind/enhancement
+      volumeMounts:
+      - name: github-token
+        mountPath: /etc/github-token
+        readOnly: true
+    volumes:
+    - name: github-token
+      secret:
+        secretName: github-token
+
+- cron: "50 14-15 * * 1-5"
+  name: ci-prow-autobump-autodeploy-jobs
+  cluster: gardener-prow-trusted
+  decorate: true
+  extra_refs:
+  - org: gardener
+    repo: ci-infra
+    base_ref: master
+  reporter_config:
+    slack:
+      channel: "gardener-prow-alerts"
+  annotations:
+    description: Runs autobumper to create/update and auto-merge a PR that bumps prowjob images to latest published version
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/generic-autobumper:v20220118-49cbff1954
+      command:
+      - /app/prow/cmd/generic-autobumper/app.binary
+      args:
+      - --config=config/prow/autobump-config/prow-job-autobump-config.yaml
+      - --labels-override=kind/enhancement,skip-review
       volumeMounts:
       - name: github-token
         mountPath: /etc/github-token

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -149,6 +149,21 @@ tide:
     - do-not-merge/release-note-label-needed
     - do-not-merge/work-in-progress
     - needs-rebase
+  - author: gardener-ci-robot
+    repos:
+    - gardener/ci-infra
+    labels: # gardener-ci-robot should only create autobump PR with this label
+    - skip-review
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
 
   merge_method:
     gardener/ci-infra: squash

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -155,7 +155,6 @@ tide:
     labels: # gardener-ci-robot should only create autobump PR with this label
     - skip-review
     missingLabels:
-    - do-not-merge
     - do-not-merge/blocked-paths
     - do-not-merge/contains-merge-commits
     - do-not-merge/hold


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Updates for prow and prow-jobs are now deployed automatically twice on a work day (14:35, 15:35 UTC prow, 14:55, 15:55 UTC prow-jobs)

**Which issue(s) this PR fixes**:
Fixes #49 

**Special notes for your reviewer**:
