### PR TITLE
Run release tests on release branches only

### DIFF
--- a/config/jobs/gardener/release/gardener-e2e-kind-release.yaml
+++ b/config/jobs/gardener/release/gardener-e2e-kind-release.yaml
@@ -4,8 +4,8 @@ presubmits:
     cluster: gardener-prow-build
     always_run: true
     # Run on release branches / adapt this setting and create a new job in case of incompatible changes in tests or go version between the releases
-    skip_branches:
-    - master
+    branches:
+    - release-v\d+.\d+
     decorate: true
     decoration_config:
       timeout: 60m
@@ -59,8 +59,8 @@ postsubmits:
   - name: post-gardener-e2e-kind-release
     cluster: gardener-prow-build
     # Run on release branches / adapt this setting and create a new job in case of incompatible changes in tests or go version between the releases
-    skip_branches:
-    - master
+    branches:
+    - release-v\d+.\d+
     decorate: true
     decoration_config:
       timeout: 60m

--- a/config/jobs/gardener/release/gardener-integration-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-integration-tests-release.yaml
@@ -4,8 +4,8 @@ presubmits:
     cluster: gardener-prow-build
     always_run: true
     # Run on release branches / adapt this setting and create a new job in case of incompatible changes in tests or go version between the releases
-    skip_branches:
-    - master
+    branches:
+    - release-v\d+.\d+
     decorate: true
     decoration_config:
       timeout: 20m
@@ -31,8 +31,8 @@ postsubmits:
   - name: post-gardener-integration-release
     cluster: gardener-prow-build
     # Run on release branches / adapt this setting and create a new job in case of incompatible changes in tests or go version between the releases
-    skip_branches:
-    - master
+    branches:
+    - release-v\d+.\d+
     decorate: true
     decoration_config:
       timeout: 20m

--- a/config/jobs/gardener/release/gardener-unit-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-unit-tests-release.yaml
@@ -4,8 +4,8 @@ presubmits:
     cluster: gardener-prow-build
     always_run: true
     # Run on release branches / adapt this setting and create a new job in case of incompatible changes in tests or go version between the releases
-    skip_branches:
-    - master
+    branches:
+    - release-v\d+.\d+
     decorate: true
     decoration_config:
       timeout: 40m
@@ -37,8 +37,8 @@ postsubmits:
   - name: post-gardener-unit-release
     cluster: gardener-prow-build
     # Run on release branches / adapt this setting and create a new job in case of incompatible changes in tests or go version between the releases
-    skip_branches:
-    - master
+    branches:
+    - release-v\d+.\d+
     decorate: true
     decoration_config:
       timeout: 40m


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Release tests should run on release branches only.
In previous configuration, they ran on branches created by `gardener-robot-ci-x` too
