### PR TITLE
Deactivate rate limit alerts

### DIFF
--- a/config/jobs/common/issue-pr-lifecycle.yaml
+++ b/config/jobs/common/issue-pr-lifecycle.yaml
@@ -12,8 +12,7 @@ periodics:
       - /app/robots/commenter/app.binary
       args:
       - |-
-        --query=org:gardener
-        repo:gardener/ci-infra
+        --query=repo:gardener/ci-infra
         -label:lifecycle/frozen
         label:lifecycle/rotten
       - --updated=720h
@@ -32,6 +31,7 @@ periodics:
         /close
       - --template
       - --ceiling=10
+      - --confirm
       volumeMounts:
       - name: token
         mountPath: /etc/github-token
@@ -53,8 +53,7 @@ periodics:
       - /app/robots/commenter/app.binary
       args:
       - |-
-        --query=org:gardener
-        repo:gardener/ci-infra
+        --query=repo:gardener/ci-infra
         -label:lifecycle/frozen
         label:lifecycle/stale
         -label:lifecycle/rotten
@@ -74,6 +73,7 @@ periodics:
         /lifecycle rotten
       - --template
       - --ceiling=10
+      - --confirm
       volumeMounts:
       - name: token
         mountPath: /etc/github-token
@@ -95,8 +95,7 @@ periodics:
       - /app/robots/commenter/app.binary
       args:
       - |-
-        --query=org:gardener
-        repo:gardener/ci-infra
+        --query=repo:gardener/ci-infra
         -label:lifecycle/frozen
         -label:lifecycle/stale
         -label:lifecycle/rotten
@@ -117,6 +116,7 @@ periodics:
         /lifecycle stale
       - --template
       - --ceiling=10
+      - --confirm
       volumeMounts:
       - name: token
         mountPath: /etc/github-token

--- a/config/prow/cluster/monitoring/prow_prometheusrule.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheusrule.yaml
@@ -190,16 +190,17 @@ spec:
         sum(rate(github_request_duration_count{status=~"403|405|422"}[30m])) by (status) / ignoring(status) group_left sum(rate(github_request_duration_count[30m])) * 100 > 10
       labels:
         severity: warning
-    - alert: ghproxy-running-out-github-tokens-in-a-hour
-      annotations:
-        message: token {{ $labels.token_hash }} will run out of API quota before the next reset.
-      expr: |
-        github_token_usage{job="ghproxy"} <  1500
-        and
-        predict_linear(github_token_usage{job="ghproxy"}[30m], 1 * 3600) < 0
-      for: 5m
-      labels:
-        severity: high
+    # TODO: reactivate this alert, once https://github.com/kubernetes/test-infra/issues/25177 is fixed
+#    - alert: ghproxy-running-out-github-tokens-in-a-hour
+#      annotations:
+#        message: token {{ $labels.token_hash }} will run out of API quota before the next reset.
+#      expr: |
+#        github_token_usage{job="ghproxy", resource!="search"} <  1500
+#        and
+#        predict_linear(github_token_usage{job="ghproxy", resource!="search"}[30m], 1 * 3600) < 0
+#      for: 5m
+#      labels:
+#        severity: high
   - name: abnormal webhook behaviors
     rules:
     # TODO: reconsider whether this alert makes sense at the scale of our org and with what timeframe based on some experience


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

Deactivate rate limit alerts and reactivate triage robot jobs. Workaround for https://github.com/kubernetes/test-infra/issues/25177
