### PR TITLE
Update to golang-1.17.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # ----------------
 # Build container
 # ----------------
+ARG GOLANG_VERSION
 
-FROM golang:1.17.7 AS builder
+FROM golang:${GOLANG_VERSION} AS builder
 LABEL stage=intermediate
 ARG OS
 ARG ARCH
@@ -28,7 +29,7 @@ USER 65532
 # Executable containers
 # ----------------------
 
-FROM golang:1.17.7-bullseye AS golang-test
+FROM golang:${GOLANG_VERSION}-bullseye AS golang-test
 # install gardener unit/integration test related dependencies
 RUN set -eux; \
 	apt-get update; \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 REGISTRY          := $(shell cat .REGISTRY 2>/dev/null)
 PUSH_LATEST_TAG   := true
-GOLANG_VERSION    := 1.17.7
+GOLANG_VERSION    := 1.17.8
 VERSION           := v$(shell date '+%Y%m%d')-$(shell git rev-parse --short HEAD)
 OS                := linux
 ARCH              := amd64
@@ -43,9 +43,9 @@ ifeq ("$(REGISTRY)", "")
 	@echo "Please set your docker registry in REGISTRY variable or .REGISTRY file first."; false;
 endif
 	@echo "Building docker golang image for tests with version and tag $(GOLANG_VERSION)"
-	@docker build -t $(REG_GOLANG_TEST):$(GOLANG_VERSION) -t $(REG_GOLANG_TEST):latest -f Dockerfile --target $(IMG_GOLANG_TEST) .
+	@docker build --build-arg GOLANG_VERSION=$(GOLANG_VERSION) -t $(REG_GOLANG_TEST):$(GOLANG_VERSION) -t $(REG_GOLANG_TEST):latest -f Dockerfile --target $(IMG_GOLANG_TEST) .
 	@echo "Building docker images with version and tag $(VERSION)"
-	@docker build --build-arg VERSION=$(VERSION) --build-arg ARCH=$(ARCH) --build-arg OS=$(OS) -t $(REG_CLA_ASSISTANT):$(VERSION) -t $(REG_CLA_ASSISTANT):latest -f Dockerfile --target $(IMG_CLA_ASSISTANT) .
+	@docker build --build-arg GOLANG_VERSION=$(GOLANG_VERSION) --build-arg VERSION=$(VERSION) --build-arg ARCH=$(ARCH) --build-arg OS=$(OS) -t $(REG_CLA_ASSISTANT):$(VERSION) -t $(REG_CLA_ASSISTANT):latest -f Dockerfile --target $(IMG_CLA_ASSISTANT) .
 
 .PHONY: docker-push
 docker-push:

--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -273,7 +273,7 @@ periodics:
     description: Runs go tests for prow developments in ci-infra 
   spec:
     containers:
-    - image: golang:1.17.7
+    - image: golang:1.17.8
       command:
       - make
       args:

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -34,7 +34,7 @@ presubmits:
     max_concurrency: 5
     spec:
       containers:
-      - image: golang:1.17.7
+      - image: golang:1.17.8
         command:
         - make
         args:

--- a/config/jobs/gardener/gardener-tests.yaml
+++ b/config/jobs/gardener/gardener-tests.yaml
@@ -16,7 +16,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: ghcr.io/gardener/ci-infra/golang-test:1.17.7
+      - image: ghcr.io/gardener/ci-infra/golang-test:1.17.8
         command:
         - make
         args:
@@ -47,7 +47,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: ghcr.io/gardener/ci-infra/golang-test:1.17.7
+        image: ghcr.io/gardener/ci-infra/golang-test:1.17.8
         command:
         - make
         args:
@@ -76,7 +76,7 @@ periodics:
     containers:
     # Run all tests sequentially in one container or as separete prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: ghcr.io/gardener/ci-infra/golang-test:1.17.7
+    - image: ghcr.io/gardener/ci-infra/golang-test:1.17.8
       command:
       - make
       args:
@@ -108,7 +108,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: ghcr.io/gardener/ci-infra/golang-test:1.17.7
+      image: ghcr.io/gardener/ci-infra/golang-test:1.17.8
       command:
       - make
       args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Update to golang-1.17.8 to keep golang-test image consistent to golang version of gardener/gardener 

**Which issue(s) this PR fixes**:
Fixes #137

**Special notes for your reviewer**:
