### PR TITLE
Fix pre-submit-test for developments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ revendor:
 	@GO111MODULE=on go mod tidy
 	@GO111MODULE=on go mod vendor
 
-.PHONY: verify-modules
+.PHONY: verify-vendor
 verify-vendor: revendor
 	@if !(git diff --quiet HEAD -- go.sum go.mod vendor); then \
 		echo "go module files or vendor folder are out of date, please run 'make revendor'"; exit 1; \

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -37,4 +37,6 @@ presubmits:
         command:
         - make
         args:
-        - check test verify-vendor # run all presubmit checks
+        - check
+        - test
+        - verify-vendor


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/bug

**What this PR does / why we need it**:
pre-submit-test for development is [broken](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_ci-infra/87/pull-ci-infra-prow-go-tests/1493289252459384832).
This fixes it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
