### PR TITLE
Revert "Restrict approve and lgtm to OWNERS for the whole org"

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -46,10 +46,6 @@ blunderbuss:
   max_request_count: 2
   use_status_availability: true
 
-owners:
-  skip_collaborators:
-  - "gardener"  # Rely on OWNERS file for the whole organization
-
 heart:
   commentregexp: ".*"
 


### PR DESCRIPTION
Reverts gardener/ci-infra#178

We want to encourage all collaborators to review PRs, especially in areas where they are more knowledgable than `OWNERS`.
Hence, `lgtm` should be allowed to be added by all collaborators (just like in the kubernetes repositories).
`approve` is still restricted to listed `OWNERS`.