### PR TITLE
Enable unit and integration tests for gardener repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,17 @@ USER 65532
 # Executable containers
 # ----------------------
 
+FROM golang:1.17.7-bullseye AS golang-test
+# install gardener unit/integration test related dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		unzip \
+		jq \
+		parallel \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 FROM ssl_runner AS cla-assistant
 ARG VERSION
 LABEL app=cla-assistant

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -31,6 +31,7 @@ presubmits:
     decorate: true
     annotations:
       description: Runs go tests for prow developments in ci-infra 
+    max_concurrency: 5
     spec:
       containers:
       - image: golang:1.17.6
@@ -40,3 +41,7 @@ presubmits:
         - check
         - test
         - verify-vendor
+        resources:
+          requests:
+            cpu: 6
+            memory: 2000Mi

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    max_concurrency: 5
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20220221-c13e827224-master

--- a/config/jobs/gardener/gardener-pull-tests.yaml
+++ b/config/jobs/gardener/gardener-pull-tests.yaml
@@ -1,0 +1,50 @@
+presubmits:
+  gardener/gardener:
+  - name: pull-gardener-unit
+    cluster: gardener-prow-build
+    skip_if_only_changed: "^docs/|\\.md$"
+    skip_branches:
+    - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+    decorate: true
+    annotations:
+      description: Runs unit tests for gardener developments in pull requests
+    max_concurrency: 5
+    spec:
+      containers:
+      # Run all tests sequentially in one container or as separete prow jobs.
+      # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
+      - image: ghcr.io/gardener/ci-infra/golang-test:1.17.7
+        command:
+        - make
+        args:
+        - check-generate
+        - check
+        - format
+        - test
+        - test-prometheus
+        - check-docforge
+        resources:
+          requests:
+            cpu: 8
+            memory: 8000Mi
+  - name: pull-gardener-integration
+    cluster: gardener-prow-build
+    skip_if_only_changed: "^docs/|\\.md$"
+    skip_branches:
+    - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+    decorate: true
+    annotations:
+      description: Runs integration tests for gardener developments in pull requests
+    max_concurrency: 5
+    spec:
+      containers:
+      - name: test-integration
+        image: ghcr.io/gardener/ci-infra/golang-test:1.17.7
+        command:
+        - make
+        args:
+        - test-integration
+        resources:
+          requests:
+            cpu: 6
+            memory: 2000Mi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR enables unit and integration tests for gardener repository.
There are two new prow jobs
- `pull-gardener-unit` which runs `check-generate`, `check`, `format`, `test`, `test-prometheus` and `check-docforge`tests
- `pull-gardener-integration` which runs `test-integration` test

Test runs in an own image based on `golang:1.17.7-bullseye` with `unzip`, `jq` and `parallel` installed. Those tools are not part of standard golang image. 1.17.7 is the same version of golang currently used in gardener repository.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Tests have been already tested manually a few times
- `pull-gardener-unit`: [1](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/5540/pull-gardener-unit/1501992616470777856), [2](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/5546/pull-gardener-unit/1502007082935652352)
- `pull-gardener-integration`: [1](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/5540/pull-gardener-integration/1501997721744052224), [2](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/5546/pull-gardener-integration/1502007280609005568)
