### PR TITLE
Add periodic job for oidc service

### DIFF
--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
@@ -25,11 +25,6 @@ presubmits:
           # https://github.com/kubernetes/test-infra/issues/23741
           iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
 
-          # install kind
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
-          chmod +x ./kind
-          mv ./kind /usr/local/bin
-
           # run test
           make test-e2e-local
         # we need privileged mode in order to do docker in docker
@@ -46,3 +41,49 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
+periodics:
+- name: ci-extension-shoot-oidc-service-e2e-kind
+  cluster: gardener-prow-build
+  interval: 24h
+  extra_refs:
+  - org: gardener
+    repo: gardener-extension-shoot-oidc-service
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 60m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20220420-a8dc19ed91-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - |
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+
+        # https://github.com/kubernetes/test-infra/issues/23741
+        iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
+        # run test
+        make test-e2e-local
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 18Gi
+        requests:
+          cpu: 5
+          memory: 9Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement
**What this PR does / why we need it**:
This PR adds a periodic job that will execute `shoot-oidc-service` e2e tests on every 24h.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
