### PR TITLE
Fix settings for concourse (3)

### DIFF
--- a/config/jobs/common/issue-pr-lifecycle.yaml
+++ b/config/jobs/common/issue-pr-lifecycle.yaml
@@ -28,6 +28,7 @@ periodics:
         - After 90d of inactivity, `lifecycle/stale` is applied
         - After 30d of inactivity since `lifecycle/stale` was applied, `lifecycle/rotten` is applied
         - After 30d of inactivity since `lifecycle/rotten` was applied, the issue is closed
+        
         You can:
         - Reopen this issue or PR with `/reopen`
         - Mark this issue or PR as fresh with `/remove-lifecycle rotten`
@@ -74,6 +75,7 @@ periodics:
         - After 90d of inactivity, `lifecycle/stale` is applied
         - After 30d of inactivity since `lifecycle/stale` was applied, `lifecycle/rotten` is applied
         - After 30d of inactivity since `lifecycle/rotten` was applied, the issue is closed
+        
         You can:
         - Mark this issue or PR as fresh with `/remove-lifecycle rotten`
         - Close this issue or PR with `/close`
@@ -120,6 +122,7 @@ periodics:
         - After 90d of inactivity, `lifecycle/stale` is applied
         - After 30d of inactivity since `lifecycle/stale` was applied, `lifecycle/rotten` is applied
         - After 30d of inactivity since `lifecycle/rotten` was applied, the issue is closed
+        
         You can:
         - Mark this issue or PR as fresh with `/remove-lifecycle stale`
         - Mark this issue or PR as rotten with `/lifecycle rotten`

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -140,7 +140,7 @@ branch-protection:
             - license/cla
             - concourse-ci/publish
             - "Check Release Milestone"
-          restrictions: # prevent everyone from pushing/merging
+          restrictions: # prevent everyone from pushing/merging (except admins)
             # NB: tide is running as GitHub App, which currently cannot be configured here to be excluded from branch
             # protections (see https://github.com/kubernetes/test-infra/issues/24530).
             # Hence, remember to manually add the `gardener-prow` GitHub App to all branch protection rules
@@ -148,7 +148,7 @@ branch-protection:
             users: []
             teams:
             - ci # allow CI users (e.g. concourse) to push (e.g. release commits)
-          enforce_admins: true # protections apply to admins as well
+          enforce_admins: false # protections don't apply to admins
 
 tide:
   sync_period: 2m

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -53,11 +53,19 @@ slack:
   mergewarnings:
   - repos:
     - gardener/ci-infra
+    channels:
+    - gardener-prow-alerts
+    exempt_users:
+    - gardener-prow[bot]
+  - repos:
     - gardener/gardener
     channels:
     - gardener-prow-alerts
     exempt_users:
     - gardener-prow[bot]
+    - gardener-robot-ci-1
+    - gardener-robot-ci-2
+    - gardener-robot-ci-3
 
 repo_milestone:
   # You can curl the following endpoint in order to determine the github ID of your team


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

- don't send Slack warnings when concourse pushes releases and upgrade PRs
- don't enforce admins to push to protected branches (seems like this is the only way to allow concourse to push release commits – GitHub branch protection is super confusing, I still don't understand why)

**Which issue(s) this PR fixes**:
Follow-up on #151, which has not helped unfortunately

**Special notes for your reviewer**:
