### PR TITLE
Cleanup old labels added by gardener-robot

### DIFF
--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -28,12 +28,14 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name: area/certification
+      - name: area/compliance
         color: 0052cc
-        description: Certification related
+        description: Compliance related
         target: both
         prowPlugin: label
         addedBy: anyone
+        previously:
+        - name: 'area/certification'
       - name: area/control-plane
         color: 0052cc
         description: Control plane related
@@ -748,12 +750,14 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
-      - name: area/certification
+      - name: area/compliance
         color: 0052cc
-        description: Certification related
+        description: Compliance related
         target: both
         prowPlugin: label
         addedBy: anyone
+        previously:
+        - name: 'area/certification'
       - name: area/control-plane
         color: 0052cc
         description: Control plane related

--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -729,6 +729,103 @@ repos:
         prowPlugin: cla-assistant
         isExternalPlugin: true
         addedBy: prow
+      # cleanup old labels added by gardener-robot
+      - name: effort/1d
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/1m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/1w
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/1y
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/2d
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/2m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/2w
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/3m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/6m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/9m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: exp/beginner
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: exp/expert
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: exp/intermediate
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: kind/consulting
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: lifecycle/icebox
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: merge/keep-commits
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: merge/squash
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/changes
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/cherry-pick
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/documentation
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/help
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/lgtm
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/ok-to-test
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/rebase
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/release-notes
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/review
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/second-opinion
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/tests
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: priority/blocker
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: priority/critical
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: reviewed/do-not-merge
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: reviewed/lgtm
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: reviewed/ok-to-test
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/accepted
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/author-action
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/blocked
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/closed
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/external-action
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/in-delivery
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/in-progress
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/new
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/on-hold
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/overdue
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/under-investigation
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: triage/consulting
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: triage/invalid
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: triage/upstream
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: triage/wont-fix
+        deleteAfter: 2022-05-16T00:00:00Z
   gardener/gardener:
     labels:
       # area
@@ -1476,6 +1573,103 @@ repos:
         prowPlugin: cla-assistant
         isExternalPlugin: true
         addedBy: prow
+      # cleanup old labels added by gardener-robot
+      - name: effort/1d
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/1m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/1w
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/1y
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/2d
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/2m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/2w
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/3m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/6m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/9m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: exp/beginner
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: exp/expert
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: exp/intermediate
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: kind/consulting
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: lifecycle/icebox
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: merge/keep-commits
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: merge/squash
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/changes
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/cherry-pick
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/documentation
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/help
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/lgtm
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/ok-to-test
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/rebase
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/release-notes
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/review
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/second-opinion
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/tests
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: priority/blocker
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: priority/critical
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: reviewed/do-not-merge
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: reviewed/lgtm
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: reviewed/ok-to-test
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/accepted
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/author-action
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/blocked
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/closed
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/external-action
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/in-delivery
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/in-progress
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/new
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/on-hold
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/overdue
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/under-investigation
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: triage/consulting
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: triage/invalid
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: triage/upstream
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: triage/wont-fix
+        deleteAfter: 2022-05-16T00:00:00Z
 gardener/gardener-extension-shoot-oidc-service:
   labels:
     - color: b60205

--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -1426,6 +1426,31 @@ repos:
         name: tide/merge-blocker
         target: issues
         addedBy: humans
+      - color: 66b5c1
+        description: Affects Garden clusters
+        name: topology/garden
+        target: both
+        addedBy: humans
+      - color: 66b5c1
+        description: Affects Soil clusters
+        name: topology/soil
+        target: both
+        addedBy: humans
+      - color: 66b5c1
+        description: Affects Seed clusters
+        name: topology/seed
+        target: both
+        addedBy: humans
+      - color: 66b5c1
+        description: Affects Shoot clusters
+        name: topology/shoot
+        target: both
+        addedBy: humans
+      - color: 66b5c1
+        description: Affects Plant clusters
+        name: topology/plant
+        target: both
+        addedBy: humans
       - color: 0ffa16
         description: Indicates a PR is trusted, used by tide for auto-merging PRs.
         name: skip-review


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind cleanup

**What this PR does / why we need it**:

Perform some labels hygiene:
- add a few labels from g/g that were missing in prow's config
- cleanup all the labels that were added by gardener-robot but are not desired anymore in g/g and g/ci-infra

**Special notes for your reviewer**:

For reference: I used the following commands to compare the list of labels in prow's config and gardener-robot's config:

```
$ z ci-infra
$ cat config/prow/labels.yaml | yq e '.repos["gardener/ci-infra"].labels[].name' - | sed -E 's|size/(.*)|size/\L\1|' | sort > /tmp/prow-labels.txt
$ z gardener-robot
$ cat config.yaml | yq e '.labels[] | select(.usedFor | (contains(["code-issue"]) or contains(["pull-request"]))) | .name' - | sort > /tmp/robot-labels.txt
$ code --diff /tmp/{prow,robot}-labels.txt
```
