### PR TITLE
Revert "Update Prow to v20220516-bc723c0e51"

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -16,7 +16,7 @@ periodics:
     description: Runs label_sync to synchronize GitHub repo labels with the label config defined in config/prow/labels.yaml
   spec:
     containers:
-    - image: gcr.io/k8s-prow/label_sync:v20220516-bc723c0e51
+    - image: gcr.io/k8s-prow/label_sync:v20220513-69ff551a87
       command:
       - label_sync
       args:
@@ -54,7 +54,7 @@ periodics:
     app: branchprotector
   spec:
     containers:
-    - image: gcr.io/k8s-prow/branchprotector:v20220516-bc723c0e51
+    - image: gcr.io/k8s-prow/branchprotector:v20220513-69ff551a87
       command:
       - branchprotector
       args:
@@ -88,7 +88,7 @@ periodics:
     description: Runs autobumper to create/update a PR that bumps prow images to the latest published version
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20220516-bc723c0e51
+    - image: gcr.io/k8s-prow/generic-autobumper:v20220513-69ff551a87
       command:
       - generic-autobumper
       args:
@@ -118,7 +118,7 @@ periodics:
     description: Runs autobumper to create/update and auto-merge a PR that bumps prow images to the latest published version
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20220516-bc723c0e51
+    - image: gcr.io/k8s-prow/generic-autobumper:v20220513-69ff551a87
       command:
       - generic-autobumper
       args:
@@ -148,7 +148,7 @@ periodics:
     description: Runs autobumper to create/update a PR that bumps prowjob images to latest published version
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20220516-bc723c0e51
+    - image: gcr.io/k8s-prow/generic-autobumper:v20220513-69ff551a87
       command:
       - generic-autobumper
       args:
@@ -178,7 +178,7 @@ periodics:
     description: Runs autobumper to create/update and auto-merge a PR that bumps prowjob images to latest published version
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20220516-bc723c0e51
+    - image: gcr.io/k8s-prow/generic-autobumper:v20220513-69ff551a87
       command:
       - generic-autobumper
       args:
@@ -211,7 +211,7 @@ periodics:
     description: Runs checkconfig to validate job configs, config.yaml and friends. Used as heartbeat job for alerts.
   spec:
     containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20220516-bc723c0e51
+    - image: gcr.io/k8s-prow/checkconfig:v20220513-69ff551a87
       command:
       - checkconfig
       args:
@@ -242,7 +242,7 @@ periodics:
     description: Runs checkconfig to validate job configs, config.yaml and friends. Used as heartbeat job for alerts.
   spec:
     containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20220516-bc723c0e51
+    - image: gcr.io/k8s-prow/checkconfig:v20220513-69ff551a87
       command:
       - checkconfig
       args:

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       description: Runs checkconfig to validate changes to job configs, config.yaml and friends
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20220516-bc723c0e51
+      - image: gcr.io/k8s-prow/checkconfig:v20220513-69ff551a87
         command:
         - checkconfig
         args:

--- a/config/jobs/common/issue-pr-lifecycle.yaml
+++ b/config/jobs/common/issue-pr-lifecycle.yaml
@@ -10,7 +10,7 @@ periodics:
     description: Closes rotten issues after 30d of inactivity
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20220516-bc723c0e51
+    - image: gcr.io/k8s-prow/commenter:v20220513-69ff551a87
       command:
       - commenter
       args:
@@ -56,7 +56,7 @@ periodics:
     description: Adds lifecycle/rotten to stale issues after 30d of inactivity
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20220516-bc723c0e51
+    - image: gcr.io/k8s-prow/commenter:v20220513-69ff551a87
       command:
       - commenter
       args:
@@ -103,7 +103,7 @@ periodics:
     description: Adds lifecycle/stale to issues after 90d of inactivity
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20220516-bc723c0e51
+    - image: gcr.io/k8s-prow/commenter:v20220513-69ff551a87
       command:
       - commenter
       args:

