### PR TITLE
Test gardener/gardener master branch with Go 1.18 image

### DIFF
--- a/config/jobs/gardener/gardener-apidiff.yaml
+++ b/config/jobs/gardener/gardener-apidiff.yaml
@@ -10,7 +10,7 @@ presubmits:
     spec:
       containers:
       - name: test
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-286e1eb-1.17
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-286e1eb-1.18
         command:
         - make
         args:

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-286e1eb-1.17
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-286e1eb-1.18
         command:
         - make
         args:
@@ -42,7 +42,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-286e1eb-1.17
+      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-286e1eb-1.18
       command:
       - make
       args:

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -15,7 +15,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-286e1eb-1.17
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-286e1eb-1.18
         command:
         - make
         args:
@@ -49,7 +49,7 @@ periodics:
     containers:
     # Run all tests sequentially in one container or as separete prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-286e1eb-1.17
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220502-286e1eb-1.18
       command:
       - make
       args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR updates test jobs for gardener/gardener to golang-test:1.18
gardener/gardener repository is updating to Go 1.18. Unit tests for Go 1.18 do not run on a Go 1.17 image and vice versa.

**Special notes for your reviewer**:
/hold
Until https://github.com/gardener/gardener/pull/5896 is ready to be merged
