### PR TITLE
Reactivate ghproxy token alerting

### DIFF
--- a/config/prow/cluster/monitoring/grafana/dashboards/ghproxy.json
+++ b/config/prow/cluster/monitoring/grafana/dashboards/ghproxy.json
@@ -490,12 +490,19 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum(github_token_usage * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login)) by (api_version, login)",
+               "expr": "sum(github_token_usage * on(token_hash) group_left(login) max(github_user_info{login=\"gardener-ci-robot\"}) by (token_hash, login, ratelimit_resource)) by (api_version, login, ratelimit_resource)",
                "format": "time_series",
                "intervalFactor": 2,
-               "legendFormat": "{{login}} : {{api_version}}",
+               "legendFormat": "{{login}} : {{api_version}} : {{ratelimit_resource}}",
                "refId": "A"
-            }
+             },
+             {
+               "expr": "sum(github_token_usage{token_hash=~\"gardener-prow.+\"}) by (token_hash, api_version, ratelimit_resource)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{token_hash}} : {{api_version}} : {{ratelimit_resource}}",
+               "refId": "B"
+             }
          ],
          "thresholds": [ ],
          "timeFrom": null,
@@ -519,7 +526,7 @@
                "format": "short",
                "label": null,
                "logBase": 1,
-               "max": "5000",
+               "max": null,
                "min": "0",
                "show": true
             },
@@ -527,7 +534,7 @@
                "format": "short",
                "label": null,
                "logBase": 1,
-               "max": "5000",
+               "max": null,
                "min": "0",
                "show": true
             }

--- a/config/prow/cluster/monitoring/prow_prometheusrule.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheusrule.yaml
@@ -194,9 +194,9 @@ spec:
       annotations:
         message: token {{ $labels.token_hash }} will run out of API quota before the next reset.
       expr: |
-        github_token_usage{job="ghproxy", resource!="search"} <  1500
+        github_token_usage{job="ghproxy", ratelimit_resource!="search"} <  1500
         and
-        predict_linear(github_token_usage{job="ghproxy", resource!="search"}[30m], 1 * 3600) < 0
+        predict_linear(github_token_usage{job="ghproxy", ratelimit_resource!="search"}[30m], 1 * 3600) < 0
       for: 5m
       labels:
         severity: high

--- a/config/prow/cluster/monitoring/prow_prometheusrule.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheusrule.yaml
@@ -192,7 +192,7 @@ spec:
         severity: warning
     - alert: ghproxy-running-out-github-tokens-in-a-hour
       annotations:
-        message: token {{ $labels.token_hash }} will run out of API quota before the next reset.
+        message: token {{ $labels.token_hash }} will run out of API quota for {{ $labels.ratelimit_resource }} before the next reset.
       expr: |
         github_token_usage{job="ghproxy", ratelimit_resource!="search"} <  1500
         and

--- a/config/prow/cluster/monitoring/prow_prometheusrule.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheusrule.yaml
@@ -190,17 +190,16 @@ spec:
         sum(rate(github_request_duration_count{status=~"403|405|422"}[30m])) by (status) / ignoring(status) group_left sum(rate(github_request_duration_count[30m])) * 100 > 10
       labels:
         severity: warning
-    # TODO: reactivate this alert, once https://github.com/kubernetes/test-infra/issues/25177 is fixed
-#    - alert: ghproxy-running-out-github-tokens-in-a-hour
-#      annotations:
-#        message: token {{ $labels.token_hash }} will run out of API quota before the next reset.
-#      expr: |
-#        github_token_usage{job="ghproxy", resource!="search"} <  1500
-#        and
-#        predict_linear(github_token_usage{job="ghproxy", resource!="search"}[30m], 1 * 3600) < 0
-#      for: 5m
-#      labels:
-#        severity: high
+    - alert: ghproxy-running-out-github-tokens-in-a-hour
+      annotations:
+        message: token {{ $labels.token_hash }} will run out of API quota before the next reset.
+      expr: |
+        github_token_usage{job="ghproxy", resource!="search"} <  1500
+        and
+        predict_linear(github_token_usage{job="ghproxy", resource!="search"}[30m], 1 * 3600) < 0
+      for: 5m
+      labels:
+        severity: high
   - name: abnormal webhook behaviors
     rules:
     # TODO: reconsider whether this alert makes sense at the scale of our org and with what timeframe based on some experience


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Bug in ghproxy token alerting has been [fixed in upstream](https://github.com/kubernetes/test-infra/pull/25702). Thus, we could enable it again.

**Which issue(s) this PR fixes**:
Fixes #133

**Special notes for your reviewer**:
Alerting was deactivated in [this PR](https://github.com/gardener/ci-infra/pull/80) before.
