### PR TITLE
Use golang-test:1.17-...

### DIFF
--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for extension-shoot-oidc-service developments in pull requests
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-ccdbaa2
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-ccdbaa2
         command:
         - make
         args:
@@ -38,7 +38,7 @@ periodics:
     description: Periodically runs unit tests for extension-shoot-oidc-service master branch
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-ccdbaa2
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-ccdbaa2
       command:
       - make
       args:

--- a/config/jobs/gardener/gardener-apidiff.yaml
+++ b/config/jobs/gardener/gardener-apidiff.yaml
@@ -10,7 +10,7 @@ presubmits:
     spec:
       containers:
       - name: test
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-ccdbaa2
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-ccdbaa2
         command:
         - make
         args:

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-ccdbaa2
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-ccdbaa2
         command:
         - make
         args:
@@ -42,7 +42,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-ccdbaa2
+      image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-ccdbaa2
       command:
       - make
       args:

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -15,7 +15,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-ccdbaa2
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-ccdbaa2
         command:
         - make
         args:
@@ -49,7 +49,7 @@ periodics:
     containers:
     # Run all tests sequentially in one container or as separete prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-ccdbaa2
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-ccdbaa2
       command:
       - make
       args:

--- a/config/jobs/gardener/release/gardener-integration-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-integration-tests-release.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-ccdbaa2
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-ccdbaa2
         command:
         - make
         args:
@@ -42,7 +42,7 @@ postsubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-ccdbaa2
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-ccdbaa2
         command:
         - make
         args:

--- a/config/jobs/gardener/release/gardener-unit-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-unit-tests-release.yaml
@@ -16,7 +16,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-ccdbaa2
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-ccdbaa2
         command:
         - make
         args:
@@ -49,7 +49,7 @@ postsubmits:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-ccdbaa2
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-ccdbaa2
         command:
         - make
         args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Autobumper was too progressive and updated to golang-test:1.18 already.
Downgrade to 1.17 to find out if this was because we changed format of the image tag or if it is a general behaviour.