### PR TITLE
Enable prow in gardener/gardener

### DIFF
--- a/config/jobs/common/issue-pr-lifecycle.yaml
+++ b/config/jobs/common/issue-pr-lifecycle.yaml
@@ -16,6 +16,7 @@ periodics:
       args:
       - |-
         --query=repo:gardener/ci-infra
+        repo:gardener/gardener
         -label:lifecycle/frozen
         label:lifecycle/rotten
       - --updated=720h
@@ -60,6 +61,7 @@ periodics:
       args:
       - |-
         --query=repo:gardener/ci-infra
+        repo:gardener/gardener
         -label:lifecycle/frozen
         label:lifecycle/stale
         -label:lifecycle/rotten
@@ -105,6 +107,7 @@ periodics:
       args:
       - |-
         --query=repo:gardener/ci-infra
+        repo:gardener/gardener
         -label:lifecycle/frozen
         -label:lifecycle/stale
         -label:lifecycle/rotten

--- a/config/prow/cluster/cherrypicker_deployment.yaml
+++ b/config/prow/cluster/cherrypicker_deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: prow
+  name: cherrypicker
+  labels:
+    app: cherrypicker
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: cherrypicker
+  template:
+    metadata:
+      labels:
+        app: cherrypicker
+    spec:
+      serviceAccountName: ""
+      serviceAccount: ""
+      terminationGracePeriodSeconds: 180
+      containers:
+      - name: cherrypicker
+        image: gcr.io/k8s-prow/cherrypicker:v20220328-67f0ba830a
+        imagePullPolicy: Always
+        args:
+        - --github-token-path=/etc/github/token
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --dry-run=false
+        ports:
+          - name: http
+            containerPort: 8888
+        volumeMounts:
+        - name: hmac
+          mountPath: /etc/webhook
+          readOnly: true
+        - name: github-token
+          mountPath: /etc/github
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: hmac
+        secret:
+          secretName: hmac-token
+      - name: github-token
+        secret:
+          secretName: github-token

--- a/config/prow/cluster/cherrypicker_service.yaml
+++ b/config/prow/cluster/cherrypicker_service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cherrypicker
+  namespace: prow
+spec:
+  selector:
+    app: cherrypicker
+  ports:
+  - port: 80
+    targetPort: 8888
+  type: ClusterIP

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -136,7 +136,7 @@ branch-protection:
             contexts:
             - license/cla
             - concourse-ci/publish
-            - check-release-milestone
+            - "Check Release Milestone"
           restrictions: # prevent everyone from pushing/merging
             # NB: tide is running as GitHub App, which currently cannot be configured here to be excluded from branch
             # protections (see https://github.com/kubernetes/test-infra/issues/24530).

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -130,12 +130,26 @@ branch-protection:
             users: []
             teams: []
           enforce_admins: true # protections apply to admins as well
+        gardener:
+          protect: true
+          required_status_checks:
+            contexts:
+            - license/cla
+          restrictions: # prevent everyone from pushing/merging
+            # NB: tide is running as GitHub App, which currently cannot be configured here to be excluded from branch
+            # protections (see https://github.com/kubernetes/test-infra/issues/24530).
+            # Hence, remember to manually add the `gardener-prow` GitHub App to all branch protection rules
+            # to allow tide to push/merge.
+            users: []
+            teams: []
+          enforce_admins: true # protections apply to admins as well
 
 tide:
   sync_period: 2m
   queries:
   - repos:
     - gardener/ci-infra
+    - gardener/gardener
     labels:
     - lgtm
     - approved
@@ -170,6 +184,7 @@ tide:
 
   merge_method:
     gardener/ci-infra: squash
+    gardener/gardener: squash
   pr_status_base_urls:
     '*': https://prow.gardener.cloud/pr
   blocker_label: tide/merge-blocker
@@ -178,7 +193,7 @@ tide:
   merge_label: tide/merge-method-merge
   priority:
   - labels: [ "kind/flake", "priority/critical-urgent" ]
-  - labels: [ "kind/failing-test", "priority/critical-urgent" ]
+  - labels: [ "kind/regression", "priority/critical-urgent" ]
   - labels: [ "kind/bug", "priority/critical-urgent" ]
 
 github_reporter:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -135,6 +135,8 @@ branch-protection:
           required_status_checks:
             contexts:
             - license/cla
+            - concourse-ci/publish
+            - check-release-milestone
           restrictions: # prevent everyone from pushing/merging
             # NB: tide is running as GitHub App, which currently cannot be configured here to be excluded from branch
             # protections (see https://github.com/kubernetes/test-infra/issues/24530).
@@ -182,6 +184,9 @@ tide:
     - needs-rebase
     - "cla: no"
 
+  context_options:
+    # Use branch protection options to define required and optional contexts
+    from-branch-protection: true
   merge_method:
     gardener/ci-infra: squash
     gardener/gardener: squash

