### PR TITLE
Test job improvements

### DIFF
--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -31,7 +31,6 @@ presubmits:
     always_run: true
     annotations:
       description: Runs go tests for prow developments in ci-infra 
-    max_concurrency: 5
     spec:
       containers:
       - image: golang:1.17.8

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -11,7 +11,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-    max_concurrency: 5
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20220322-c5eee43783-master

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -2,7 +2,6 @@ presubmits:
   gardener/gardener:
   - name: pull-gardener-e2e-kind
     cluster: gardener-prow-build
-    skip_if_only_changed: "^docs/|\\.md$"
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -2,7 +2,6 @@ presubmits:
   gardener/gardener:
   - name: pull-gardener-integration
     cluster: gardener-prow-build
-    skip_if_only_changed: "^docs/|\\.md$"
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -10,7 +10,6 @@ presubmits:
       grace_period: 10m
     annotations:
       description: Runs integration tests for gardener developments in pull requests
-    max_concurrency: 5
     spec:
       containers:
       - name: test-integration

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -10,7 +10,6 @@ presubmits:
       grace_period: 10m
     annotations:
       description: Runs unit tests for gardener developments in pull requests
-    max_concurrency: 5
     spec:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -2,7 +2,6 @@ presubmits:
   gardener/gardener:
   - name: pull-gardener-unit
     cluster: gardener-prow-build
-    skip_if_only_changed: "^docs/|\\.md$"
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/release/gardener-e2e-kind-release.yaml
+++ b/config/jobs/gardener/release/gardener-e2e-kind-release.yaml
@@ -2,7 +2,6 @@ presubmits:
   gardener/gardener:
   - name: pull-gardener-e2e-kind-release
     cluster: gardener-prow-build
-    skip_if_only_changed: "^docs/|\\.md$"
     # Run on release branches / adapt this setting and create a new job in case of incompatible changes in tests or go version between the releases
     skip_branches:
     - master

--- a/config/jobs/gardener/release/gardener-e2e-kind-release.yaml
+++ b/config/jobs/gardener/release/gardener-e2e-kind-release.yaml
@@ -12,7 +12,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-    max_concurrency: 5
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20220322-c5eee43783-master
@@ -68,7 +67,6 @@ postsubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-    max_concurrency: 5
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20220322-c5eee43783-master

--- a/config/jobs/gardener/release/gardener-integration-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-integration-tests-release.yaml
@@ -11,7 +11,6 @@ presubmits:
       grace_period: 10m
     annotations:
       description: Runs integration tests for gardener releases in pull requests
-    max_concurrency: 5
     spec:
       containers:
       - name: test-integration
@@ -39,7 +38,6 @@ postsubmits:
       grace_period: 10m
     annotations:
       description: Runs integration tests for gardener releases when merging
-    max_concurrency: 5
     spec:
       containers:
       - name: test-integration

--- a/config/jobs/gardener/release/gardener-integration-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-integration-tests-release.yaml
@@ -2,7 +2,6 @@ presubmits:
   gardener/gardener:
   - name: pull-gardener-integration-release
     cluster: gardener-prow-build
-    skip_if_only_changed: "^docs/|\\.md$"
     # Run on release branches / adapt this setting and create a new job in case of incompatible changes in tests or go version between the releases
     skip_branches:
     - master

--- a/config/jobs/gardener/release/gardener-unit-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-unit-tests-release.yaml
@@ -11,7 +11,6 @@ presubmits:
       grace_period: 10m
     annotations:
       description: Runs unit tests for gardener releases in pull requests
-    max_concurrency: 5
     spec:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.
@@ -45,7 +44,6 @@ postsubmits:
       grace_period: 10m
     annotations:
       description: Runs unit tests for gardener releases when merging
-    max_concurrency: 5
     spec:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.

--- a/config/jobs/gardener/release/gardener-unit-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-unit-tests-release.yaml
@@ -2,7 +2,6 @@ presubmits:
   gardener/gardener:
   - name: pull-gardener-unit-release
     cluster: gardener-prow-build
-    skip_if_only_changed: "^docs/|\\.md$"
     # Run on release branches / adapt this setting and create a new job in case of incompatible changes in tests or go version between the releases
     skip_branches:
     - master


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Some improvements of our test job configuration
- remove `skip_if_only_changed: "^docs/|\\.md$"` directive from test jobs
  - in the current setting we cannot merge PRs which contain docs changes only, because the tests are skipped, but required by branch protection rules
  - Changing docs only is a corner case (only 2 commits in 2022) so far. Thus, there would be no real benefit in creating a special treatment for those commits
- remove `max_concurrency` property from test prow jobs.
  - Autoscaling the cluster works pretty well, so we can easily run more tests in parallel

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
