### PR TITLE
Improve scheduling of test jobs

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -258,3 +258,31 @@ periodics:
       - --warnings=validate-urls
       - --warnings=unknown-fields
       - --warnings=duplicate-job-refs
+- name: ci-ci-infra-prow-go-tests
+  cluster: gardener-prow-build
+  interval: 4h
+  extra_refs:
+  - org: gardener
+    repo: ci-infra
+    base_ref: master
+  reporter_config:
+    slack:
+      channel: "gardener-prow-alerts"
+  decorate: true
+  annotations:
+    description: Runs go tests for prow developments in ci-infra 
+  spec:
+    containers:
+    - image: golang:1.17.7
+      command:
+      - make
+      args:
+      - check
+      - test
+      - verify-vendor
+      resources:
+        limits:
+          memory: 4000Mi
+        requests:
+          cpu: 4
+          memory: 2000Mi

--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -282,7 +282,7 @@ periodics:
       - verify-vendor
       resources:
         limits:
-          memory: 4000Mi
+          memory: 4Gi
         requests:
           cpu: 4
-          memory: 2000Mi
+          memory: 2Gi

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
         - verify-vendor
         resources:
           limits:
-            memory: 4000Mi
+            memory: 4Gi
           requests:
             cpu: 4
-            memory: 2000Mi
+            memory: 2Gi

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -41,6 +41,8 @@ presubmits:
         - test
         - verify-vendor
         resources:
+          limits:
+            memory: 4000Mi
           requests:
-            cpu: 6
+            cpu: 4
             memory: 2000Mi

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -28,6 +28,7 @@ presubmits:
   - name: pull-ci-infra-prow-go-tests
     cluster: gardener-prow-build
     decorate: true
+    always_run: true
     annotations:
       description: Runs go tests for prow developments in ci-infra 
     max_concurrency: 5

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -45,10 +45,10 @@ presubmits:
           privileged: true
         resources:
           limits:
-            memory: 18000Mi
+            memory: 18Gi
           requests:
             cpu: 5
-            memory: 9000Mi
+            memory: 9Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -101,10 +101,10 @@ periodics:
         privileged: true
       resources:
         limits:
-          memory: 18000Mi
+          memory: 18Gi
         requests:
           cpu: 5
-          memory: 9000Mi
+          memory: 9Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -7,7 +7,7 @@ presubmits:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true
     decoration_config:
-      timeout: 120m
+      timeout: 60m
       grace_period: 15m
     labels:
       preset-dind-enabled: "true"
@@ -45,10 +45,9 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 7
-            memory: 9000Mi
+            memory: 18000Mi
           requests:
-            cpu: 7
+            cpu: 5
             memory: 9000Mi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
@@ -65,7 +64,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 120m
+    timeout: 60m
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"
@@ -102,10 +101,9 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 7
-          memory: 9000Mi
+          memory: 18000Mi
         requests:
-          cpu: 7
+          cpu: 5
           memory: 9000Mi
       env:
       - name: SKAFFOLD_UPDATE_CHECK

--- a/config/jobs/gardener/gardener-pull-tests.yaml
+++ b/config/jobs/gardener/gardener-pull-tests.yaml
@@ -6,6 +6,9 @@ presubmits:
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true
+    decoration_config:
+      timeout: 40m
+      grace_period: 10m
     annotations:
       description: Runs unit tests for gardener developments in pull requests
     max_concurrency: 5
@@ -24,8 +27,10 @@ presubmits:
         - test-prometheus
         - check-docforge
         resources:
+          limits:
+            memory: 16000Mi
           requests:
-            cpu: 8
+            cpu: 5
             memory: 8000Mi
   - name: pull-gardener-integration
     cluster: gardener-prow-build
@@ -33,6 +38,9 @@ presubmits:
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true
+    decoration_config:
+      timeout: 20m
+      grace_period: 10m
     annotations:
       description: Runs integration tests for gardener developments in pull requests
     max_concurrency: 5
@@ -45,6 +53,69 @@ presubmits:
         args:
         - test-integration
         resources:
+          limits:
+            memory: 4000Mi
           requests:
-            cpu: 6
+            cpu: 4
             memory: 2000Mi
