### PR TITLE
Update kubectl image to v1.22.10

### DIFF
--- a/config/jobs/ci-infra/ci-infra-postsubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-postsubmits.yaml
@@ -26,7 +26,7 @@ postsubmits:
     spec:
       serviceAccountName: deployer
       containers:
-      - image: bitnami/kubectl:1.21.7
+      - image: bitnami/kubectl:1.22.10
         command:
         - config/prow/deploy.sh
         env:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Our kubectl image is outdated. Updating to v1.22.10 which is the latest version fitting to the minor version skew of +/-1 to our cluster.
