### PR TITLE
remove duplicated autobump config for eu.gcr.io/gardener-project/ci-infra

### DIFF
--- a/config/prow/autobump-config/prow-component-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-component-autobump-config.yaml
@@ -27,4 +27,4 @@ prefixes:
     refConfigFile: "config/prow/cluster/cla_assistant_deployment.yaml"
     repo: "https://github.com/gardener/ci-infra"
     summarise: true
-    consistentImages: true
+    consistentImages: false

--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -28,8 +28,3 @@ prefixes:
     repo: "https://github.com/kubernetes/test-infra"
     summarise: false
     consistentImages: false
-  - name: "Prow - ci-infra"
-    prefix: "eu.gcr.io/gardener-project/ci-infra/"
-    repo: "https://github.com/gardener/ci-infra"
-    summarise: true
-    consistentImages: false


### PR DESCRIPTION


<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
We have a duplicated autobump configurations for eu.gcr.io/gardener-project/ci-infra. Jobs are updated twice.
This PR removes the dedicated config in autobump jobs.