+periodics:
+- name: ci-gardener-unit
+  cluster: gardener-prow-build
+  interval: 4h
+  extra_refs:
+  - org: gardener
+    repo: gardener
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 40m
+    grace_period: 10m
+  annotations:
+    description: Runs unit tests for gardener developments in pull requests
+  spec:
+    containers:
+    # Run all tests sequentially in one container or as separete prow jobs.
+    # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
+    - image: ghcr.io/gardener/ci-infra/golang-test:1.17.7
+      command:
+      - make
+      args:
+      - check-generate
+      - check
+      - format
+      - test
+      - test-prometheus
+      - check-docforge
+      resources:
+        limits:
+          memory: 16000Mi
+        requests:
+          cpu: 5
+          memory: 8000Mi
+- name: ci-gardener-integration
+  cluster: gardener-prow-build
+  interval: 4h
+  extra_refs:
+  - org: gardener
+    repo: gardener
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 20m
+    grace_period: 10m
+  annotations:
+    description: Runs integration tests for gardener developments in pull requests
+  spec:
+    containers:
+    - name: test-integration
+      image: ghcr.io/gardener/ci-infra/golang-test:1.17.7
+      command:
+      - make
+      args:
+      - test-integration
+      resources:
+        limits:
+          memory: 4000Mi
+        requests:
+          cpu: 4
+          memory: 2000Mi

--- a/config/jobs/gardener/gardener-tests.yaml
+++ b/config/jobs/gardener/gardener-tests.yaml
@@ -28,10 +28,10 @@ presubmits:
         - check-docforge
         resources:
           limits:
-            memory: 16000Mi
+            memory: 16Gi
           requests:
             cpu: 5
-            memory: 8000Mi
+            memory: 8Gi
   - name: pull-gardener-integration
     cluster: gardener-prow-build
     skip_if_only_changed: "^docs/|\\.md$"
@@ -54,10 +54,10 @@ presubmits:
         - test-integration
         resources:
           limits:
-            memory: 4000Mi
+            memory: 4Gi
           requests:
             cpu: 4
-            memory: 2000Mi
+            memory: 2Gi
 periodics:
 - name: ci-gardener-unit
   cluster: gardener-prow-build
@@ -88,10 +88,10 @@ periodics:
       - check-docforge
       resources:
         limits:
-          memory: 16000Mi
+          memory: 16Gi
         requests:
           cpu: 5
-          memory: 8000Mi
+          memory: 8Gi
 - name: ci-gardener-integration
   cluster: gardener-prow-build
   interval: 4h
@@ -115,7 +115,7 @@ periodics:
       - test-integration
       resources:
         limits:
-          memory: 4000Mi
+          memory: 4Gi
         requests:
           cpu: 4
-          memory: 2000Mi
+          memory: 2Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR includes two improvements of scheduling of the test jobs we introduced recently
- introduce periodic test jobs running every 4 hours
- optimize resource request of test jobs

*Resource request optimization:*
In current configuration the 3 test of a PR request more CPU than an entire node provides. Thus, in many cases the cluster has scale up, before the pods of all tests could be started.
Our current worker machine provides 16 CPUs of which 15.9 are allocatable. About 1.1 CPUs are allocated for system components and 14.8 remain for the test pods.
```
Capacity:
  cpu:                16
  ephemeral-storage:  102033388Ki
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  memory:             65867564Ki
  pods:               110
Allocatable:
  cpu:                15920m
  ephemeral-storage:  99258079769
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  memory:             64716588Ki
  pods:               110
```
We would like to optimize the processing time of the combination of our 3 PR tests while trying to avoid the cluster to scale up and down for a short time.
The proposed CPU request looks like this:
- `pull-gardener-e2e-kind`: 5 CPUs
  - this job consumes only little CPU resources most of the time, but has spikes where it his its current CPU limit of 7
  - the test normally runs 20-23min which is the test with the longest runtime we have. In order to extend runtime by CPU throttling it is getting a relatively high CPU request
- `pull-gardener-unit`: 5 CPUs
  - this job could consume the entire CPU of the node for most of the time
  - it is running for 9-10 minutes. A slightly increased runtime because of CPU throttling might be more efficient than waiting for a new node to come up.
- `pull-gardener-integration`: 4 CPUs
  - this job could consume the entire CPU of the node for most of the time
  - It is usually running for about 2 minutes, so the effect of CPU throttling would be even smaller 

Sidecars use the default CPU resource request of 0.1. Thus, our 3 test jobs will request a total amount of 14.3 CPUs.
There are 0.5 CPUs left which could be used for the small prow jobs in worker cluster.

All jobs will have no CPU limit to be able to consume all the CPUs of the worker nodes.
Memory limits are enforced. They are not very strict as our worker nodes usually have more than enough memory.

*Timeouts of E2E test are decreased to 60 minutes, which is about 3x their normal runtime.*

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
