### PR TITLE
Only include desired branches in protection

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -132,6 +132,9 @@ branch-protection:
           enforce_admins: true # protections apply to admins as well
         gardener:
           protect: true
+          include:
+          - "master"
+          - "release-.*"
           required_status_checks:
             contexts:
             - license/cla


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

`branch-protector` is iterating over branches in a repository and creating branch protections for each one.
We should only include well-known branches, to not protect branches from upgrade PRs like https://github.com/gardener/gardener/pull/5693. Otherwise, these cannot be deleted anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
