### PR TITLE
do not build images when only configuration files are changing in ci-infra

### DIFF
--- a/.github/workflows/build-ci-infra-images.yaml
+++ b/.github/workflows/build-ci-infra-images.yaml
@@ -7,7 +7,6 @@ on:
     paths-ignore:
     - 'docs/**'
     - '**/*.md'
-    - '*.md'
     - 'config/**'
     - 'hack/**'
 

--- a/.github/workflows/build-ci-infra-images.yaml
+++ b/.github/workflows/build-ci-infra-images.yaml
@@ -7,6 +7,9 @@ on:
     paths-ignore:
     - 'docs/**'
     - '**/*.md'
+    - '*.md'
+    - 'config/**'
+    - 'hack/**'
 
 jobs:
   build:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
It would save storage space on github if we do not build images on configuration changes anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is a github workflow change. Please remember checking if gardener-ci-robot is still able to push changes to https://github.com/gardener-ci-robot/ci-infra afterwards.
