### PR TITLE
Disable parallel builds / don't build ci-infra images on config changes

### DIFF
--- a/config/jobs/ci-infra/build-ci-infra-images.yaml
+++ b/config/jobs/ci-infra/build-ci-infra-images.yaml
@@ -3,12 +3,13 @@ postsubmits:
   - name: post-ci-infra-build-images
     cluster: gardener-prow-trusted
     # skip config/prow folder that build and autobumper do not end up in an endless loop
-    skip_if_only_changed: '^config\/mkpj\.sh|^config\/prow\/|^hack\/(bootstrap|check)-config\.sh'
+    skip_if_only_changed: '^config\/|^hack\/(bootstrap|check)-config\.sh'
     branches:
     - ^master$
     annotations:
       description: Build ci-infra images on master branch
     decorate: true
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: "gardener-prow-alerts"

--- a/config/jobs/ci-infra/build-golang-test-image.yaml
+++ b/config/jobs/ci-infra/build-golang-test-image.yaml
@@ -8,6 +8,7 @@ postsubmits:
     annotations:
       description: Build golang-test image on master branch
     decorate: true
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: "gardener-prow-alerts"

--- a/config/jobs/gardener/build-gardener-images.yaml
+++ b/config/jobs/gardener/build-gardener-images.yaml
@@ -7,6 +7,7 @@ postsubmits:
     annotations:
       description: Testing gardener image build on master branch
     decorate: true
+    max_concurrency: 1
     reporter_config:
       slack:
         channel: "gardener-prow-alerts"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Two small fixes regarding builds and autodeployment
- Do not build ci-infra images on changes in entire `config/`
  - Currently autobumping jobs triggers a build which triggers a new autobump which triggers a new build....
- Disable parallel builds for the same repository
  - parallel builds could mess up fixed tags like `latest` in case two commits are pushed at about the same time. With parallel builds it is not deterministic which build is tagged as `latest` 
