### PR TITLE
Add a prow job to verify ci-infra builds

### DIFF
--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -46,3 +46,23 @@ presubmits:
           requests:
             cpu: 4
             memory: 2Gi
+  - name: pull-ci-infra-verify-image-build
+    cluster: gardener-prow-build
+    always_run: true
+    annotations:
+      description: Verify ci-infra image build on pull requests to master branch
+    decorate: true
+    spec:
+      containers:
+      - name: kaniko
+        image: gcr.io/kaniko-project/executor:v1.8.1
+        command:
+        - /kaniko/executor
+        args:
+        - --context=/home/prow/go/src/github.com/gardener/ci-infra
+        - --dockerfile=Dockerfile
+        - --no-push
+        resources:
+          requests:
+            cpu: 6
+            memory: 2Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Add a prow job similar to `pull-gardener-verify-image-build` prow job to verify building ci-infra images in PRs.
