### PR TITLE
Allow g/g maintainers to delete outdated release branches

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -153,6 +153,7 @@ branch-protection:
             teams:
             - ci # allow CI users (e.g. concourse) to push (e.g. release commits)
           enforce_admins: false # protections don't apply to admins
+          allow_deletions: true # allow maintainers to delete outdated release branches
 
 tide:
   sync_period: 2m


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

Allow g/g maintainers to delete outdated release branches.
We usually delete release branches of releases that are out of maintenance. So maintainers should be allowed to delete them.
