### PR TITLE
Do not inject-effective-version in ci-infra build jobs

### DIFF
--- a/config/jobs/ci-infra/build-ci-infra-images.yaml
+++ b/config/jobs/ci-infra/build-ci-infra-images.yaml
@@ -30,6 +30,7 @@ postsubmits:
         - --kaniko-arg=--build-arg=GOLANG_VERSION=1.17.9
         - --add-date-sha-tag=true
         - --add-fixed-tag=latest
+        - --inject-effective-version=false
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted
         # to multiple build pods in parallel.

--- a/config/jobs/ci-infra/build-golang-test-image.yaml
+++ b/config/jobs/ci-infra/build-golang-test-image.yaml
@@ -29,6 +29,7 @@ postsubmits:
         - --add-fixed-tag=1.17
         - --add-fixed-tag=latest
         - --add-date-sha-tag=true
+        - --inject-effective-version=false
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted
         # to multiple build pods in parallel.


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The new `--inject-effective-version` make the build jobs in `ci-infra` repo fail. It relies on a VERSION file which is not existing here.
Considering to set the default value of this parameter to `false` instead of true in the future.