--- a/config/prow/deploy.sh
+++ b/config/prow/deploy.sh
@@ -43,6 +43,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 prow_components=(
 "prow_namespace.yaml"
 "test-pods_namespace.yaml"
+"cherrypicker_deployment.yaml"
+"cherrypicker_service.yaml"
 "cla_assistant_deployment.yaml"
 "cla_assistant_service.yaml"
 "cpu-limit-range_limitrange.yaml"

--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -9,6 +9,444 @@
 repos:
   gardener/ci-infra:
     labels:
+      # area
+      - name:  area/audit-logging
+        color: 0052cc
+        description: Audit logging related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/auto-scaling
+        color: 0052cc
+        description: Auto-scaling (CA/HPA/VPA/HVPA, predominantly control plane, but also otherwise) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/backup
+        color: 0052cc
+        description: Backup related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/certification
+        color: 0052cc
+        description: Certification related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/control-plane
+        color: 0052cc
+        description: Control plane related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/control-plane-migration
+        color: 0052cc
+        description: Control plane migration related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/cost
+        color: 0052cc
+        description: Cost related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/delivery
+        color: 0052cc
+        description: Delivery related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/dev-productivity
+        color: 0052cc
+        description: Developer productivity related (how to improve development)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/disaster-recovery
+        color: 0052cc
+        description: Disaster recovery related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/documentation
+        color: 0052cc
+        description: Documentation related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: documentation
+      - name:  area/high-availability
+        color: 0052cc
+        description: High availability related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/logging
+        color: 0052cc
+        description: Logging related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/metering
+        color: 0052cc
+        description: Metering related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/monitoring
+        color: 0052cc
+        description: Monitoring (including availability monitoring and alerting) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/networking
+        color: 0052cc
+        description: Networking related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/open-source
+        color: 0052cc
+        description: Open Source (community, enablement, contributions, conferences, CNCF, etc.) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/ops-productivity
+        color: 0052cc
+        description: Operator productivity related (how to improve operations)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/os
+        color: 0052cc
+        description: Operator system related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/performance
+        color: 0052cc
+        description: Performance (across all domains, such as control plane, networking, storage, etc.) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/quality
+        color: 0052cc
+        description: Output qualification (tests, checks, scans, automation in general, etc.) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/robustness
+        color: 0052cc
+        description: Robustness, reliability, resilience related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/scalability
+        color: 0052cc
+        description: Scalability related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/security
+        color: 0052cc
+        description: Security related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/storage
+        color: 0052cc
+        description: Storage related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/testing
+        color: 0052cc
+        description: Testing related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/usability
+        color: 0052cc
+        description: Usability related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/user-management
+        color: 0052cc
+        description: User-management related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      # component
+      - name:  component/cicd
+        color: 25399e
+        description: Continuous integration/delivery (tooling and processes)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/dashboard
+        color: 25399e
+        description: Gardener Dashboard
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/documentation
+        color: 25399e
+        description: Gardener Documentation
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/etcd-backup-restore
+        color: 25399e
+        description: ETCD Backup & Restore
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/etcd-druid
+        color: 25399e
+        description: ETCD Druid
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/gardenctl
+        color: 25399e
+        description: Gardener CLI
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/gardener
+        color: 25399e
+        description: Gardener
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/hvpa
+        color: 25399e
+        description: HVPA
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/kubify
+        color: 25399e
+        description: Kubify
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/landscaper
+        color: 25399e
+        description: Landscape Installer
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/mcm
+        color: 25399e
+        description: Machine Controller Manager (including Node Problem Detector, Cluster Auto Scaler, etc.)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/tm
+        color: 25399e
+        description: Test machinery (tooling and processes)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      # kind
+      - name:  kind/epic
+        color: c7def8
+        description: Large multi-story topic
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: epic
+      - name:  kind/bug
+        color: e11d21
+        description: Bug
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: bug
+      - name:  kind/regression
+        color: e11d21
+        description: Bug that hit us already in the past and that is reappearing/requires a proper solution
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/post-mortem
+        color: e11d21
+        description: Bug that requires deeper analysis after immediate issues were resolved (usually after downtime)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/impediment
+        color: eb6420
+        description: Something that impedes developers, operators, users or others in their work
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/technical-debt
+        color: eb6420
+        description: Something that is only solved on the surface, but requires more (re)work to be done properly
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/api-change
+        color: eb6420
+        description: API change with impact on API users
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/enhancement
+        color: c7def8
+        description: Enhancement, improvement, extension
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: enhancement
+      - name:  kind/poc
+        color: c7def8
+        description: Proof of concept or prototype
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/task
+        color: c7def8
+        description: General task
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/test
+        color: c7def8
+        description: Test
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/flake
+        color: f7c6c7
+        description: Tracking or fixing a flaky test
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/cleanup
+        color: c7def8
+        description: Something that is not needed anymore and can be cleaned up
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/question
+        color: c7def8
+        description: Question (asking for help, advice, or technical detail)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: question
+      - name:  kind/discussion
+        color: c7def8
+        description: Discussion (enaging others in deciding about multiple options)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: discussion
+      - name:  kind/consulting
+        color: 33cc3f
+        description: Consulting (requiring support to solve a problem)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/onboarding
+        color: 33cc3f
+        description: Onboarding
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/quota-request
+        color: c7def8
+        description: Resource quota related changes
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      # priority
+      - name:  priority/1
+        color: e11d21
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name:  priority/2
+        color: e54014
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name:  priority/3
+        color: e96f0b
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name:  priority/4
+        color: ec9a04
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name:  priority/5
+        color: fbca04
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name:  priority/blocker
+        color: e11d21
+        description: Needs to be resolved now, because it breaks the service
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  priority/critical
+        color: e54014
+        description: Needs to be resolved soon, because it impacts users negatively
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  priority/normal
+        color: fbca04
+        description: Has no particular urgency
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      # roadmap
+      - name:  roadmap/cloud
+        color: 4c38a5
+        purpose: Roadmap for the (managed) cloud delivery, i.e. gardener.cloud.sap
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: roadmap/cloud-sap
+      - name:  roadmap/standalone
+        color: 4c38a5
+        purpose: Roadmap for the (on-prem) standalone delivery, e.g. CDC, NS2, etc.
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: roadmap/on-prem
+      - name:  roadmap/internal
+        color: 4c38a5
+        purpose: Roadmap for our team-internal goals, e.g. drive up seed utilization
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: roadmap/team-internal
+      # prow
       - color: 0ffa16
         description: Indicates a PR has been approved by an approver from all required OWNERS files.
         name: approved
@@ -239,24 +677,691 @@ repos:
         name: 'cla: no'
         target: prs
         prowPlugin: cla-assistant
+        isExternalPlugin: true
         addedBy: prow
       - color: bfe5bf
         description: Indicates the PR's author has signed the cla-assistant.io CLA.
         name: 'cla: yes'
         target: prs
         prowPlugin: cla-assistant
+        isExternalPlugin: true
         addedBy: prow
   gardener/gardener:
     labels:
+      # area
+      - name:  area/audit-logging
+        color: 0052cc
+        description: Audit logging related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/auto-scaling
+        color: 0052cc
+        description: Auto-scaling (CA/HPA/VPA/HVPA, predominantly control plane, but also otherwise) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/backup
+        color: 0052cc
+        description: Backup related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/certification
+        color: 0052cc
+        description: Certification related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/control-plane
+        color: 0052cc
+        description: Control plane related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/control-plane-migration
+        color: 0052cc
+        description: Control plane migration related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/cost
+        color: 0052cc
+        description: Cost related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/delivery
+        color: 0052cc
+        description: Delivery related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/dev-productivity
+        color: 0052cc
+        description: Developer productivity related (how to improve development)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/disaster-recovery
+        color: 0052cc
+        description: Disaster recovery related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/documentation
+        color: 0052cc
+        description: Documentation related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: documentation
+      - name:  area/high-availability
+        color: 0052cc
+        description: High availability related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/logging
+        color: 0052cc
+        description: Logging related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/metering
+        color: 0052cc
+        description: Metering related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/monitoring
+        color: 0052cc
+        description: Monitoring (including availability monitoring and alerting) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/networking
+        color: 0052cc
+        description: Networking related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/open-source
+        color: 0052cc
+        description: Open Source (community, enablement, contributions, conferences, CNCF, etc.) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/ops-productivity
+        color: 0052cc
+        description: Operator productivity related (how to improve operations)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/os
+        color: 0052cc
+        description: Operator system related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/performance
+        color: 0052cc
+        description: Performance (across all domains, such as control plane, networking, storage, etc.) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/quality
+        color: 0052cc
+        description: Output qualification (tests, checks, scans, automation in general, etc.) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/robustness
+        color: 0052cc
+        description: Robustness, reliability, resilience related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/scalability
+        color: 0052cc
+        description: Scalability related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/security
+        color: 0052cc
+        description: Security related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/storage
+        color: 0052cc
+        description: Storage related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/testing
+        color: 0052cc
+        description: Testing related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/usability
+        color: 0052cc
+        description: Usability related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  area/user-management
+        color: 0052cc
+        description: User-management related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      # component
+      - name:  component/cicd
+        color: 25399e
+        description: Continuous integration/delivery (tooling and processes)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/dashboard
+        color: 25399e
+        description: Gardener Dashboard
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/documentation
+        color: 25399e
+        description: Gardener Documentation
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/etcd-backup-restore
+        color: 25399e
+        description: ETCD Backup & Restore
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/etcd-druid
+        color: 25399e
+        description: ETCD Druid
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/gardenctl
+        color: 25399e
+        description: Gardener CLI
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/gardener
+        color: 25399e
+        description: Gardener
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/hvpa
+        color: 25399e
+        description: HVPA
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/kubify
+        color: 25399e
+        description: Kubify
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/landscaper
+        color: 25399e
+        description: Landscape Installer
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/mcm
+        color: 25399e
+        description: Machine Controller Manager (including Node Problem Detector, Cluster Auto Scaler, etc.)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  component/tm
+        color: 25399e
+        description: Test machinery (tooling and processes)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      # kind
+      - name:  kind/epic
+        color: c7def8
+        description: Large multi-story topic
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: epic
+      - name:  kind/bug
+        color: e11d21
+        description: Bug
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: bug
+      - name:  kind/regression
+        color: e11d21
+        description: Bug that hit us already in the past and that is reappearing/requires a proper solution
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/post-mortem
+        color: e11d21
+        description: Bug that requires deeper analysis after immediate issues were resolved (usually after downtime)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/impediment
+        color: eb6420
+        description: Something that impedes developers, operators, users or others in their work
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/technical-debt
+        color: eb6420
+        description: Something that is only solved on the surface, but requires more (re)work to be done properly
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/api-change
+        color: eb6420
+        description: API change with impact on API users
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/enhancement
+        color: c7def8
+        description: Enhancement, improvement, extension
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: enhancement
+      - name:  kind/poc
+        color: c7def8
+        description: Proof of concept or prototype
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/task
+        color: c7def8
+        description: General task
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/test
+        color: c7def8
+        description: Test
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/flake
+        color: f7c6c7
+        description: Tracking or fixing a flaky test
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/cleanup
+        color: c7def8
+        description: Something that is not needed anymore and can be cleaned up
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/question
+        color: c7def8
+        description: Question (asking for help, advice, or technical detail)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: question
+      - name:  kind/discussion
+        color: c7def8
+        description: Discussion (enaging others in deciding about multiple options)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: discussion
+      - name:  kind/consulting
+        color: 33cc3f
+        description: Consulting (requiring support to solve a problem)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/onboarding
+        color: 33cc3f
+        description: Onboarding
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name:  kind/quota-request
+        color: c7def8
+        description: Resource quota related changes
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      # priority
+      - name:  priority/1
+        color: e11d21
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name:  priority/2
+        color: e54014
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name:  priority/3
+        color: e96f0b
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name:  priority/4
+        color: ec9a04
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name:  priority/5
+        color: fbca04
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name:  priority/blocker
+        color: e11d21
+        description: Needs to be resolved now, because it breaks the service
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  priority/critical
+        color: e54014
+        description: Needs to be resolved soon, because it impacts users negatively
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name:  priority/normal
+        color: fbca04
+        description: Has no particular urgency
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      # roadmap
+      - name:  roadmap/cloud
+        color: 4c38a5
+        purpose: Roadmap for the (managed) cloud delivery, i.e. gardener.cloud.sap
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: roadmap/cloud-sap
+      - name:  roadmap/standalone
+        color: 4c38a5
+        purpose: Roadmap for the (on-prem) standalone delivery, e.g. CDC, NS2, etc.
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: roadmap/on-prem
+      - name:  roadmap/internal
+        color: 4c38a5
+        purpose: Roadmap for our team-internal goals, e.g. drive up seed utilization
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: roadmap/team-internal
+      # prow
+      - color: 0ffa16
+        description: Indicates a PR has been approved by an approver from all required OWNERS files.
+        name: approved
+        target: prs
+        prowPlugin: approve
+        addedBy: approvers
+      - color: fef2c0
+        description: Indicates a cherry-pick PR into a release branch has been approved by the release branch manager. # Consumed by the kubernetes/kubernetes cherry-pick-queue.
+        name: cherry-pick-approved
+        target: prs
+        addedBy: humans
+      - color: 8fc951
+        description: Indicates an issue or PR is ready to be actively worked on.
+        name: triage/accepted
+        target: both
+        prowPlugin: label
+        addedBy: org members
+      - color: d455d0
+        description: Indicates an issue is a duplicate of other open issue.
+        name: triage/duplicate
+        target: both
+        addedBy: humans
+      - color: d455d0
+        description: Indicates an issue needs more information in order to work on it.
+        name: triage/needs-information
+        target: both
+        addedBy: humans
+      - color: d455d0
+        description: Indicates an issue can not be reproduced as described.
+        name: triage/not-reproducible
+        target: both
+        addedBy: humans
+      - color: d455d0
+        description: Indicates an issue that can not or will not be resolved.
+        name: triage/unresolved
+        target: both
+        addedBy: humans
+      - color: e11d21
+        description: Indicates that a PR should not merge because it touches files in blocked paths.
+        name: do-not-merge/blocked-paths
+        target: prs
+        prowPlugin: blockade
+        addedBy: prow
+      - color: e11d21
+        description: Indicates that a PR is not yet approved to merge into a release branch.
+        name: do-not-merge/cherry-pick-not-approved
+        target: prs
+        addedBy: prow
+        prowPlugin: cherrypickunapproved
+      - color: e11d21
+        description: Indicates that a PR should not merge because someone has issued a /hold command.
+        name: do-not-merge/hold
+        target: prs
+        prowPlugin: hold
+        addedBy: anyone
+      - color: e11d21
+        description: Indicates that a PR should not merge because it has an invalid commit message.
+        name: do-not-merge/invalid-commit-message
+        target: prs
+        prowPlugin: invalidcommitmsg
+        addedBy: prow
+      - color: e11d21
+        description: Indicates that a PR should not merge because it has an invalid OWNERS file in it.
+        name: do-not-merge/invalid-owners-file
+        target: prs
+        prowPlugin: verify-owners
+        addedBy: prow
+      - color: e11d21
+        description: Indicates that a PR should not merge because it's missing one of the release note labels.
+        name: do-not-merge/release-note-label-needed
+        target: prs
+        prowPlugin: releasenote
+        addedBy: prow
+      - color: e11d21
+        description: Indicates that a PR should not merge because it is a work in progress.
+        name: do-not-merge/work-in-progress
+        target: prs
+        prowPlugin: wip
+        addedBy: prow
+      - color: e11d21
+        description: Indicates a PR which contains merge commits.
+        name: do-not-merge/contains-merge-commits
+        target: prs
+        prowPlugin: mergecommitblocker
+        addedBy: prow
+      - color: e11d21
+        description: Indicates a PR lacks a `kind/foo` label and requires one.
+        name: do-not-merge/needs-kind
+        target: prs
+        prowPlugin: require-matching-label
+        addedBy: prow
+      - color: 7057ff
+        description: Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.
+        name: 'good first issue'
+        target: issues
+        prowPlugin: help
+        addedBy: anyone
+      - color: 006b75
+        description: Denotes an issue that needs help from a contributor. Must meet "help wanted" guidelines.
+        name: 'help wanted'
+        target: issues
+        prowPlugin: help
+        addedBy: anyone
+      - color: 15dd18
+        description: Indicates that a PR is ready to be merged.
+        name: lgtm
+        target: prs
+        prowPlugin: lgtm
+        addedBy: reviewers or members
+      - color: d3e2f0
+        description: Indicates that an issue or PR should not be auto-closed due to staleness.
+        name: lifecycle/frozen
+        target: both
+        prowPlugin: lifecycle
+        addedBy: anyone
+      - color: 8fc951
+        description: Indicates that an issue or PR is actively being worked on by a contributor.
+        name: lifecycle/active
+        target: both
+        prowPlugin: lifecycle
+        addedBy: anyone
+      - color: "604460"
+        description: Denotes an issue or PR that has aged beyond stale and will be auto-closed.
+        name: lifecycle/rotten
+        target: both
+        prowPlugin: lifecycle
+        addedBy: anyone or prow
+      - color: "795548"
+        description: Denotes an issue or PR has remained open with no activity and has become stale.
+        name: lifecycle/stale
+        target: both
+        prowPlugin: lifecycle
+        addedBy: anyone or prow
+      - color: ededed
+        description: Indicates a PR lacks a `kind/foo` label and requires one.
+        name: needs-kind
+        target: prs
+        prowPlugin: require-matching-label
+        addedBy: prow
       - color: b60205
         description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
         name: needs-ok-to-test
         target: prs
         prowPlugin: trigger
         addedBy: prow
+      - color: e11d21
+        description: Indicates a PR cannot be merged because it has merge conflicts with HEAD.
+        name: needs-rebase
+        target: prs
+        prowPlugin: needs-rebase
+        isExternalPlugin: true
+        addedBy: prow
       - color: 15dd18
         description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
         name: ok-to-test
         target: prs
         prowPlugin: trigger
+        addedBy: prow
+      - color: ee9900
+        description: Denotes a PR that changes 100-499 lines, ignoring generated files.
+        name: size/L
+        target: prs
+        prowPlugin: size
+        addedBy: prow
+      - color: eebb00
+        description: Denotes a PR that changes 30-99 lines, ignoring generated files.
+        name: size/M
+        target: prs
+        prowPlugin: size
+        addedBy: prow
+      - color: 77bb00
+        description: Denotes a PR that changes 10-29 lines, ignoring generated files.
+        name: size/S
+        target: prs
+        prowPlugin: size
+        addedBy: prow
+      - color: ee5500
+        description: Denotes a PR that changes 500-999 lines, ignoring generated files.
+        name: size/XL
+        target: prs
+        prowPlugin: size
+        addedBy: prow
+      - color: "009900"
+        description: Denotes a PR that changes 0-9 lines, ignoring generated files.
+        name: size/XS
+        target: prs
+        prowPlugin: size
+        addedBy: prow
+      - color: ee0000
+        description: Denotes a PR that changes 1000+ lines, ignoring generated files.
+        name: size/XXL
+        target: prs
+        prowPlugin: size
+        addedBy: prow
+      - color: ffaa00
+        description: Denotes a PR that should be squashed by tide when it merges.
+        name: tide/merge-method-squash
+        target: prs
+        addedBy: humans
+      - color: ffaa00
+        description: Denotes a PR that should be rebased by tide when it merges.
+        name: tide/merge-method-rebase
+        target: prs
+        addedBy: humans
+      - color: ffaa00
+        description: Denotes a PR that should use a standard merge by tide when it merges.
+        name: tide/merge-method-merge
+        target: prs
+        addedBy: humans
+      - color: e11d21
+        description: Denotes an issue that blocks the tide merge queue for a branch while it is open.
+        name: tide/merge-blocker
+        target: issues
+        addedBy: humans
+      - color: 0ffa16
+        description: Indicates a PR is trusted, used by tide for auto-merging PRs.
+        name: skip-review
+        target: prs
+        addedBy: autobump bot
+      - color: f9d0c4
+        description: ¯\\\_(ツ)_/¯
+        name: "¯\\_(ツ)_/¯"
+        target: both
+        prowPlugin: shrug
+        addedBy: humans
+      - color: e11d21
+        description: Indicates the PR's author has not signed the cla-assistant.io CLA.
+        name: 'cla: no'
+        target: prs
+        prowPlugin: cla-assistant
+        isExternalPlugin: true
+        addedBy: prow
+      - color: bfe5bf
+        description: Indicates the PR's author has signed the cla-assistant.io CLA.
+        name: 'cla: yes'
+        target: prs
+        prowPlugin: cla-assistant
+        isExternalPlugin: true
         addedBy: prow

--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -354,23 +354,82 @@ repos:
         addedBy: anyone
         previously:
           - name: discussion
-      - name:  kind/consulting
-        color: 33cc3f
-        description: Consulting (requiring support to solve a problem)
-        target: issues
-        prowPlugin: label
+      # os
+      - name:  os/garden-linux
+        color: 187c00
+        description: Related to Garden Linux OS
+        target: both
         addedBy: anyone
-      - name:  kind/onboarding
-        color: 33cc3f
-        description: Onboarding
-        target: issues
-        prowPlugin: label
+      - name:  os/suse-chost
+        color: 187c00
+        description: Related to SUSE Container Host OS
+        target: both
         addedBy: anyone
-      - name:  kind/quota-request
-        color: c7def8
-        description: Resource quota related changes
-        target: issues
-        prowPlugin: label
+      - name:  os/ubuntu
+        color: 187c00
+        description: Related to Ubuntu OS
+        target: both
+        addedBy: anyone
+      # platform
+      - name:  platform/alicloud
+        color: 006b75
+        description: Alicloud platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/aws
+        color: 006b75
+        description: Amazon web services platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/aws-gov
+        color: 006b75
+        description: Amazon web services (government) platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/azure
+        color: 006b75
+        description: Microsoft Azure platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/metal
+        color: 006b75
+        description: Bare metal platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/kubevirt
+        color: 006b75
+        description: Container Native Virtualization (CNV) KubeVirt platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/converged-cloud
+        color: 006b75
+        description: Converged Cloud (CC) platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/gcp
+        color: 006b75
+        description: Google cloud platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/gmp
+        color: 006b75
+        description: GMP (SEN) platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/openstack
+        color: 006b75
+        description: OpenStack platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/equinix-metal
+        color: 006b75
+        description: Equinix Metal platform/infrastructure (previously Packet)
+        target: both
+        addedBy: anyone
+      - name:  platform/vsphere
+        color: 006b75
+        description: VMware vSphere platform/infrastructure
+        target: both
         addedBy: anyone
       # priority
       - name:  priority/1
@@ -403,28 +462,10 @@ repos:
         target: issues
         prowPlugin: label
         addedBy: anyone
-      - name:  priority/blocker
-        color: e11d21
-        description: Needs to be resolved now, because it breaks the service
-        target: both
-        prowPlugin: label
-        addedBy: anyone
-      - name:  priority/critical
-        color: e54014
-        description: Needs to be resolved soon, because it impacts users negatively
-        target: both
-        prowPlugin: label
-        addedBy: anyone
-      - name:  priority/normal
-        color: fbca04
-        description: Has no particular urgency
-        target: issues
-        prowPlugin: label
-        addedBy: anyone
       # roadmap
       - name:  roadmap/cloud
         color: 4c38a5
-        purpose: Roadmap for the (managed) cloud delivery, i.e. gardener.cloud.sap
+        description: Roadmap for the (managed) cloud delivery, i.e. gardener.cloud.sap
         target: both
         prowPlugin: label
         addedBy: anyone
@@ -432,7 +473,7 @@ repos:
           - name: roadmap/cloud-sap
       - name:  roadmap/standalone
         color: 4c38a5
-        purpose: Roadmap for the (on-prem) standalone delivery, e.g. CDC, NS2, etc.
+        description: Roadmap for the (on-prem) standalone delivery, e.g. CDC, NS2, etc.
         target: both
         prowPlugin: label
         addedBy: anyone
@@ -440,7 +481,7 @@ repos:
           - name: roadmap/on-prem
       - name:  roadmap/internal
         color: 4c38a5
-        purpose: Roadmap for our team-internal goals, e.g. drive up seed utilization
+        description: Roadmap for our team-internal goals, e.g. drive up seed utilization
         target: both
         prowPlugin: label
         addedBy: anyone
@@ -1033,23 +1074,82 @@ repos:
         addedBy: anyone
         previously:
           - name: discussion
-      - name:  kind/consulting
-        color: 33cc3f
-        description: Consulting (requiring support to solve a problem)
-        target: issues
-        prowPlugin: label
+      # os
+      - name:  os/garden-linux
+        color: 187c00
+        description: Related to Garden Linux OS
+        target: both
         addedBy: anyone
-      - name:  kind/onboarding
-        color: 33cc3f
-        description: Onboarding
-        target: issues
-        prowPlugin: label
+      - name:  os/suse-chost
+        color: 187c00
+        description: Related to SUSE Container Host OS
+        target: both
         addedBy: anyone
-      - name:  kind/quota-request
-        color: c7def8
-        description: Resource quota related changes
-        target: issues
-        prowPlugin: label
+      - name:  os/ubuntu
+        color: 187c00
+        description: Related to Ubuntu OS
+        target: both
+        addedBy: anyone
+      # platform
+      - name:  platform/alicloud
+        color: 006b75
+        description: Alicloud platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/aws
+        color: 006b75
+        description: Amazon web services platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/aws-gov
+        color: 006b75
+        description: Amazon web services (government) platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/azure
+        color: 006b75
+        description: Microsoft Azure platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/metal
+        color: 006b75
+        description: Bare metal platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/kubevirt
+        color: 006b75
+        description: Container Native Virtualization (CNV) KubeVirt platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/converged-cloud
+        color: 006b75
+        description: Converged Cloud (CC) platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/gcp
+        color: 006b75
+        description: Google cloud platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/gmp
+        color: 006b75
+        description: GMP (SEN) platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/openstack
+        color: 006b75
+        description: OpenStack platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name:  platform/equinix-metal
+        color: 006b75
+        description: Equinix Metal platform/infrastructure (previously Packet)
+        target: both
+        addedBy: anyone
+      - name:  platform/vsphere
+        color: 006b75
+        description: VMware vSphere platform/infrastructure
+        target: both
         addedBy: anyone
       # priority
       - name:  priority/1
@@ -1082,28 +1182,10 @@ repos:
         target: issues
         prowPlugin: label
         addedBy: anyone
-      - name:  priority/blocker
-        color: e11d21
-        description: Needs to be resolved now, because it breaks the service
-        target: both
-        prowPlugin: label
-        addedBy: anyone
-      - name:  priority/critical
-        color: e54014
-        description: Needs to be resolved soon, because it impacts users negatively
-        target: both
-        prowPlugin: label
-        addedBy: anyone
-      - name:  priority/normal
-        color: fbca04
-        description: Has no particular urgency
-        target: issues
-        prowPlugin: label
-        addedBy: anyone
       # roadmap
       - name:  roadmap/cloud
         color: 4c38a5
-        purpose: Roadmap for the (managed) cloud delivery, i.e. gardener.cloud.sap
+        description: Roadmap for the (managed) cloud delivery, i.e. gardener.cloud.sap
         target: both
         prowPlugin: label
         addedBy: anyone
@@ -1111,7 +1193,7 @@ repos:
           - name: roadmap/cloud-sap
       - name:  roadmap/standalone
         color: 4c38a5
-        purpose: Roadmap for the (on-prem) standalone delivery, e.g. CDC, NS2, etc.
+        description: Roadmap for the (on-prem) standalone delivery, e.g. CDC, NS2, etc.
         target: both
         prowPlugin: label
         addedBy: anyone
@@ -1119,7 +1201,7 @@ repos:
           - name: roadmap/on-prem
       - name:  roadmap/internal
         color: 4c38a5
-        purpose: Roadmap for our team-internal goals, e.g. drive up seed utilization
+        description: Roadmap for our team-internal goals, e.g. drive up seed utilization
         target: both
         prowPlugin: label
         addedBy: anyone

--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -10,67 +10,67 @@ repos:
   gardener/ci-infra:
     labels:
       # area
-      - name:  area/audit-logging
+      - name: area/audit-logging
         color: 0052cc
         description: Audit logging related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/auto-scaling
+      - name: area/auto-scaling
         color: 0052cc
         description: Auto-scaling (CA/HPA/VPA/HVPA, predominantly control plane, but also otherwise) related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/backup
+      - name: area/backup
         color: 0052cc
         description: Backup related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/certification
+      - name: area/certification
         color: 0052cc
         description: Certification related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/control-plane
+      - name: area/control-plane
         color: 0052cc
         description: Control plane related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/control-plane-migration
+      - name: area/control-plane-migration
         color: 0052cc
         description: Control plane migration related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/cost
+      - name: area/cost
         color: 0052cc
         description: Cost related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/delivery
+      - name: area/delivery
         color: 0052cc
         description: Delivery related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/dev-productivity
+      - name: area/dev-productivity
         color: 0052cc
         description: Developer productivity related (how to improve development)
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/disaster-recovery
+      - name: area/disaster-recovery
         color: 0052cc
         description: Disaster recovery related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/documentation
+      - name: area/documentation
         color: 0052cc
         description: Documentation related
         target: both
@@ -78,183 +78,183 @@ repos:
         addedBy: anyone
         previously:
           - name: documentation
-      - name:  area/high-availability
+      - name: area/high-availability
         color: 0052cc
         description: High availability related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/logging
+      - name: area/logging
         color: 0052cc
         description: Logging related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/metering
+      - name: area/metering
         color: 0052cc
         description: Metering related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/monitoring
+      - name: area/monitoring
         color: 0052cc
         description: Monitoring (including availability monitoring and alerting) related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/networking
+      - name: area/networking
         color: 0052cc
         description: Networking related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/open-source
+      - name: area/open-source
         color: 0052cc
         description: Open Source (community, enablement, contributions, conferences, CNCF, etc.) related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/ops-productivity
+      - name: area/ops-productivity
         color: 0052cc
         description: Operator productivity related (how to improve operations)
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/os
+      - name: area/os
         color: 0052cc
         description: Operator system related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/performance
+      - name: area/performance
         color: 0052cc
         description: Performance (across all domains, such as control plane, networking, storage, etc.) related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/quality
+      - name: area/quality
         color: 0052cc
         description: Output qualification (tests, checks, scans, automation in general, etc.) related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/robustness
+      - name: area/robustness
         color: 0052cc
         description: Robustness, reliability, resilience related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/scalability
+      - name: area/scalability
         color: 0052cc
         description: Scalability related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/security
+      - name: area/security
         color: 0052cc
         description: Security related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/storage
+      - name: area/storage
         color: 0052cc
         description: Storage related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/testing
+      - name: area/testing
         color: 0052cc
         description: Testing related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/usability
+      - name: area/usability
         color: 0052cc
         description: Usability related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/user-management
+      - name: area/user-management
         color: 0052cc
         description: User-management related
         target: both
         prowPlugin: label
         addedBy: anyone
       # component
-      - name:  component/cicd
+      - name: component/cicd
         color: 25399e
         description: Continuous integration/delivery (tooling and processes)
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/dashboard
+      - name: component/dashboard
         color: 25399e
         description: Gardener Dashboard
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/documentation
+      - name: component/documentation
         color: 25399e
         description: Gardener Documentation
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/etcd-backup-restore
+      - name: component/etcd-backup-restore
         color: 25399e
         description: ETCD Backup & Restore
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/etcd-druid
+      - name: component/etcd-druid
         color: 25399e
         description: ETCD Druid
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/gardenctl
+      - name: component/gardenctl
         color: 25399e
         description: Gardener CLI
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/gardener
+      - name: component/gardener
         color: 25399e
         description: Gardener
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/hvpa
+      - name: component/hvpa
         color: 25399e
         description: HVPA
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/kubify
+      - name: component/kubify
         color: 25399e
         description: Kubify
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/landscaper
+      - name: component/landscaper
         color: 25399e
         description: Landscape Installer
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/mcm
+      - name: component/mcm
         color: 25399e
         description: Machine Controller Manager (including Node Problem Detector, Cluster Auto Scaler, etc.)
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/tm
+      - name: component/tm
         color: 25399e
         description: Test machinery (tooling and processes)
         target: both
         prowPlugin: label
         addedBy: anyone
       # kind
-      - name:  kind/epic
+      - name: kind/epic
         color: c7def8
         description: Large multi-story topic
         target: both
@@ -262,7 +262,7 @@ repos:
         addedBy: anyone
         previously:
           - name: epic
-      - name:  kind/bug
+      - name: kind/bug
         color: e11d21
         description: Bug
         target: both
@@ -270,37 +270,37 @@ repos:
         addedBy: anyone
         previously:
           - name: bug
-      - name:  kind/regression
+      - name: kind/regression
         color: e11d21
         description: Bug that hit us already in the past and that is reappearing/requires a proper solution
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/post-mortem
+      - name: kind/post-mortem
         color: e11d21
         description: Bug that requires deeper analysis after immediate issues were resolved (usually after downtime)
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/impediment
+      - name: kind/impediment
         color: eb6420
         description: Something that impedes developers, operators, users or others in their work
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/technical-debt
+      - name: kind/technical-debt
         color: eb6420
         description: Something that is only solved on the surface, but requires more (re)work to be done properly
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/api-change
+      - name: kind/api-change
         color: eb6420
         description: API change with impact on API users
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/enhancement
+      - name: kind/enhancement
         color: c7def8
         description: Enhancement, improvement, extension
         target: both
@@ -308,37 +308,37 @@ repos:
         addedBy: anyone
         previously:
           - name: enhancement
-      - name:  kind/poc
+      - name: kind/poc
         color: c7def8
         description: Proof of concept or prototype
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/task
+      - name: kind/task
         color: c7def8
         description: General task
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/test
+      - name: kind/test
         color: c7def8
         description: Test
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/flake
+      - name: kind/flake
         color: f7c6c7
         description: Tracking or fixing a flaky test
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/cleanup
+      - name: kind/cleanup
         color: c7def8
         description: Something that is not needed anymore and can be cleaned up
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/question
+      - name: kind/question
         color: c7def8
         description: Question (asking for help, advice, or technical detail)
         target: issues
@@ -346,7 +346,7 @@ repos:
         addedBy: anyone
         previously:
           - name: question
-      - name:  kind/discussion
+      - name: kind/discussion
         color: c7def8
         description: Discussion (enaging others in deciding about multiple options)
         target: issues
@@ -355,115 +355,115 @@ repos:
         previously:
           - name: discussion
       # os
-      - name:  os/garden-linux
+      - name: os/garden-linux
         color: 187c00
         description: Related to Garden Linux OS
         target: both
         addedBy: anyone
-      - name:  os/suse-chost
+      - name: os/suse-chost
         color: 187c00
         description: Related to SUSE Container Host OS
         target: both
         addedBy: anyone
-      - name:  os/ubuntu
+      - name: os/ubuntu
         color: 187c00
         description: Related to Ubuntu OS
         target: both
         addedBy: anyone
       # platform
-      - name:  platform/alicloud
+      - name: platform/alicloud
         color: 006b75
         description: Alicloud platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/aws
+      - name: platform/aws
         color: 006b75
         description: Amazon web services platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/aws-gov
+      - name: platform/aws-gov
         color: 006b75
         description: Amazon web services (government) platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/azure
+      - name: platform/azure
         color: 006b75
         description: Microsoft Azure platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/metal
+      - name: platform/metal
         color: 006b75
         description: Bare metal platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/kubevirt
+      - name: platform/kubevirt
         color: 006b75
         description: Container Native Virtualization (CNV) KubeVirt platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/converged-cloud
+      - name: platform/converged-cloud
         color: 006b75
         description: Converged Cloud (CC) platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/gcp
+      - name: platform/gcp
         color: 006b75
         description: Google cloud platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/gmp
+      - name: platform/gmp
         color: 006b75
         description: GMP (SEN) platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/openstack
+      - name: platform/openstack
         color: 006b75
         description: OpenStack platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/equinix-metal
+      - name: platform/equinix-metal
         color: 006b75
         description: Equinix Metal platform/infrastructure (previously Packet)
         target: both
         addedBy: anyone
-      - name:  platform/vsphere
+      - name: platform/vsphere
         color: 006b75
         description: VMware vSphere platform/infrastructure
         target: both
         addedBy: anyone
       # priority
-      - name:  priority/1
+      - name: priority/1
         color: e11d21
         description: Priority (lower number equals higher priority)
         target: issues
         prowPlugin: label
         addedBy: anyone
-      - name:  priority/2
+      - name: priority/2
         color: e54014
         description: Priority (lower number equals higher priority)
         target: issues
         prowPlugin: label
         addedBy: anyone
-      - name:  priority/3
+      - name: priority/3
         color: e96f0b
         description: Priority (lower number equals higher priority)
         target: issues
         prowPlugin: label
         addedBy: anyone
-      - name:  priority/4
+      - name: priority/4
         color: ec9a04
         description: Priority (lower number equals higher priority)
         target: issues
         prowPlugin: label
         addedBy: anyone
-      - name:  priority/5
+      - name: priority/5
         color: fbca04
         description: Priority (lower number equals higher priority)
         target: issues
         prowPlugin: label
         addedBy: anyone
       # roadmap
-      - name:  roadmap/cloud
+      - name: roadmap/cloud
         color: 4c38a5
         description: Roadmap for the (managed) cloud delivery, i.e. gardener.cloud.sap
         target: both
@@ -471,7 +471,7 @@ repos:
         addedBy: anyone
         previously:
           - name: roadmap/cloud-sap
-      - name:  roadmap/standalone
+      - name: roadmap/standalone
         color: 4c38a5
         description: Roadmap for the (on-prem) standalone delivery, e.g. CDC, NS2, etc.
         target: both
@@ -479,7 +479,7 @@ repos:
         addedBy: anyone
         previously:
           - name: roadmap/on-prem
-      - name:  roadmap/internal
+      - name: roadmap/internal
         color: 4c38a5
         description: Roadmap for our team-internal goals, e.g. drive up seed utilization
         target: both
@@ -730,67 +730,67 @@ repos:
   gardener/gardener:
     labels:
       # area
-      - name:  area/audit-logging
+      - name: area/audit-logging
         color: 0052cc
         description: Audit logging related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/auto-scaling
+      - name: area/auto-scaling
         color: 0052cc
         description: Auto-scaling (CA/HPA/VPA/HVPA, predominantly control plane, but also otherwise) related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/backup
+      - name: area/backup
         color: 0052cc
         description: Backup related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/certification
+      - name: area/certification
         color: 0052cc
         description: Certification related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/control-plane
+      - name: area/control-plane
         color: 0052cc
         description: Control plane related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/control-plane-migration
+      - name: area/control-plane-migration
         color: 0052cc
         description: Control plane migration related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/cost
+      - name: area/cost
         color: 0052cc
         description: Cost related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/delivery
+      - name: area/delivery
         color: 0052cc
         description: Delivery related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/dev-productivity
+      - name: area/dev-productivity
         color: 0052cc
         description: Developer productivity related (how to improve development)
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/disaster-recovery
+      - name: area/disaster-recovery
         color: 0052cc
         description: Disaster recovery related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/documentation
+      - name: area/documentation
         color: 0052cc
         description: Documentation related
         target: both
@@ -798,183 +798,183 @@ repos:
         addedBy: anyone
         previously:
           - name: documentation
-      - name:  area/high-availability
+      - name: area/high-availability
         color: 0052cc
         description: High availability related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/logging
+      - name: area/logging
         color: 0052cc
         description: Logging related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/metering
+      - name: area/metering
         color: 0052cc
         description: Metering related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/monitoring
+      - name: area/monitoring
         color: 0052cc
         description: Monitoring (including availability monitoring and alerting) related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/networking
+      - name: area/networking
         color: 0052cc
         description: Networking related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/open-source
+      - name: area/open-source
         color: 0052cc
         description: Open Source (community, enablement, contributions, conferences, CNCF, etc.) related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/ops-productivity
+      - name: area/ops-productivity
         color: 0052cc
         description: Operator productivity related (how to improve operations)
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/os
+      - name: area/os
         color: 0052cc
         description: Operator system related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/performance
+      - name: area/performance
         color: 0052cc
         description: Performance (across all domains, such as control plane, networking, storage, etc.) related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/quality
+      - name: area/quality
         color: 0052cc
         description: Output qualification (tests, checks, scans, automation in general, etc.) related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/robustness
+      - name: area/robustness
         color: 0052cc
         description: Robustness, reliability, resilience related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/scalability
+      - name: area/scalability
         color: 0052cc
         description: Scalability related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/security
+      - name: area/security
         color: 0052cc
         description: Security related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/storage
+      - name: area/storage
         color: 0052cc
         description: Storage related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/testing
+      - name: area/testing
         color: 0052cc
         description: Testing related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/usability
+      - name: area/usability
         color: 0052cc
         description: Usability related
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  area/user-management
+      - name: area/user-management
         color: 0052cc
         description: User-management related
         target: both
         prowPlugin: label
         addedBy: anyone
       # component
-      - name:  component/cicd
+      - name: component/cicd
         color: 25399e
         description: Continuous integration/delivery (tooling and processes)
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/dashboard
+      - name: component/dashboard
         color: 25399e
         description: Gardener Dashboard
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/documentation
+      - name: component/documentation
         color: 25399e
         description: Gardener Documentation
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/etcd-backup-restore
+      - name: component/etcd-backup-restore
         color: 25399e
         description: ETCD Backup & Restore
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/etcd-druid
+      - name: component/etcd-druid
         color: 25399e
         description: ETCD Druid
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/gardenctl
+      - name: component/gardenctl
         color: 25399e
         description: Gardener CLI
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/gardener
+      - name: component/gardener
         color: 25399e
         description: Gardener
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/hvpa
+      - name: component/hvpa
         color: 25399e
         description: HVPA
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/kubify
+      - name: component/kubify
         color: 25399e
         description: Kubify
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/landscaper
+      - name: component/landscaper
         color: 25399e
         description: Landscape Installer
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/mcm
+      - name: component/mcm
         color: 25399e
         description: Machine Controller Manager (including Node Problem Detector, Cluster Auto Scaler, etc.)
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  component/tm
+      - name: component/tm
         color: 25399e
         description: Test machinery (tooling and processes)
         target: both
         prowPlugin: label
         addedBy: anyone
       # kind
-      - name:  kind/epic
+      - name: kind/epic
         color: c7def8
         description: Large multi-story topic
         target: both
@@ -982,7 +982,7 @@ repos:
         addedBy: anyone
         previously:
           - name: epic
-      - name:  kind/bug
+      - name: kind/bug
         color: e11d21
         description: Bug
         target: both
@@ -990,37 +990,37 @@ repos:
         addedBy: anyone
         previously:
           - name: bug
-      - name:  kind/regression
+      - name: kind/regression
         color: e11d21
         description: Bug that hit us already in the past and that is reappearing/requires a proper solution
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/post-mortem
+      - name: kind/post-mortem
         color: e11d21
         description: Bug that requires deeper analysis after immediate issues were resolved (usually after downtime)
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/impediment
+      - name: kind/impediment
         color: eb6420
         description: Something that impedes developers, operators, users or others in their work
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/technical-debt
+      - name: kind/technical-debt
         color: eb6420
         description: Something that is only solved on the surface, but requires more (re)work to be done properly
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/api-change
+      - name: kind/api-change
         color: eb6420
         description: API change with impact on API users
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/enhancement
+      - name: kind/enhancement
         color: c7def8
         description: Enhancement, improvement, extension
         target: both
@@ -1028,37 +1028,37 @@ repos:
         addedBy: anyone
         previously:
           - name: enhancement
-      - name:  kind/poc
+      - name: kind/poc
         color: c7def8
         description: Proof of concept or prototype
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/task
+      - name: kind/task
         color: c7def8
         description: General task
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/test
+      - name: kind/test
         color: c7def8
         description: Test
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/flake
+      - name: kind/flake
         color: f7c6c7
         description: Tracking or fixing a flaky test
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/cleanup
+      - name: kind/cleanup
         color: c7def8
         description: Something that is not needed anymore and can be cleaned up
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name:  kind/question
+      - name: kind/question
         color: c7def8
         description: Question (asking for help, advice, or technical detail)
         target: issues
@@ -1066,7 +1066,7 @@ repos:
         addedBy: anyone
         previously:
           - name: question
-      - name:  kind/discussion
+      - name: kind/discussion
         color: c7def8
         description: Discussion (enaging others in deciding about multiple options)
         target: issues
@@ -1075,115 +1075,115 @@ repos:
         previously:
           - name: discussion
       # os
-      - name:  os/garden-linux
+      - name: os/garden-linux
         color: 187c00
         description: Related to Garden Linux OS
         target: both
         addedBy: anyone
-      - name:  os/suse-chost
+      - name: os/suse-chost
         color: 187c00
         description: Related to SUSE Container Host OS
         target: both
         addedBy: anyone
-      - name:  os/ubuntu
+      - name: os/ubuntu
         color: 187c00
         description: Related to Ubuntu OS
         target: both
         addedBy: anyone
       # platform
-      - name:  platform/alicloud
+      - name: platform/alicloud
         color: 006b75
         description: Alicloud platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/aws
+      - name: platform/aws
         color: 006b75
         description: Amazon web services platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/aws-gov
+      - name: platform/aws-gov
         color: 006b75
         description: Amazon web services (government) platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/azure
+      - name: platform/azure
         color: 006b75
         description: Microsoft Azure platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/metal
+      - name: platform/metal
         color: 006b75
         description: Bare metal platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/kubevirt
+      - name: platform/kubevirt
         color: 006b75
         description: Container Native Virtualization (CNV) KubeVirt platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/converged-cloud
+      - name: platform/converged-cloud
         color: 006b75
         description: Converged Cloud (CC) platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/gcp
+      - name: platform/gcp
         color: 006b75
         description: Google cloud platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/gmp
+      - name: platform/gmp
         color: 006b75
         description: GMP (SEN) platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/openstack
+      - name: platform/openstack
         color: 006b75
         description: OpenStack platform/infrastructure
         target: both
         addedBy: anyone
-      - name:  platform/equinix-metal
+      - name: platform/equinix-metal
         color: 006b75
         description: Equinix Metal platform/infrastructure (previously Packet)
         target: both
         addedBy: anyone
-      - name:  platform/vsphere
+      - name: platform/vsphere
         color: 006b75
         description: VMware vSphere platform/infrastructure
         target: both
         addedBy: anyone
       # priority
-      - name:  priority/1
+      - name: priority/1
         color: e11d21
         description: Priority (lower number equals higher priority)
         target: issues
         prowPlugin: label
         addedBy: anyone
-      - name:  priority/2
+      - name: priority/2
         color: e54014
         description: Priority (lower number equals higher priority)
         target: issues
         prowPlugin: label
         addedBy: anyone
-      - name:  priority/3
+      - name: priority/3
         color: e96f0b
         description: Priority (lower number equals higher priority)
         target: issues
         prowPlugin: label
         addedBy: anyone
-      - name:  priority/4
+      - name: priority/4
         color: ec9a04
         description: Priority (lower number equals higher priority)
         target: issues
         prowPlugin: label
         addedBy: anyone
-      - name:  priority/5
+      - name: priority/5
         color: fbca04
         description: Priority (lower number equals higher priority)
         target: issues
         prowPlugin: label
         addedBy: anyone
       # roadmap
-      - name:  roadmap/cloud
+      - name: roadmap/cloud
         color: 4c38a5
         description: Roadmap for the (managed) cloud delivery, i.e. gardener.cloud.sap
         target: both
@@ -1191,7 +1191,7 @@ repos:
         addedBy: anyone
         previously:
           - name: roadmap/cloud-sap
-      - name:  roadmap/standalone
+      - name: roadmap/standalone
         color: 4c38a5
         description: Roadmap for the (on-prem) standalone delivery, e.g. CDC, NS2, etc.
         target: both
@@ -1199,7 +1199,7 @@ repos:
         addedBy: anyone
         previously:
           - name: roadmap/on-prem
-      - name:  roadmap/internal
+      - name: roadmap/internal
         color: 4c38a5
         description: Roadmap for our team-internal goals, e.g. drive up seed utilization
         target: both

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -9,6 +9,7 @@ triggers:
 approve:
 - repos:
   - gardener/ci-infra
+  - gardener/gardener
   lgtm_acts_as_approve: true
   require_self_approval: true
   commandHelpLink: "https://prow.gardener.cloud/command-help"
@@ -32,6 +33,7 @@ label:
 lgtm:
 - repos:
   - gardener/ci-infra
+  - gardener/gardener
   review_acts_as_lgtm: true
 
 blunderbuss:
@@ -46,6 +48,7 @@ slack:
   mergewarnings:
   - repos:
     - gardener/ci-infra
+    - gardener/gardener
     channels:
     - gardener-prow-alerts
     exempt_users:
@@ -58,6 +61,9 @@ repo_milestone:
   gardener/ci-infra:
     maintainers_id: 5415312
     maintainers_team: ci-infra-maintainers
+  gardener/gardener:
+    maintainers_id: 2609205
+    maintainers_team: gardener-maintainers
 
 config_updater:
   maps:
@@ -81,12 +87,18 @@ config_updater:
 welcome:
 - repos:
   - gardener/ci-infra
+  - gardener/gardener
   message_template: "Welcome @{{.AuthorLogin}}! <br><br>It looks like this is your first PR to <a href='https://github.com/{{.Org}}/{{.Repo}}'>{{.Org}}/{{.Repo}}</a> 🎉. Please refer to our [pull request process documentation](https://gardener.cloud/docs/contribute/#pull-request-checklist) to help your PR have a smooth ride to approval. <br><br>You will be prompted by a bot to use commands during the review process. Do not be afraid to follow the prompts! It is okay to experiment. [Here is the bot commands documentation](https://prow.k8s.io/command-help). <br><br>You can also check if {{.Org}}/{{.Repo}} has [its own contribution guidelines](https://github.com/{{.Org}}/{{.Repo}}/tree/master/CONTRIBUTING.md). <br><br>Thank you, and welcome to Gardener. :smiley:"
 
 require_matching_label:
 - missing_label: do-not-merge/needs-kind
   org: gardener
   repo: ci-infra
+  prs: true
+  regexp: ^kind/
+- missing_label: do-not-merge/needs-kind
+  org: gardener
+  repo: gardener
   prs: true
   regexp: ^kind/
 
@@ -131,12 +143,49 @@ plugins:
     - yuks
   gardener/gardener:
     plugins:
+    - approve
+    - assign
+    - blunderbuss
+    - dog
+    - golint
+    - heart
+    - help
+    - hold
+    - invalidcommitmsg
+    - label
+    - lgtm
+    - lifecycle
+    - mergecommitblocker
+    - milestone
     - override
+    - owners-label
+    - require-matching-label
+    - retitle
+    - shrug
+    - size
     - skip
+    - slackevents
+    - transfer-issue
+    - trick-or-treat
     - trigger
+    - verify-owners
+    - welcome
+    - wip
+    - yuks
 
 external_plugins:
   gardener/ci-infra:
+  - name: cla-assistant
+    events:
+      - issue_comment
+      - pull_request_review
+      - pull_request_review_comment
+      - status
+  - name: needs-rebase
+    events:
+      - issue_comment
+      - pull_request
+  gardener/gardener:
   - name: cla-assistant
     events:
       - issue_comment

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -201,3 +201,7 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -9,8 +9,13 @@ triggers:
 approve:
 - repos:
   - gardener/ci-infra
-  - gardener/gardener
   lgtm_acts_as_approve: true
+  require_self_approval: true
+  commandHelpLink: "https://prow.gardener.cloud/command-help"
+  pr_process_link: "https://gardener.cloud/docs/contribute/#pull-request-checklist"
+- repos:
+  - gardener/gardener
+  lgtm_acts_as_approve: false
   require_self_approval: true
   commandHelpLink: "https://prow.gardener.cloud/command-help"
   pr_process_link: "https://gardener.cloud/docs/contribute/#pull-request-checklist"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR enables prow support for gardener/gardener repository

- [x] enable label synchronization 
  - `area/*`, `component/*`, `kind/*`, `priority/*` and `roadmap/*` labels have been copied from [gardener-robot](https://github.tools.sap/kubernetes/gardener-robot/blob/master/config.yaml) labels. Other labels from this source seem to be not relevant **(please check)** 
  - `prow` labels have been copied from `gardener/ci-infra` configuration
- [x] enable tide for gardener/gardener - default merge method: squash
- [x] enable issue lifecycle prow jobs  
- [x] enable branch protection rules
- [x] enable prow plugins
  - cla-assistant
  - approve
  - lgtm
  - needs-rebase
  - invalidcommitmsg
  - milestone
  - cherrypicker
  - and some more... 

It turned out that not all labels of `gardener/ci-infra` repository are synched yet. Some of them might be initially created by gardener-robot and remained untouched since then. I added them to label sync too.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
There are some tasks apart from this PR
- [x] create OWNERS and OWNER_ALIASES in `gardener/gardener` repository
- [x] verify that `gardener-prow` github app has permissions to merge PRs in `gardener/gardener` repository
- [ ] write an announcement about the ongoing change in slack
  - Changed commands
    - `/cc @user` instead of `/invite @user` for requesting a review
    - `/label tide/merge-method-[merge|rebase|squash]` instead of `/merge [merge|rebase|squash]`. Default method is `squash`
    - `/assign @author` instead of `/author-action`
    - `/cla` to recheck CLA status
    - `/cherrypick release-v1.xy` create a cherry pick PR to the release branch based on this PR
    - command-help: https://prow.gardener.cloud/command-help 
  - That tide now merges PRs automatically after `/lgtm` + `/approve` comment 
  - we have to reiterate `/hold` commands for existing PRs (block labels used by tide are different)
- [ ] deactivate [gardener-robot](https://github.tools.sap/kubernetes/gardener-robot/blob/f8adda8c8dedaf810e12c5cf074e30bf8c4f4ff0/config.yaml#L50-L53) in `gardener/gardener`
- [ ] remove "require approval" setting from branch protection rule once tide is used for merging
- [ ] deactivate `Commit Message Check` github action