### PR TITLE
Increase memory limits for gardener integration tests

### DIFF
--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -21,10 +21,10 @@ presubmits:
         - test-integration
         resources:
           limits:
-            memory: 4Gi
+            memory: 16Gi
           requests:
             cpu: 4
-            memory: 2Gi
+            memory: 8Gi
 periodics:
 - name: ci-gardener-integration
   cluster: gardener-prow-build
@@ -49,7 +49,7 @@ periodics:
       - test-integration
       resources:
         limits:
-          memory: 4Gi
+          memory: 16Gi
         requests:
           cpu: 4
-          memory: 2Gi
+          memory: 8Gi

--- a/config/jobs/gardener/release/gardener-integration-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-integration-tests-release.yaml
@@ -22,10 +22,10 @@ presubmits:
         - test-integration
         resources:
           limits:
-            memory: 4Gi
+            memory: 16Gi
           requests:
             cpu: 4
-            memory: 2Gi
+            memory: 8Gi
 postsubmits:
   gardener/gardener:
   - name: post-gardener-integration-release
@@ -49,7 +49,7 @@ postsubmits:
         - test-integration
         resources:
           limits:
-            memory: 4Gi
+            memory: 16Gi
           requests:
             cpu: 4
-            memory: 2Gi
+            memory: 8Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:

Increase memory limits for gardener integration tests

**Which issue(s) this PR fixes**:

Integration test jobs got `OOMKilled`:
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/5784/pull-gardener-integration/1513447190545043456
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/5784/pull-gardener-integration/1513454017219399680

**Special notes for your reviewer**:

Seems, that executing tests with `ginkgo` instead of `go test` temporarily consumes more memory while compiling (`ginkgo` probably just doesn't have as sophisticated resource management as `go tests`).
ref https://github.com/gardener/gardener/pull/5784