### PR TITLE
Fix prow job entrypoints

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -18,7 +18,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/label_sync:v20220222-8d1661c08e
       command:
-      - /app/label_sync/app.binary
+      - label_sync
       args:
       - --config=config/prow/labels.yaml
       - --confirm=true
@@ -56,7 +56,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/branchprotector:v20220222-8d1661c08e
       command:
-      - /app/prow/cmd/branchprotector/app.binary
+      - branchprotector
       args:
       - --config-path=config/prow/config.yaml
       - --confirm
@@ -90,7 +90,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220222-8d1661c08e
       command:
-      - /app/prow/cmd/generic-autobumper/app.binary
+      - generic-autobumper
       args:
       - --config=config/prow/autobump-config/prow-component-autobump-config.yaml
       - --labels-override=kind/enhancement
@@ -120,7 +120,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220222-8d1661c08e
       command:
-      - /app/prow/cmd/generic-autobumper/app.binary
+      - generic-autobumper
       args:
       - --config=config/prow/autobump-config/prow-component-autobump-config.yaml
       - --labels-override=kind/enhancement,skip-review
@@ -150,7 +150,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220222-8d1661c08e
       command:
-      - /app/prow/cmd/generic-autobumper/app.binary
+      - generic-autobumper
       args:
       - --config=config/prow/autobump-config/prow-job-autobump-config.yaml
       - --labels-override=kind/enhancement
@@ -180,7 +180,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220222-8d1661c08e
       command:
-      - /app/prow/cmd/generic-autobumper/app.binary
+      - generic-autobumper
       args:
       - --config=config/prow/autobump-config/prow-job-autobump-config.yaml
       - --labels-override=kind/enhancement,skip-review
@@ -213,7 +213,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/checkconfig:v20220222-8d1661c08e
       command:
-      - /checkconfig
+      - checkconfig
       args:
       - --config-path=config/prow/config.yaml
       - --job-config-path=config/jobs
@@ -244,7 +244,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/checkconfig:v20220222-8d1661c08e
       command:
-      - /checkconfig
+      - checkconfig
       args:
       - --config-path=config/prow/config.yaml
       - --job-config-path=config/jobs

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-prow/checkconfig:v20220222-8d1661c08e
         command:
-        - /checkconfig
+        - checkconfig
         args:
         - --config-path=config/prow/config.yaml
         - --job-config-path=config/jobs

--- a/config/jobs/common/issue-pr-lifecycle.yaml
+++ b/config/jobs/common/issue-pr-lifecycle.yaml
@@ -12,7 +12,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20220222-8d1661c08e
       command:
-      - /app/robots/commenter/app.binary
+      - commenter
       args:
       - |-
         --query=repo:gardener/ci-infra
@@ -56,7 +56,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20220222-8d1661c08e
       command:
-      - /app/robots/commenter/app.binary
+      - commenter
       args:
       - |-
         --query=repo:gardener/ci-infra
@@ -101,7 +101,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20220222-8d1661c08e
       command:
-      - /app/robots/commenter/app.binary
+      - commenter
       args:
       - |-
         --query=repo:gardener/ci-infra


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Wow, prow just changed the [entrypoints of all prow job apps](https://github.com/kubernetes/test-infra/commit/f2345258fcb29798214060aaa33ba6032c5abe40) in the last update. This makes every prow job fail atm.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
