### PR TITLE
Change default for inject-effective-version to false

### DIFF
--- a/config/jobs/gardener/gardener-build-dev-images.yaml
+++ b/config/jobs/gardener/gardener-build-dev-images.yaml
@@ -31,6 +31,7 @@ postsubmits:
         - --target=gardener-extension-provider-local
         - --add-version-tag=true
         - --add-version-sha-tag=true
+        - --inject-effective-version=true
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted
         # to multiple build pods in parallel.

--- a/config/jobs/gardener/gardener-test-builds.yaml
+++ b/config/jobs/gardener/gardener-test-builds.yaml
@@ -51,6 +51,7 @@ presubmits:
         - --target=resource-manager
         - --target=gardener-extension-provider-local
         - --add-version-sha-tag=true
+        - --inject-effective-version=true
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted
         # to multiple build pods in parallel.

--- a/config/jobs/gardener/release/gardener-build-dev-images-release.yaml
+++ b/config/jobs/gardener/release/gardener-build-dev-images-release.yaml
@@ -31,6 +31,7 @@ postsubmits:
         - --target=gardener-extension-provider-local
         - --add-version-tag=true
         - --add-version-sha-tag=true
+        - --inject-effective-version=true
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted
         # to multiple build pods in parallel.

--- a/config/jobs/gardener/release/gardener-test-builds-release.yaml
+++ b/config/jobs/gardener/release/gardener-test-builds-release.yaml
@@ -53,6 +53,7 @@ presubmits:
         - --target=resource-manager
         - --target=gardener-extension-provider-local
         - --add-version-sha-tag=true
+        - --inject-effective-version=true
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted
         # to multiple build pods in parallel.

--- a/prow/cmd/image-builder/main.go
+++ b/prow/cmd/image-builder/main.go
@@ -103,7 +103,7 @@ func gatherOptions() options {
 	fs.BoolVar(&o.addVersionSHATag, "add-version-sha-tag", false, "Add label from VERSION file of git root directory plus SHA from git HEAD to image tags")
 	fs.BoolVar(&o.addDateSHATag, "add-date-sha-tag", false, "Using vYYYYMMDD-<rev short> scheme which is compatible to autobumper")
 	fs.Var(&o.addFixedTags, "add-fixed-tag", "Add a fixed tag to images")
-	fs.BoolVar(&o.injectEffectiveVersion, "inject-effective-version", true, "Inject EFFECTIVE_VERSION build-arg")
+	fs.BoolVar(&o.injectEffectiveVersion, "inject-effective-version", false, "Inject EFFECTIVE_VERSION build-arg")
 
 	fs.StringVar(&o.logLevel, "log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
 


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Change default values of `--inject-effective-version` in `image-builder` to `false`.
When setting the parameter to `true` image-builder requires a `VERSION` file in the root directory of the Github repository. This is not always the case, so `false` is less error prone setting.

As a result, `--inject-effective-version` must be set to `true` for all gardener build prow jobs. 

