### PR TITLE
Add option to inject EFFECTIVE_VERSION build-arg

### DIFF
--- a/prow/cmd/image-builder/buildcontroller_test.go
+++ b/prow/cmd/image-builder/buildcontroller_test.go
@@ -138,7 +138,7 @@ func createTestImageBuildController(t *testing.T, initObjs ...client.Object) *bu
 		logLevel:           "debug",
 		targets:            flagutil.NewStrings("target1", "target2", "target3"),
 		kanikoArgs:         flagutil.NewStrings("--build-arg=buildarg1=abc", "--build-arg=buildarg1=xyz"),
-		baseSHA:            "abcdef1234567890",
+		headSHA:            "abcdef1234567890",
 	}
 
 	r := &buildReconciler{


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Add option to inject EFFECTIVE_VERSION build-arg that gardener/gardener binaries contain the right version info.

Manual test for a PR presubmit job:
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/5779/pull-gardener-publish-test-images/1513833918111944704
```bash
➜  ~ docker run --rm eu.gcr.io/gardener-project/gardener/apiserver:v1.45.0-dev-4f5dd702ed31a14abc026d3bce8381cbddbe97ed --version                                                                                                                (gardener-prow-trusted/default)
Unable to find image 'eu.gcr.io/gardener-project/gardener/apiserver:v1.45.0-dev-4f5dd702ed31a14abc026d3bce8381cbddbe97ed' locally
v1.45.0-dev-4f5dd702ed31a14abc026d3bce8381cbddbe97ed: Pulling from gardener-project/gardener/apiserver
5758d4e389a3: Already exists
317fe4fc145e: Pull complete
a92bd55327e9: Pull complete
Digest: sha256:d402045447d0aad07b9bab49f30e02099cd34242d59cdb54f00c0aae5f38799f
Status: Downloaded newer image for eu.gcr.io/gardener-project/gardener/apiserver:v1.45.0-dev-4f5dd702ed31a14abc026d3bce8381cbddbe97ed
Gardener v1.45.0-dev-4f5dd702ed31a14abc026d3bce8381cbddbe97ed
```

Manual test for a postsubmit job:
https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-gardener-build-dev-images/1513834382115213312
```bash
➜  ~ docker run --rm eu.gcr.io/gardener-project/gardener/apiserver:v1.45.0-dev-f5882800d5821bcc18198da96324bbe013bb1afe --version                                                                                                                (gardener-prow-trusted/default)
Unable to find image 'eu.gcr.io/gardener-project/gardener/apiserver:v1.45.0-dev-f5882800d5821bcc18198da96324bbe013bb1afe' locally
v1.45.0-dev-f5882800d5821bcc18198da96324bbe013bb1afe: Pulling from gardener-project/gardener/apiserver
5758d4e389a3: Already exists
fd2d5834177c: Pull complete
1ab5ad74e424: Pull complete
Digest: sha256:89671e05c1d5e1b91b58edc898a9c90a1742cd30ef21453b6056ad2844f1b04b
Status: Downloaded newer image for eu.gcr.io/gardener-project/gardener/apiserver:v1.45.0-dev-f5882800d5821bcc18198da96324bbe013bb1afe
Gardener v1.45.0-dev-f5882800d5821bcc18198da96324bbe013bb1afe
```

