### PR TITLE
Drop obsolete kind installation in gardener-e2e-kind

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -27,11 +27,6 @@ presubmits:
           # https://github.com/kubernetes/test-infra/issues/23741
           iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
 
-          # install kind
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
-          chmod +x ./kind
-          mv ./kind /usr/local/bin
-
           # test setup
           make kind-up
           export KUBECONFIG=$PWD/example/provider-local/base/kubeconfig
@@ -82,11 +77,6 @@ periodics:
 
         # https://github.com/kubernetes/test-infra/issues/23741
         iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
-
-        # install kind
-        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
-        chmod +x ./kind
-        mv ./kind /usr/local/bin
 
         # test setup
         make kind-up

--- a/config/jobs/gardener/release/gardener-e2e-kind-release.yaml
+++ b/config/jobs/gardener/release/gardener-e2e-kind-release.yaml
@@ -28,11 +28,6 @@ presubmits:
           # https://github.com/kubernetes/test-infra/issues/23741
           iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
 
-          # install kind
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
-          chmod +x ./kind
-          mv ./kind /usr/local/bin
-
           # test setup
           make kind-up
           export KUBECONFIG=$PWD/example/provider-local/base/kubeconfig
@@ -82,11 +77,6 @@ postsubmits:
 
           # https://github.com/kubernetes/test-infra/issues/23741
           iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
-
-          # install kind
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
-          chmod +x ./kind
-          mv ./kind /usr/local/bin
 
           # test setup
           make kind-up


### PR DESCRIPTION
/kind cleanup

g/g already installs kind on the fly for make targets that require it.
No need to install it twice.