### PR TITLE
Add e2e tests for shoot-oidc-service pull requests

### DIFF
--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
@@ -1,0 +1,48 @@
+presubmits:
+  gardener/gardener-extension-shoot-oidc-service:
+  - name: pull-extension-shoot-oidc-service-e2e-kind
+    cluster: gardener-prow-build
+    always_run: true
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20220404-0178a71d18-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - |
+          set -o nounset
+          set -o pipefail
+          set -o errexit
+
+          # https://github.com/kubernetes/test-infra/issues/23741
+          iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
+          # install kind
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+          chmod +x ./kind
+          mv ./kind /usr/local/bin
+
+          # run test
+          make test-e2e-local
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: 5
+            memory: 9Gi
+        env:
+        - name: SKAFFOLD_UPDATE_CHECK
+          value: "false"
+        - name: SKAFFOLD_INTERACTIVE
+          value: "false"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Add e2e tests execution step on pull requests towards `gardener-extension-shoot-oidc-service`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
