### PR TITLE
Allow concourse to push release commits

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -146,7 +146,8 @@ branch-protection:
             # Hence, remember to manually add the `gardener-prow` GitHub App to all branch protection rules
             # to allow tide to push/merge.
             users: []
-            teams: []
+            teams:
+            - gardener/ci # allow CI users (e.g. concourse) to push (e.g. release commits)
           enforce_admins: true # protections apply to admins as well
 
 tide:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

Allow concourse to push release commits

**Which issue(s) this PR fixes**:

Release jobs in concourse are failing because it is unable to push release commits: 
```
2022-03-30 13:58:29,565 [WARNING] step.release: An error occured while applying step_name='Create Release Commit' e=GitCommandError(['git', 'push', '--porcelain', 'tbdjkrreveld', 'f82dced03a904a398cc5184e32729211f499621e:release-v1.41'], 1, b"error: failed to push some refs to 'ssh://github.com/gardener/gardener'")
```
ref https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-release-v1.41/jobs/release-v1.41-release-job/builds/9#L624ed8af:13

**Special notes for your reviewer**:
I'm not sure, if the team is correctly specified. But let's try :)