### PR TITLE
Add org to triage robot queries

### DIFF
--- a/config/jobs/common/issue-pr-lifecycle.yaml
+++ b/config/jobs/common/issue-pr-lifecycle.yaml
@@ -12,7 +12,8 @@ periodics:
       - /app/robots/commenter/app.binary
       args:
       - |-
-        --query=repo:gardener/ci-infra
+        --query=org:gardener
+        repo:gardener/ci-infra
         -label:lifecycle/frozen
         label:lifecycle/rotten
       - --updated=720h
@@ -53,7 +54,8 @@ periodics:
       - /app/robots/commenter/app.binary
       args:
       - |-
-        --query=repo:gardener/ci-infra
+        --query=org:gardener
+        repo:gardener/ci-infra
         -label:lifecycle/frozen
         label:lifecycle/stale
         -label:lifecycle/rotten
@@ -95,7 +97,8 @@ periodics:
       - /app/robots/commenter/app.binary
       args:
       - |-
-        --query=repo:gardener/ci-infra
+        --query=org:gardener
+        repo:gardener/ci-infra
         -label:lifecycle/frozen
         -label:lifecycle/stale
         -label:lifecycle/rotten

--- a/config/prow/cluster/monitoring/grafana/dashboards/ghproxy.json
+++ b/config/prow/cluster/monitoring/grafana/dashboards/ghproxy.json
@@ -55,14 +55,14 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(increase(ghcache_responses[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"k8s-ci-robot\"}) by (token_hash, login)) by (mode)",
+               "expr": "sum(increase(ghcache_responses[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login)) by (mode)",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "{{mode}}",
                "refId": "A"
             },
             {
-               "expr": "sum(increase(ghcache_responses{mode=~\"COALESCED|REVALIDATED\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"k8s-ci-robot\"}) by (token_hash, login))",
+               "expr": "sum(increase(ghcache_responses{mode=~\"COALESCED|REVALIDATED\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login))",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "(No Cost)",
@@ -147,7 +147,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(increase(ghcache_responses{mode=~\"COALESCED|REVALIDATED\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"k8s-ci-robot\"}) by (token_hash, login)) \n/ sum(increase(ghcache_responses{mode=~\"COALESCED|REVALIDATED|MISS|CHANGED\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"k8s-ci-robot\"}) by (token_hash, login))",
+               "expr": "sum(increase(ghcache_responses{mode=~\"COALESCED|REVALIDATED\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login)) \n/ sum(increase(ghcache_responses{mode=~\"COALESCED|REVALIDATED|MISS|CHANGED\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login))",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "Efficiency",
@@ -344,7 +344,7 @@
          "tableColumn": "",
          "targets": [
             {
-               "expr": "sum(increase(ghcache_responses{mode=~\"COALESCED|REVALIDATED\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"k8s-ci-robot\"}) by (token_hash, login))",
+               "expr": "sum(increase(ghcache_responses{mode=~\"COALESCED|REVALIDATED\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login))",
                "format": "time_series",
                "instant": true,
                "intervalFactor": 2,
@@ -427,7 +427,7 @@
          "tableColumn": "",
          "targets": [
             {
-               "expr": "sum(increase(ghcache_responses{mode=~\"COALESCED|REVALIDATED\"}[7d]) * on(token_hash) group_left(login) max(github_user_info{login=\"k8s-ci-robot\"}) by (token_hash, login))",
+               "expr": "sum(increase(ghcache_responses{mode=~\"COALESCED|REVALIDATED\"}[7d]) * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login))",
                "format": "time_series",
                "instant": true,
                "intervalFactor": 2,
@@ -490,7 +490,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(github_token_usage * on(token_hash) group_left(login) max(github_user_info{login=\"k8s-ci-robot\"}) by (token_hash, login)) by (api_version, login)",
+               "expr": "sum(github_token_usage * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login)) by (api_version, login)",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "{{login}} : {{api_version}}",
@@ -575,7 +575,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(github_request_duration_count[${range}]) * on(token_hash) group_left(login) max(github_user_info{login=\"k8s-ci-robot\"}) by (token_hash, login)) by (status)",
+               "expr": "sum(rate(github_request_duration_count[${range}]) * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login)) by (status)",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "{{status}}",
@@ -660,7 +660,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(rate(github_request_duration_count{status=\"${status}\"}[${range}]) * on(token_hash) group_left(login) max(github_user_info{login=\"k8s-ci-robot\"}) by (token_hash, login)) by (path)",
+               "expr": "sum(rate(github_request_duration_count{status=\"${status}\"}[${range}]) * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login)) by (path)",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "{{path}}",
@@ -1036,7 +1036,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(increase(ghcache_responses{mode=~\"MISS|NO-STORE|CHANGED\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"k8s-ci-robot\"}) by (token_hash, login)) by (user_agent)",
+               "expr": "sum(increase(ghcache_responses{mode=~\"MISS|NO-STORE|CHANGED\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login)) by (user_agent)",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "{{user_agent}}",
@@ -1123,7 +1123,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(increase(ghcache_responses{mode=~\"MISS|NO-STORE|CHANGED\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"k8s-ci-robot\"}) by (token_hash, login)) by (path)",
+               "expr": "sum(increase(ghcache_responses{mode=~\"MISS|NO-STORE|CHANGED\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login)) by (path)",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "{{path}}",
@@ -1210,7 +1210,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(increase(ghcache_responses{mode=~\"MISS|NO-STORE|CHANGED\",path=\"${path}\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"k8s-ci-robot\"}) by (token_hash, login)) by (user_agent)",
+               "expr": "sum(increase(ghcache_responses{mode=~\"MISS|NO-STORE|CHANGED\",path=\"${path}\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login)) by (user_agent)",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "{{user_agent}}",
@@ -1297,7 +1297,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(increase(ghcache_responses{mode=~\"MISS|NO-STORE|CHANGED\",user_agent=\"${user_agent}\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"k8s-ci-robot\"}) by (token_hash, login)) by (path)",
+               "expr": "sum(increase(ghcache_responses{mode=~\"MISS|NO-STORE|CHANGED\",user_agent=\"${user_agent}\"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login)) by (path)",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "{{path}}",
@@ -1358,7 +1358,7 @@
             "multi": false,
             "name": "login",
             "options": [ ],
-            "query": "label_values(github_user_info{login=\"k8s-ci-robot\"}, login)",
+            "query": "label_values(github_user_info{login=\"gardener-ci-robot\"}, login)",
             "refresh": 2,
             "regex": "",
             "sort": 0,

--- a/config/prow/cluster/monitoring/grafana/dashboards/tide.json
+++ b/config/prow/cluster/monitoring/grafana/dashboards/tide.json
@@ -276,7 +276,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "prometheus",
-         "description": "Tide stats for the master branch of the kubernetes/kubernetes repo.\nSpecifically, the number of pooled PRs and the daily merge rate.\n(See the more general graphs for details on how these are calculated.)",
+         "description": "Tide stats for the master branch of the gardener/gardener repo.\nSpecifically, the number of pooled PRs and the daily merge rate.\n(See the more general graphs for details on how these are calculated.)",
          "fill": 1,
          "gridPos": {
             "h": 9,
@@ -312,14 +312,14 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "avg(pooledprs{org=\"kubernetes\",repo=\"kubernetes\",branch=\"master\"} and ((time() - updatetime) < 240)) or vector(0)",
+               "expr": "avg(pooledprs{org=\"gardener\",repo=\"gardener\",branch=\"master\"} and ((time() - updatetime) < 240)) or vector(0)",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "Pool size",
                "refId": "A"
             },
             {
-               "expr": "sum(rate(merges_sum{org=\"kubernetes\",repo=\"kubernetes\",branch=\"master\"}[1d])) * 86400",
+               "expr": "sum(rate(merges_sum{org=\"gardener\",repo=\"gardener\",branch=\"master\"}[1d])) * 86400",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "Daily merge rate",
@@ -329,7 +329,7 @@
          "thresholds": [ ],
          "timeFrom": null,
          "timeShift": null,
-         "title": "Tide Pool: kubernetes/kubernetes:master",
+         "title": "Tide Pool: gardener/gardener:master",
          "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

Add org to triage robot queries. Hopefully, this will get the github token usage under control again. Currently, every job run of the triage robot jobs deplete all available hourly tokens:
<img width="1648" alt="Screen Shot 2022-02-09 at 07 56 24" src="https://user-images.githubusercontent.com/46341950/153141249-8b3c37f9-dda9-41f8-9a4c-8bdb1bdae5a1.png">


Also, replace k8s specifics in ghproxy dashboard (e.g. `s/k8s-ci-robot/gardener-ci-robot/`)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
