### PR TITLE
Set triage robot to dry-run

### DIFF
--- a/config/jobs/common/issue-pr-lifecycle.yaml
+++ b/config/jobs/common/issue-pr-lifecycle.yaml
@@ -32,7 +32,6 @@ periodics:
         /close
       - --template
       - --ceiling=10
-      - --confirm
       volumeMounts:
       - name: token
         mountPath: /etc/github-token
@@ -75,7 +74,6 @@ periodics:
         /lifecycle rotten
       - --template
       - --ceiling=10
-      - --confirm
       volumeMounts:
       - name: token
         mountPath: /etc/github-token
@@ -119,7 +117,6 @@ periodics:
         /lifecycle stale
       - --template
       - --ceiling=10
-      - --confirm
       volumeMounts:
       - name: token
         mountPath: /etc/github-token


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:

Set triage robot to dry-run mode until we have understood the github query API and how to limit it to this repository.

**Which issue(s) this PR fixes**:

Triage robot currently considers all repositories in the gardener org, e.g.:
https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-triage-robot-close/1491326365922758656

**Special notes for your reviewer**:
