### PR TITLE
Enable testgrid for gardener prow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,34 @@ Gardener uses a [`prow`](https://github.com/kubernetes/test-infra/blob/master/pr
 Everyone can participate in a self-service PR-based workflow, where changes are automatically deployed after they have been reviewed and merged.
 All job configs are located in [`config/jobs`](config/jobs).
 
+### TestGrid
+The results of prow jobs can be visualized in TestGrid in dashboards at [testgrid.k8s.io/gardener](https://testgrid.k8s.io/gardener). We don't run our own TestGrid installation, but include our dashboards into the TestGrid installation of Kubernetes.
+
+We configured dashboards for each of our repositories where we run tests with prow. You find them at [config/prow/gardener-testgrid.yaml](./config/prow/gardener-testgrid.yaml).
+
+When the desired dashboard is defined, you can add your prow job to a dashboard annotating them like in the example below.
+
+```yaml
+annotations:
+  testgrid-dashboards: dashboard-name      # [Required] A dashboard already defined in gardener-testgrid.yaml.
+  testgrid-tab-name: some-short-name       # [Optional] A shorter name for the tab. If omitted, just uses the job name.
+  testgrid-alert-email: me@me.com          # [Optional] An alert email that will be applied to the tab created in the first dashboard specified in testgrid-dashboards.
+  description: Words about your job.       # [Optional] A description of your job. If omitted, only the job name is used.
+  testgrid-num-columns-recent: "10"        # [Optional] The number of runs in a row that can be omitted before the run is considered stale. The default value is 10.
+  testgrid-num-failures-to-alert: "3"      # [Optional] The number of continuous failures before sending an email. The default value is 3.
+  testgrid-days-of-results: "15"           # [Optional] The number of days for which the results are visible. The default value is 15.
+  testgrid-alert-stale-results-hours: "12" # [Optional] The number of hours that pass with no results after which the email is sent. The default value is 12.
+```
+
+For `postsubmit` and `periodic` prow jobs there will be a test-group created automatically. If you don't want to add them to TestGrid please use this annotation to disable creation of a test-group. For `presubmit` prow jobs no test-group will be created unless you annotate them as in the previous example.
+```yaml
+annotations:
+  testgrid-create-test-group: "false"
+```
+
+When your configuration is finalized and merged into `ci-infra` repository `gardener-ci-robot` automatically creates a PR for `kubernetes/test-infra` repository to update our configuration there. Once this PR is merged the new configuration is active.
+
+
 ## How to setup
 
 1. Create the prow cluster and prow workload cluster.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ annotations:
   testgrid-create-test-group: "false"
 ```
 
-When your configuration is finalized and merged into `ci-infra` repository `gardener-ci-robot` automatically creates a PR for `kubernetes/test-infra` repository to update our configuration there. Once this PR is merged the new configuration is active.
+When your configuration is finalized and merged into `ci-infra` repository `gardener-ci-robot` automatically creates a PR for `kubernetes/test-infra` repository to update [our configuration there](https://github.com/kubernetes/test-infra/tree/master/config/testgrids/gardener). Once this PR is merged the new configuration is active.
 
 
 ## How to setup

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ All job configs are located in [`config/jobs`](config/jobs).
 ### TestGrid
 The results of prow jobs can be visualized in TestGrid in dashboards at [testgrid.k8s.io/gardener](https://testgrid.k8s.io/gardener). We don't run our own TestGrid installation, but include our dashboards into the TestGrid installation of Kubernetes.
 
-We configured dashboards for each of our repositories where we run tests with prow. You find them at [config/prow/gardener-testgrid.yaml](./config/prow/gardener-testgrid.yaml).
+We configured dashboards for each of our repositories where we run tests with prow. You find them at [config/testgrids/config.yaml](./config/testgrids/config.yaml).
 
 When the desired dashboard is defined, you can add your prow job to a dashboard annotating them like in the example below.
 
@@ -37,7 +37,7 @@ annotations:
   testgrid-create-test-group: "false"
 ```
 
-When your configuration is finalized and merged into `ci-infra` repository `gardener-ci-robot` automatically creates a PR for `kubernetes/test-infra` repository to update [our configuration there](https://github.com/kubernetes/test-infra/tree/master/config/testgrids/gardener). Once this PR is merged the new configuration is active.
+You can test your TestGrid configuration locally with the `./hack/check-testgrid-config.sh`. Please open a PR for `ci-infra` repository for your new configuration. When it is merged the new configuration will be pushed to `gs://gardener-prow/testgrid/config` automatically and your jobs will become visible at [testgrid.k8s.io/gardener](https://testgrid.k8s.io/gardener) soon.
 
 
 ## How to setup

--- a/config/jobs/ci-infra/build-ci-infra-images.yaml
+++ b/config/jobs/ci-infra/build-ci-infra-images.yaml
@@ -8,6 +8,8 @@ postsubmits:
     - ^master$
     annotations:
       description: Build ci-infra images on master branch
+      testgrid-dashboards: gardener-ci-infra
+      testgrid-days-of-results: "60" 
     decorate: true
     max_concurrency: 1
     reporter_config:

--- a/config/jobs/ci-infra/build-golang-test-image.yaml
+++ b/config/jobs/ci-infra/build-golang-test-image.yaml
@@ -7,6 +7,8 @@ postsubmits:
     - ^master$
     annotations:
       description: Build golang-test image on master branch
+      testgrid-dashboards: gardener-ci-infra
+      testgrid-days-of-results: "60" 
     decorate: true
     max_concurrency: 1
     reporter_config:

--- a/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
+++ b/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
@@ -12,7 +12,7 @@ presubmits:
       containers:
       - image: "gcr.io/k8s-prow/transfigure:v20220519-c750e0df24"
         command:
-        - "/transfigure.sh"
+        - "/ko-app/transfigure"
         args:
         - "test"
         - "config/prow/config.yaml"
@@ -38,7 +38,7 @@ postsubmits:
       containers:
       - image: "gcr.io/k8s-prow/transfigure:v20220519-c750e0df24"
         command:
-        - "/transfigure.sh"
+        - "/ko-app/transfigure"
         args:
         - "/etc/github-token/token"
         - "config/prow/config.yaml"

--- a/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
+++ b/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
@@ -10,7 +10,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: "gcr.io/k8s-prow/transfigure:v20220519-c750e0df24"
+      - image: "gcr.io/k8s-prow/transfigure:v20220523-6e12e42c76"
         command:
         - "/ko-app/transfigure"
         args:
@@ -36,7 +36,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: "gcr.io/k8s-prow/transfigure:v20220519-c750e0df24"
+      - image: "gcr.io/k8s-prow/transfigure:v20220523-6e12e42c76"
         command:
         - "/ko-app/transfigure"
         args:

--- a/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
+++ b/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
@@ -37,12 +37,12 @@ postsubmits:
     annotations:
       testgrid-create-test-group: "false"
     spec:
-      serviceAccountName: gardener-prow-storage
       containers:
       - image: gcr.io/k8s-prow/configurator:v20220618-82a6661467
         command:
         - /ko-app/configurator
         args:
+        - --gcp-service-account=/secrets/gcs/gcs-credentials
         - --yaml=config/testgrids/config.yaml
         - --default=config/testgrids/default.yaml
         - --prow-config=config/prow/config.yaml
@@ -50,6 +50,7 @@ postsubmits:
         - --prowjob-url-prefix=https://github.com/gardener/ci-infra/tree/master/config/jobs
         - --update-description
         - --output=gs://gardener-prow/testgrid/config
+        - --world-readable=true
         - --oneshot
         resources:
           requests:

--- a/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
+++ b/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
@@ -42,7 +42,7 @@ postsubmits:
         command:
         - /ko-app/configurator
         args:
-        - --gcp-service-account=/secrets/gcs/gcs-credentials
+        - --gcp-service-account=/secrets/gcs/gcs-credentials/service-account.json
         - --yaml=config/testgrids/config.yaml
         - --default=config/testgrids/default.yaml
         - --prow-config=config/prow/config.yaml

--- a/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
+++ b/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
@@ -42,7 +42,7 @@ postsubmits:
         command:
         - /ko-app/configurator
         args:
-        - --gcp-service-account=/secrets/gcs/gcs-credentials/service-account.json
+        - --gcp-service-account=/etc/gcp-service-account/service-account.json
         - --yaml=config/testgrids/config.yaml
         - --default=config/testgrids/default.yaml
         - --prow-config=config/prow/config.yaml
@@ -55,3 +55,11 @@ postsubmits:
         resources:
           requests:
             memory: "1Gi"
+        volumeMounts:
+        - name: gcp-service-account
+          mountPath: /etc/gcp-service-account
+          readOnly: true
+      volumes:
+      - name: gcp-service-account
+        secret:
+          secretName: gardener-prow-storage

--- a/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
+++ b/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
@@ -1,60 +1,56 @@
-presubmits: 
+presubmits:
   gardener/ci-infra:
-  - name: pull-ci-infra-validate-testgrid-config
+  - name: pull-ci-infra-check-testgrid-config
     cluster: gardener-prow-build
-    run_if_changed: '^(config\/jobs\/.*.yaml)|(config\/prow\/gardener-testgrid.yaml)$'
     branches:
     - ^master$
+    run_if_changed: '^(config\/jobs\/.*.yaml)|(config\/testgrids\/.*.yaml)$'
+    decorate: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     spec:
       containers:
-      - image: "gcr.io/k8s-prow/transfigure:v20220523-6e12e42c76"
+      - image: gcr.io/k8s-prow/configurator:v20220618-82a6661467
         command:
-        - "/ko-app/transfigure"
+        - /ko-app/configurator
         args:
-        - "test"
-        - "config/prow/config.yaml"
-        - "config/jobs"
-        - "config/prow/gardener-testgrid.yaml"
-        - "gardener"
-        - "kubernetes-test-infra"
+        - --yaml=config/testgrids/config.yaml
+        - --default=config/testgrids/default.yaml
+        - --prow-config=config/prow/config.yaml
+        - --prow-job-config=config/jobs
+        - --prowjob-url-prefix=https://github.com/gardener/ci-infra/tree/master/config/jobs
+        - --update-description
+        - --validate-config-file
+        - --oneshot
         resources:
           requests:
-            memory: 1.5Gi
-            cpu: 1
+            memory: "1Gi"
 postsubmits:
   gardener/ci-infra:
-  - name: post-ci-infra-update-testgrid-config
-    cluster: gardener-prow-trusted
-    run_if_changed: '^(config\/jobs\/.*.yaml)|(config\/prow\/gardener-testgrid.yaml)$'
+  - name: post-ci-infra-upload-testgrid-config
+    cluster: gardener-prow-build
     branches:
     - ^master$
+    max_concurrency: 1
+    run_if_changed: '^(config\/jobs\/.*.yaml)|(config\/testgrids\/.*.yaml)$'
+    decorate: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     spec:
+      serviceAccountName: gardener-prow-storage
       containers:
-      - image: "gcr.io/k8s-prow/transfigure:v20220523-6e12e42c76"
+      - image: gcr.io/k8s-prow/configurator:v20220618-82a6661467
         command:
-        - "/ko-app/transfigure"
+        - /ko-app/configurator
         args:
-        - "/etc/github-token/token"
-        - "config/prow/config.yaml"
-        - "config/jobs"
-        - "config/prow/gardener-testgrid.yaml"
-        - "gardener"
-        - "kubernetes-test-infra"
+        - --yaml=config/testgrids/config.yaml
+        - --default=config/testgrids/default.yaml
+        - --prow-config=config/prow/config.yaml
+        - --prow-job-config=config/jobs
+        - --prowjob-url-prefix=https://github.com/gardener/ci-infra/tree/master/config/jobs
+        - --update-description
+        - --output=gs://gardener-prow/testgrid/config
+        - --oneshot
         resources:
           requests:
-            memory: 1.5Gi
-            cpu: 1
-        volumeMounts:
-        - name: github-token
-          mountPath: /etc/github-token
-          readOnly: true
-      volumes:
-      - name: github-token
-        secret:
-          secretName: github-token
+            memory: "1Gi"

--- a/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
+++ b/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
@@ -1,0 +1,60 @@
+presubmits: 
+  gardener/ci-infra:
+  - name: pull-ci-infra-validate-testgrid-config
+    cluster: gardener-prow-build
+    run_if_changed: '^(config\/jobs\/.*.yaml)|(config\/prow\/gardener-testgrid.yaml)$'
+    branches:
+    - ^master$
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    spec:
+      containers:
+      - image: "gcr.io/k8s-prow/transfigure:v20220519-c750e0df24"
+        command:
+        - "/transfigure.sh"
+        args:
+        - "test"
+        - "config/prow/config.yaml"
+        - "config/jobs"
+        - "config/prow/gardener-testgrid.yaml"
+        - "gardener"
+        - "kubernetes-test-infra"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 1
+postsubmits:
+  gardener/ci-infra:
+  - name: post-ci-infra-update-testgrid-config
+    cluster: gardener-prow-trusted
+    run_if_changed: '^(config\/jobs\/.*.yaml)|(config\/prow\/gardener-testgrid.yaml)$'
+    branches:
+    - ^master$
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    spec:
+      containers:
+      - image: "gcr.io/k8s-prow/transfigure:v20220519-c750e0df24"
+        command:
+        - "/transfigure.sh"
+        args:
+        - "/etc/github-token/token"
+        - "config/prow/config.yaml"
+        - "config/jobs"
+        - "config/prow/gardener-testgrid.yaml"
+        - "gardener"
+        - "kubernetes-test-infra"
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 1
+        volumeMounts:
+        - name: github-token
+          mountPath: /etc/github-token
+          readOnly: true
+      volumes:
+      - name: github-token
+        secret:
+          secretName: github-token

--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -14,6 +14,7 @@ periodics:
       channel: "gardener-prow-alerts"
   annotations:
     description: Runs label_sync to synchronize GitHub repo labels with the label config defined in config/prow/labels.yaml
+    testgrid-create-test-group: "false"
   spec:
     containers:
     - image: gcr.io/k8s-prow/label_sync:v20220519-c750e0df24
@@ -50,6 +51,7 @@ periodics:
     base_ref: master
   annotations:
     description: Runs Prow's branchprotector to apply configured GitHub status context requirements and merge policies
+    testgrid-create-test-group: "false"
   labels:
     app: branchprotector
   spec:
@@ -86,6 +88,7 @@ periodics:
       channel: "gardener-prow-alerts"
   annotations:
     description: Runs autobumper to create/update a PR that bumps prow images to the latest published version
+    testgrid-create-test-group: "false"
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220519-c750e0df24
@@ -116,6 +119,7 @@ periodics:
       channel: "gardener-prow-alerts"
   annotations:
     description: Runs autobumper to create/update and auto-merge a PR that bumps prow images to the latest published version
+    testgrid-create-test-group: "false"
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220519-c750e0df24
@@ -146,6 +150,7 @@ periodics:
       channel: "gardener-prow-alerts"
   annotations:
     description: Runs autobumper to create/update a PR that bumps prowjob images to latest published version
+    testgrid-create-test-group: "false"
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220519-c750e0df24
@@ -176,6 +181,7 @@ periodics:
       channel: "gardener-prow-alerts"
   annotations:
     description: Runs autobumper to create/update and auto-merge a PR that bumps prowjob images to latest published version
+    testgrid-create-test-group: "false"
   spec:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20220519-c750e0df24
@@ -209,6 +215,7 @@ periodics:
       channel: "gardener-prow-alerts"
   annotations:
     description: Runs checkconfig to validate job configs, config.yaml and friends. Used as heartbeat job for alerts.
+    testgrid-create-test-group: "false"
   spec:
     containers:
     - image: gcr.io/k8s-prow/checkconfig:v20220519-c750e0df24
@@ -240,6 +247,7 @@ periodics:
       channel: "gardener-prow-alerts"
   annotations:
     description: Runs checkconfig to validate job configs, config.yaml and friends. Used as heartbeat job for alerts.
+    testgrid-create-test-group: "false"
   spec:
     containers:
     - image: gcr.io/k8s-prow/checkconfig:v20220519-c750e0df24
@@ -270,7 +278,9 @@ periodics:
       channel: "gardener-prow-alerts"
   decorate: true
   annotations:
-    description: Runs go tests for prow developments in ci-infra 
+    description: Runs go tests for prow developments in ci-infra
+    testgrid-dashboards: gardener-ci-infra
+    testgrid-days-of-results: "60"
   spec:
     containers:
     - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220517-f80c2bf-1.17

--- a/config/jobs/ci-infra/ci-infra-postsubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-postsubmits.yaml
@@ -23,6 +23,7 @@ postsubmits:
           *<{{.Status.URL}}|Spyglass> | <https://prow.gardener.cloud/?job={{.Spec.Job}}|Deck>*
     annotations:
       description: Deploys the configured version of prow by running config/prow/deploy.sh
+      testgrid-create-test-group: "false"
     spec:
       serviceAccountName: deployer
       containers:

--- a/config/jobs/common/issue-pr-lifecycle.yaml
+++ b/config/jobs/common/issue-pr-lifecycle.yaml
@@ -8,6 +8,7 @@ periodics:
       channel: "gardener-prow-alerts" 
   annotations:
     description: Closes rotten issues after 30d of inactivity
+    testgrid-create-test-group: "false"
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20220519-c750e0df24
@@ -54,6 +55,7 @@ periodics:
       channel: "gardener-prow-alerts"
   annotations:
     description: Adds lifecycle/rotten to stale issues after 30d of inactivity
+    testgrid-create-test-group: "false"
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20220519-c750e0df24
@@ -101,6 +103,7 @@ periodics:
       channel: "gardener-prow-alerts"
   annotations:
     description: Adds lifecycle/stale to issues after 90d of inactivity
+    testgrid-create-test-group: "false"
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20220519-c750e0df24

--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
@@ -60,7 +60,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   annotations:
     description: Runs end-to-end tests for gardener-extension-shoot-oidc-service developments periodically
-    testgrid-dashboards: gardener-gardener-extension-shoot-oidc-service
+    testgrid-dashboards: gardener-extension-shoot-oidc-service
     testgrid-days-of-results: "60"
   spec:
     containers:

--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
@@ -10,6 +10,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for gardener-extension-shoot-oidc-service developments in pull requests
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20220514-17efd5d2c3-master
@@ -56,6 +58,10 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs end-to-end tests for gardener-extension-shoot-oidc-service developments periodically
+    testgrid-dashboards: gardener-gardener-extension-shoot-oidc-service
+    testgrid-days-of-results: "60"
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/krte:v20220514-17efd5d2c3-master

--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
@@ -36,7 +36,7 @@ periodics:
     grace_period: 10m
   annotations:
     description: Periodically runs unit tests for extension-shoot-oidc-service master branch
-    testgrid-dashboards: gardener-gardener-extension-shoot-oidc-service
+    testgrid-dashboards: gardener-extension-shoot-oidc-service
     testgrid-days-of-results: "60"
   spec:
     containers:

--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
@@ -36,6 +36,8 @@ periodics:
     grace_period: 10m
   annotations:
     description: Periodically runs unit tests for extension-shoot-oidc-service master branch
+    testgrid-dashboards: gardener-gardener-extension-shoot-oidc-service
+    testgrid-days-of-results: "60"
   spec:
     containers:
     - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220517-f80c2bf-1.17

--- a/config/jobs/gardener/gardener-build-dev-images.yaml
+++ b/config/jobs/gardener/gardener-build-dev-images.yaml
@@ -7,6 +7,8 @@ postsubmits:
     - ^master$
     annotations:
       description: Gardener development image build on master branch
+      testgrid-dashboards: gardener-gardener
+      testgrid-days-of-results: "60"
     decorate: true
     max_concurrency: 1
     spec:

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -12,6 +12,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for gardener developments in pull requests
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20220514-17efd5d2c3-master
@@ -63,6 +65,10 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs end-to-end tests for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/krte:v20220514-17efd5d2c3-master

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -38,7 +38,9 @@ periodics:
     timeout: 20m
     grace_period: 10m
   annotations:
-    description: Runs integration tests for gardener developments in pull requests
+    description: Runs integration tests for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
   spec:
     containers:
     - name: test-integration

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -44,7 +44,9 @@ periodics:
     timeout: 40m
     grace_period: 10m
   annotations:
-    description: Runs unit tests for gardener developments in pull requests
+    description: Runs unit tests for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
   spec:
     containers:
     # Run all tests sequentially in one container or as separete prow jobs.

--- a/config/jobs/gardener/release/gardener-build-dev-images-release.yaml
+++ b/config/jobs/gardener/release/gardener-build-dev-images-release.yaml
@@ -7,6 +7,8 @@ postsubmits:
     - release-v\d+.\d+
     annotations:
       description: Gardener development image build on release branch
+      testgrid-dashboards: gardener-gardener
+      testgrid-days-of-results: "60"
     decorate: true
     max_concurrency: 1
     spec:

--- a/config/jobs/gardener/release/gardener-e2e-kind-release.yaml
+++ b/config/jobs/gardener/release/gardener-e2e-kind-release.yaml
@@ -13,6 +13,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for gardener developments in pull requests
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20220514-17efd5d2c3-master
@@ -63,6 +65,10 @@ postsubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for gardener developments periodically
+      testgrid-dashboards: gardener-gardener
+      testgrid-days-of-results: "60"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20220514-17efd5d2c3-master

--- a/config/jobs/gardener/release/gardener-integration-tests-release-previous-golang.yaml
+++ b/config/jobs/gardener/release/gardener-integration-tests-release-previous-golang.yaml
@@ -39,6 +39,8 @@ postsubmits:
       grace_period: 10m
     annotations:
       description: Runs integration tests for gardener releases when merging
+      testgrid-dashboards: gardener-gardener
+      testgrid-days-of-results: "60"
     spec:
       containers:
       - name: test-integration

--- a/config/jobs/gardener/release/gardener-integration-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-integration-tests-release.yaml
@@ -43,6 +43,8 @@ postsubmits:
       grace_period: 10m
     annotations:
       description: Runs integration tests for gardener releases when merging
+      testgrid-dashboards: gardener-gardener
+      testgrid-days-of-results: "60"
     spec:
       containers:
       - name: test-integration

--- a/config/jobs/gardener/release/gardener-unit-tests-release-previous-golang.yaml
+++ b/config/jobs/gardener/release/gardener-unit-tests-release-previous-golang.yaml
@@ -45,6 +45,8 @@ postsubmits:
       grace_period: 10m
     annotations:
       description: Runs unit tests for gardener releases when merging
+      testgrid-dashboards: gardener-gardener
+      testgrid-days-of-results: "60"
     spec:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.

--- a/config/jobs/gardener/release/gardener-unit-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-unit-tests-release.yaml
@@ -49,6 +49,8 @@ postsubmits:
       grace_period: 10m
     annotations:
       description: Runs unit tests for gardener releases when merging
+      testgrid-dashboards: gardener-gardener
+      testgrid-days-of-results: "60"
     spec:
       containers:
       # Run all tests sequentially in one container or as separete prow jobs.

--- a/config/prow/autobump-config/prow-component-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-component-autobump-config.yaml
@@ -14,6 +14,7 @@ extraFiles:
   - "config/mkpj.sh"
   - "hack/bootstrap-config.sh"
   - "hack/check-config.sh"
+  - "hack/check-testgrid-config.sh"
 targetVersion: "latest"
 prefixes:
   - name: "Prow"

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -46,8 +46,8 @@ deck:
   spyglass:
     size_limit: 100000000 # 100MB
     gcs_browser_prefix: https://gcsweb.gardener.cloud/gcs/
-#    testgrid_config: gs://k8s-testgrid/config
-#    testgrid_root: https://testgrid.k8s.io/
+    testgrid_config: gs://k8s-testgrid/config
+    testgrid_root: https://testgrid.k8s.io/
     lenses:
     - lens:
         name: metadata

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -46,7 +46,7 @@ deck:
   spyglass:
     size_limit: 100000000 # 100MB
     gcs_browser_prefix: https://gcsweb.gardener.cloud/gcs/
-    testgrid_config: gs://k8s-testgrid/config
+    testgrid_config: gs://gardener-prow/testgrid/config
     testgrid_root: https://testgrid.k8s.io/
     lenses:
     - lens:

--- a/config/prow/gardener-testgrid.yaml
+++ b/config/prow/gardener-testgrid.yaml
@@ -1,4 +1,0 @@
-dashboards:
-- name: gardener-gardener
-- name: gardener-ci-infra
-- name: gardener-extension-shoot-oidc-service

--- a/config/prow/gardener-testgrid.yaml
+++ b/config/prow/gardener-testgrid.yaml
@@ -1,0 +1,4 @@
+dashboards:
+- name: gardener-gardener
+- name: gardener-ci-infra
+- name: gardener-extension-shoot-oidc-service

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -1,0 +1,11 @@
+dashboard_groups:
+- name: gardener
+  dashboard_names:
+    - gardener-gardener
+    - gardener-ci-infra
+    - gardener-extension-shoot-oidc-service
+
+dashboards:
+- name: gardener-gardener
+- name: gardener-ci-infra
+- name: gardener-extension-shoot-oidc-service

--- a/config/testgrids/default.yaml
+++ b/config/testgrids/default.yaml
@@ -1,0 +1,40 @@
+# Template copied From kubernetes/test-infra https://github.com/kubernetes/test-infra/blob/12421e4ff4d279808deaf3826b115f9ad514e60d/config/testgrids/default.yaml
+default_test_group:
+  # TODO: Reduce this back down to 14 once a full update has completed.
+  days_of_results: 15 # Number of days of test results to gather and serve.
+  tests_name_policy: 2 # replace the name of the test
+  ignore_pending: false # Show in-progress tests.
+  ignore_skip: true # Don't show skipped tests by default.
+  column_header:
+    - configuration_value: Commit # Shows the commit number on column header
+    - configuration_value: infra-commit
+  num_columns_recent: 10
+  use_kubernetes_client: true # These two fields are deprecated and should always be true
+  is_external: true
+  alert_stale_results_hours: 0 # Don't alert for staleness by default.
+  num_failures_to_alert: 3 # Consider a test failed if it has 3 or more consecutive failures.
+  num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes.
+  code_search_path: github.com/gardener/gardener/search # URL for regression search links.
+
+default_dashboard_tab:
+  open_test_template: # The URL template to visit after clicking on a cell
+    url: https://prow.gardener.cloud/view/gs/<gcs_prefix>/<changelist>
+  file_bug_template: # The URL template to visit when filing a bug
+    url: https://github.com/gardener/gardener/issues/new
+    options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+  attach_bug_template: # The URL template to visit when attaching to an existing bug
+    url: # empty
+    options: #empty
+  open_bug_template: # The URL template to visit when visiting an associated bug
+    url: https://github.com/gardener/gardener/issues/
+  results_text: See these results on Prow # Text to show in the about menu as a link to another view of the results
+  results_url_template: # The URL template to visit after clicking
+    url: https://prow.gardener.cloud/job-history/<gcs_prefix>
+  code_search_path: github.com/gardener/gardener/search # URL for regression search links.
+  num_columns_recent: 10
+  code_search_url_template: # The URL template to visit when searching for changelists
+    url: https://github.com/gardener/gardener/compare/<start-custom-0>...<end-custom-0>

--- a/hack/check-testgrid-config.sh
+++ b/hack/check-testgrid-config.sh
@@ -20,10 +20,12 @@ set -o pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 docker run --rm -w /etc/ci-infra -v $PWD:/etc/ci-infra \
-  gcr.io/k8s-prow/transfigure:v20220523-6e12e42c76 \
-  test \
-  config/prow/config.yaml \
-  config/jobs \
-  config/prow/gardener-testgrid.yaml \
-  gardener \
-  kubernetes-test-infra
+  gcr.io/k8s-prow/configurator:v20220618-82a6661467 \
+  --yaml=config/testgrids/config.yaml \
+  --default=config/testgrids/default.yaml \
+  --prow-config=config/prow/config.yaml \
+  --prow-job-config=config/jobs \
+  --prowjob-url-prefix=https://github.com/gardener/ci-infra/tree/master/config/jobs \
+  --update-description \
+  --validate-config-file \
+  --oneshot

--- a/hack/check-testgrid-config.sh
+++ b/hack/check-testgrid-config.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+docker run --rm -w /etc/ci-infra -v $PWD:/etc/ci-infra \
+  gcr.io/k8s-prow/transfigure:v20220523-6e12e42c76 \
+  test \
+  config/prow/config.yaml \
+  config/jobs \
+  config/prow/gardener-testgrid.yaml \
+  gardener \
+  kubernetes-test-infra


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds dashboards for tests carried out in prow for following gardener repositories to https://testgrid.k8s.io/gardener
- gardener/gardener
- gardener/ci-infra
- gardener/gardener-extension-shoot-oidc-service

We are using the old transfigure image of prow which create PRs to kubernetes/test-infra on config changes instead of config-merger because there are the gardener conformance tests which will share the same testgrid dashboard.

**Special notes for your reviewer**:
/hold
before merging the PR I'd like to create a PR for https://github.com/kubernetes/test-infra/tree/master/config/testgrids/gardener to include the new dashboard groups.