--- a/config/mkpj.sh
+++ b/config/mkpj.sh
@@ -26,7 +26,7 @@
 cd "$(git rev-parse --show-toplevel)"
 
 docker run -i --rm -w /etc/ci-infra -v $PWD:/etc/ci-infra \
-  gcr.io/k8s-prow/mkpj:v20220516-bc723c0e51 \
+  gcr.io/k8s-prow/mkpj:v20220513-69ff551a87 \
   --config-path=config/prow/config.yaml \
   --job-config-path=config/jobs \
   "$@"

--- a/config/prow/cluster/cherrypicker_deployment.yaml
+++ b/config/prow/cluster/cherrypicker_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20220516-bc723c0e51
+        image: gcr.io/k8s-prow/cherrypicker:v20220513-69ff551a87
         imagePullPolicy: Always
         args:
         - --github-token-path=/etc/github/token

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20220516-bc723c0e51
+        image: gcr.io/k8s-prow/crier:v20220513-69ff551a87
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20220516-bc723c0e51
+        image: gcr.io/k8s-prow/deck:v20220513-69ff551a87
         imagePullPolicy: Always
         ports:
         - name: http

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20220516-bc723c0e51
+        image: gcr.io/k8s-prow/ghproxy:v20220513-69ff551a87
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20220516-bc723c0e51
+        image: gcr.io/k8s-prow/hook:v20220513-69ff551a87
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20220516-bc723c0e51
+        image: gcr.io/k8s-prow/horologium:v20220513-69ff551a87
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/cluster/needs-rebase_deployment.yaml
+++ b/config/prow/cluster/needs-rebase_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20220516-bc723c0e51
+        image: gcr.io/k8s-prow/needs-rebase:v20220513-69ff551a87
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/config/prow/cluster/prow_controller_manager_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20220516-bc723c0e51
+        image: gcr.io/k8s-prow/prow-controller-manager:v20220513-69ff551a87
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20220516-bc723c0e51
+        image: gcr.io/k8s-prow/sinker:v20220513-69ff551a87
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20220516-bc723c0e51
+        image: gcr.io/k8s-prow/status-reconciler:v20220513-69ff551a87
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20220516-bc723c0e51
+        image: gcr.io/k8s-prow/tide:v20220513-69ff551a87
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -14,10 +14,10 @@ plank:
       timeout: 2h
       grace_period: 15m
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220516-bc723c0e51"
-        initupload: "gcr.io/k8s-prow/initupload:v20220516-bc723c0e51"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220516-bc723c0e51"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20220516-bc723c0e51"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220513-69ff551a87"
+        initupload: "gcr.io/k8s-prow/initupload:v20220513-69ff551a87"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220513-69ff551a87"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20220513-69ff551a87"
       gcs_configuration:
         bucket: "gs://gardener-prow"
         path_strategy: explicit

--- a/hack/bootstrap-config.sh
+++ b/hack/bootstrap-config.sh
@@ -83,7 +83,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 docker run --rm -w /etc/ci-infra -v $PWD:/etc/ci-infra \
   -v "$temp_kubeconfig":/etc/kubeconfig \
-  gcr.io/k8s-prow/config-bootstrapper:v20220516-bc723c0e51 \
+  gcr.io/k8s-prow/config-bootstrapper:v20220513-69ff551a87 \
   --kubeconfig=/etc/kubeconfig \
   --source-path=.  \
   --config-path=config/prow/config.yaml \

--- a/hack/check-config.sh
+++ b/hack/check-config.sh
@@ -20,7 +20,7 @@ set -o pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 docker run --rm -w /etc/ci-infra -v $PWD:/etc/ci-infra \
-  gcr.io/k8s-prow/checkconfig:v20220516-bc723c0e51 \
+  gcr.io/k8s-prow/checkconfig:v20220513-69ff551a87 \
   --config-path=config/prow/config.yaml \
   --job-config-path=config/jobs \
   --plugin-config=config/prow/plugins.yaml \


### PR DESCRIPTION
/kind bug

Reverts gardener/ci-infra#250
Spyglass is broken again and does not show anything. The issue seems to be upstream https://github.com/kubernetes/test-infra/issues/26344