### PR TITLE
Fix token path in cla triage job

### DIFF
--- a/config/jobs/common/cla-assistant.yaml
+++ b/config/jobs/common/cla-assistant.yaml
@@ -18,7 +18,7 @@ periodics:
         -label:"cla: no"
         -label:"cla: yes"
       - --updated=10m
-      - --token=/etc/github-token/token
+      - --token=/etc/github/token
       - --endpoint=http://ghproxy.prow.svc.cluster.local
       - |-
         --comment=Unknown CLA label state. Rechecking at cla-assistant.io.

--- a/config/jobs/common/cla-assistant.yaml
+++ b/config/jobs/common/cla-assistant.yaml
@@ -3,6 +3,9 @@ periodics:
   interval: 10m
   cluster: gardener-prow-trusted
   decorate: true
+  reporter_config:
+    slack:
+      channel: "gardener-prow-alerts"
   annotations:
     description: Trigger recheck of CLAs for open PRs without an CLA label
   spec:

--- a/config/jobs/common/issue-pr-lifecycle.yaml
+++ b/config/jobs/common/issue-pr-lifecycle.yaml
@@ -3,6 +3,9 @@ periodics:
   interval: 1h
   cluster: gardener-prow-trusted
   decorate: true
+  reporter_config:
+    slack:
+      channel: "gardener-prow-alerts" 
   annotations:
     description: Closes rotten issues after 30d of inactivity
   spec:
@@ -44,6 +47,9 @@ periodics:
   interval: 1h
   cluster: gardener-prow-trusted
   decorate: true
+  reporter_config:
+    slack:
+      channel: "gardener-prow-alerts"
   annotations:
     description: Adds lifecycle/rotten to stale issues after 30d of inactivity
   spec:
@@ -86,6 +92,9 @@ periodics:
   interval: 1h
   cluster: gardener-prow-trusted
   decorate: true
+  reporter_config:
+    slack:
+      channel: "gardener-prow-alerts"
   annotations:
     description: Adds lifecycle/stale to issues after 90d of inactivity
   spec:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
cla triage robot currently fails because of a wrong token path
https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-triage-robot-cla/1492101656794370048

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
