### PR TITLE
Fix protection restriction

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -147,7 +147,7 @@ branch-protection:
             # to allow tide to push/merge.
             users: []
             teams:
-            - gardener/ci # allow CI users (e.g. concourse) to push (e.g. release commits)
+            - ci # allow CI users (e.g. concourse) to push (e.g. release commits)
           enforce_admins: true # protections apply to admins as well
 
 tide:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Follow-up on #150:
In https://github.com/kubernetes/test-infra/blob/master/prow/cmd/branchprotector/README.md#policy-configuration it seems like the org is not required for the team slug.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
