### PR TITLE
Make buildlog highlighting more helpful

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -66,7 +66,7 @@ deck:
           - level=fatal\b
           - "fatal:"
           - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
-          - make:.*Error 2
+          - make:.*Error\b
           # This highlights the start of tests to skip noise in build log
           - "^> (Test|Test Cover|Integration Tests|E2E Tests)$"
       required_files:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -63,7 +63,10 @@ deck:
           - "ERROR:"
           - (FAIL|Failure \[|FAILED)\b
           - panic\b
+          - level=fatal\b
+          - "fatal:"
           - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
+          - make:.*Error 2
           # This highlights the start of tests to skip noise in build log
           - "^> (Test|Test Cover|Integration Tests|E2E Tests)$"
       required_files:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -61,11 +61,11 @@ deck:
           highlight_regexes:
           - timed out
           - "ERROR:"
-          - (FAIL|Failure \[)\b
+          - (FAIL|Failure \[|FAILED)\b
           - panic\b
           - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
-          # This highlights the start of bazel tests/runs to skip go importing noise.
-          - "^INFO: Analyzed \\d+ targets"
+          # This highlights the start of tests to skip noise in build log
+          - "^> (Test|Test Cover|Integration Tests|E2E Tests)$"
       required_files:
         - ^.*build-log\.txt$
     - lens:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Make buildlog highlighting more helpful by using regexes that match commonly used patterns in this github org (e.g. ginkgo failure output)