### PR TITLE
Restrict approve and lgtm to OWNERS for the whole org

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -46,6 +46,10 @@ blunderbuss:
   max_request_count: 2
   use_status_availability: true
 
+owners:
+  skip_collaborators:
+  - "gardener"  # Rely on OWNERS file for the whole organization
+
 heart:
   commentregexp: ".*"
 


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
At the moment every collaborator is able to `/lgtm` a PR. 
According to our best practices only dedicated people should be able to do so.

Thus, this PR restricts approve and lgtm to people listed in the OWNERS files for the whole `gardener` org.
