### PR TITLE
Null route for KubeAggregatedAPIDown errors

### DIFF
--- a/config/prow/cluster/monitoring/base-prow/alertmanager/config.yaml
+++ b/config/prow/cluster/monitoring/base-prow/alertmanager/config.yaml
@@ -15,7 +15,7 @@ route:
   # Metrics not visible in shoot cluster
   - receiver: 'null-receiver'
     matchers:
-      - alertname=~"KubeSchedulerDown|KubeControllerManagerDown|KubeAggregatedAPIErrors"
+      - alertname=~"KubeSchedulerDown|KubeControllerManagerDown|KubeAggregatedAPIErrors|KubeAggregatedAPIDown"
   - receiver: 'slack-alerts'
     group_interval: 5m
     repeat_interval: 2h


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
`KubeAggregatedAPIDown` fires too often for `v1beta1.metrics.k8s.io/default`  in our case.