### PR TITLE
Allow deployer creating daemonsets and podmonitors

### DIFF
--- a/config/prow/cluster/bootstrap-trusted/trusted_serviceaccounts.yaml
+++ b/config/prow/cluster/bootstrap-trusted/trusted_serviceaccounts.yaml
@@ -44,6 +44,7 @@ rules:
   - apps
   resources:
   - deployments
+  - daemonsets
   verbs:
   - create
   - get
@@ -140,6 +141,7 @@ rules:
   - prometheuses
   - prometheusrules
   - servicemonitors
+  - podmonitors
   verbs:
   - create
   - get


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The new kube-prometheus based monitoring needs deployer to be able to create daemonsets (for node-exporter) and podmonitors.