### PR TITLE
Use golang-test:1.17-...again

### DIFF
--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for extension-shoot-oidc-service developments in pull requests
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-61a6041-1.17
         command:
         - make
         args:
@@ -38,7 +38,7 @@ periodics:
     description: Periodically runs unit tests for extension-shoot-oidc-service master branch
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-61a6041-1.17
       command:
       - make
       args:

--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for extension-shoot-oidc-service developments in pull requests
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-61a6041
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
         command:
         - make
         args:
@@ -38,7 +38,7 @@ periodics:
     description: Periodically runs unit tests for extension-shoot-oidc-service master branch
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-61a6041
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
       command:
       - make
       args:

--- a/config/jobs/gardener/gardener-apidiff.yaml
+++ b/config/jobs/gardener/gardener-apidiff.yaml
@@ -10,7 +10,7 @@ presubmits:
     spec:
       containers:
       - name: test
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-61a6041-1.17
         command:
         - make
         args:

--- a/config/jobs/gardener/gardener-apidiff.yaml
+++ b/config/jobs/gardener/gardener-apidiff.yaml
@@ -10,7 +10,7 @@ presubmits:
     spec:
       containers:
       - name: test
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-61a6041
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
         command:
         - make
         args:

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-61a6041-1.17
         command:
         - make
         args:
@@ -42,7 +42,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
+      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-61a6041-1.17
       command:
       - make
       args:

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-61a6041
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
         command:
         - make
         args:
@@ -42,7 +42,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-61a6041
+      image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
       command:
       - make
       args:

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -15,7 +15,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-61a6041
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
         command:
         - make
         args:
@@ -49,7 +49,7 @@ periodics:
     containers:
     # Run all tests sequentially in one container or as separete prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-61a6041
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
       command:
       - make
       args:

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -15,7 +15,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-61a6041-1.17
         command:
         - make
         args:
@@ -49,7 +49,7 @@ periodics:
     containers:
     # Run all tests sequentially in one container or as separete prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-61a6041-1.17
       command:
       - make
       args:

--- a/config/jobs/gardener/release/gardener-integration-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-integration-tests-release.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-61a6041
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
         command:
         - make
         args:
@@ -42,7 +42,7 @@ postsubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-61a6041
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
         command:
         - make
         args:

--- a/config/jobs/gardener/release/gardener-integration-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-integration-tests-release.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-61a6041-1.17
         command:
         - make
         args:
@@ -42,7 +42,7 @@ postsubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-61a6041-1.17
         command:
         - make
         args:

--- a/config/jobs/gardener/release/gardener-unit-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-unit-tests-release.yaml
@@ -16,7 +16,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-61a6041-1.17
         command:
         - make
         args:
@@ -49,7 +49,7 @@ postsubmits:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-61a6041-1.17
         command:
         - make
         args:

--- a/config/jobs/gardener/release/gardener-unit-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-unit-tests-release.yaml
@@ -16,7 +16,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-61a6041
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
         command:
         - make
         args:
@@ -49,7 +49,7 @@ postsubmits:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.18-v20220502-61a6041
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:1.17-v20220502-61a6041
         command:
         - make
         args:

--- a/prow/cmd/image-builder/buildcontroller.go
+++ b/prow/cmd/image-builder/buildcontroller.go
@@ -618,6 +618,8 @@ func (r *buildReconciler) defineDestinationsForVariant(target, variant string) (
 	if err := r.validateHeadSHA(); err != nil {
 		return destinations, err
 	}
+	// tag format with build variant as suffix (v<data>-<headSHA>-<suffix>) is compatible to autobumper
+	// https://github.com/kubernetes/test-infra/blob/884bcd554bcdb87c5d9b28401a37ed6cf086d360/experiment/image-bumper/bumper/bumper.go#L176-L178
 	tag := fmt.Sprintf("v%s-%s-%s", time.Now().Format("20060102"), r.options.headSHA[:7], variant)
 	destination := fmt.Sprintf("--destination=%s/%s:%s", r.options.registry, target, tag)
 	destinations = append(destinations, destination)

--- a/prow/cmd/image-builder/buildcontroller.go
+++ b/prow/cmd/image-builder/buildcontroller.go
@@ -618,7 +618,7 @@ func (r *buildReconciler) defineDestinationsForVariant(target, variant string) (
 	if err := r.validateHeadSHA(); err != nil {
 		return destinations, err
 	}
-	tag := fmt.Sprintf("%s-v%s-%s", variant, time.Now().Format("20060102"), r.options.headSHA[:7])
+	tag := fmt.Sprintf("v%s-%s-%s", time.Now().Format("20060102"), r.options.headSHA[:7], variant)
 	destination := fmt.Sprintf("--destination=%s/%s:%s", r.options.registry, target, tag)
 	destinations = append(destinations, destination)
 

--- a/prow/cmd/image-builder/main.go
+++ b/prow/cmd/image-builder/main.go
@@ -114,7 +114,7 @@ func gatherOptions() options {
 	fs.BoolVar(&o.addVersionTag, "add-version-tag", false, "Add label from VERSION file of git root directory to image tags")
 	fs.BoolVar(&o.addVersionSHATag, "add-version-sha-tag", false, "Add label from VERSION file of git root directory plus SHA from git HEAD to image tags")
 	fs.BoolVar(&o.addDateSHATag, "add-date-sha-tag", false, "Using vYYYYMMDD-<rev short> scheme which is compatible to autobumper")
-	fs.Var(&o.addDateSHATagWithPrefix, "add-date-sha-tag-with-prefix", "Add a <prefix>-vYYYYMMDD-<rev short> tag which is compatible to autobumper")
+	fs.Var(&o.addDateSHATagWithPrefix, "add-date-sha-tag-with-prefix", "Add a <prefix>-vYYYYMMDD-<rev short> tag")
 	fs.Var(&o.addDateSHATagWithSuffix, "add-date-sha-tag-with-suffix", "Add a vYYYYMMDD-<rev short>-<suffix> tag which is compatible to autobumper")
 	fs.Var(&o.addFixedTags, "add-fixed-tag", "Add a fixed tag to images")
 	fs.BoolVar(&o.injectEffectiveVersion, "inject-effective-version", false, "Inject EFFECTIVE_VERSION build-arg")


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/bug

**What this PR does / why we need it**:
Unfortunately autobumper does not handle bumps with a prefix correctly.
Manual downgrade to golang 1.17