### PR TITLE
Fix deployer permissions

### DIFF
--- a/config/prow/cluster/bootstrap-trusted/trusted_serviceaccounts.yaml
+++ b/config/prow/cluster/bootstrap-trusted/trusted_serviceaccounts.yaml
@@ -24,10 +24,22 @@ rules:
   - persistentvolumeclaims
   - configmaps
   - secrets
+  - pods
+  - pods/log
+  - events
   verbs:
   - create
   - get
+  - list
+  - watch
+  - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
 - apiGroups:
   - apps
   resources:
@@ -35,6 +47,9 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
+  - update
   - patch
 - apiGroups:
   - batch
@@ -43,6 +58,9 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
+  - update
   - patch
 - apiGroups:
   - policy
@@ -51,6 +69,9 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
+  - update
   - patch
 - apiGroups:
   - admissionregistration.k8s.io
@@ -59,6 +80,9 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
+  - update
   - patch
 - apiGroups:
   - rbac.authorization.k8s.io
@@ -70,6 +94,9 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
+  - update
   - patch
 - apiGroups:
   - storage.k8s.io
@@ -78,15 +105,22 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
+  - update
   - patch
 - apiGroups:
   - networking.k8s.io
   resources:
   - ingresses
+  - ingresses/status
   - ingressclasses
   verbs:
   - create
   - get
+  - list
+  - watch
+  - update
   - patch
 - apiGroups:
   - apiextensions.k8s.io
@@ -95,6 +129,9 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
+  - update
   - patch
 - apiGroups:
   - monitoring.coreos.com
@@ -106,7 +143,33 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
+  - update
   - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - prow.k8s.io
+  resources:
+  - prowjobs
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/deploy.sh
+++ b/config/prow/deploy.sh
@@ -127,14 +127,14 @@ kubectl config use-context gardener-prow-trusted
 kubectl apply --server-side=true -f "$SCRIPT_DIR/cluster/prowjob_customresourcedefinition.yaml"
 
 for c in "${prow_components[@]}"; do
-  kubectl apply -f "$SCRIPT_DIR/cluster/$c"
+  kubectl apply --server-side=true -f "$SCRIPT_DIR/cluster/$c"
 done
 echo "$(color-green done)"
 
 echo "$(color-step "Deploying prow components to gardener-prow-build cluster...")"
 kubectl config use-context gardener-prow-build
 for c in "${prow_components_build[@]}"; do
-  kubectl apply -f "$SCRIPT_DIR/cluster/$c"
+  kubectl apply --server-side=true -f "$SCRIPT_DIR/cluster/$c"
 done
 echo "$(color-green done)"
 


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
When trying to [switch to server-side apply a while ago](https://github.com/gardener/ci-infra/pull/117#discussion_r824719270) I noticed that `test-pods/deployer` service account does not have all permissions to create the apply the configuration of our entire prow cluster.
This PR adds the missing permissions.
As a result we can use server-side apply in `deploy.sh` now.

**Which issue(s) this PR fixes**:
Fixes #121 

**Special notes for your reviewer**:
The changed permissions are already applied on our prow cluster.
