### PR TITLE
Fix/nginx deployment permissions

### DIFF
--- a/config/prow/cluster/bootstrap-trusted/kustomization.yaml
+++ b/config/prow/cluster/bootstrap-trusted/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- trusted_serviceaccounts.yaml

--- a/config/prow/cluster/bootstrap-trusted/trusted_serviceaccounts.yaml
+++ b/config/prow/cluster/bootstrap-trusted/trusted_serviceaccounts.yaml
@@ -37,6 +37,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - delete

--- a/hack/bootstrap-config.sh
+++ b/hack/bootstrap-config.sh
@@ -37,10 +37,6 @@ color-missing() { # Yellow
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-bootstrap_trusted_components=(
-"trusted_serviceaccounts.yaml"
-)
-
 if ! [ -x "$(command -v "kubectl")" ]; then
   echo "ERROR: kubectl is not present. Exiting..."
   exit 1
@@ -72,9 +68,7 @@ echo " $(color-green done)"
 
 echo "$(color-step "Deploying bootstrap components to gardener-prow-trusted cluster...")"
 kubectl config use-context gardener-prow-trusted
-for c in "${bootstrap_trusted_components[@]}"; do
-  kubectl apply --server-side=true -f "$SCRIPT_DIR/../config/prow/cluster/bootstrap-trusted/$c"
-done
+kubectl apply --server-side=true -k "$SCRIPT_DIR/../config/prow/cluster/bootstrap-trusted"
 echo " $(color-green done)"
 
 echo "$(color-step "Bootstrapping prow to gardener-prow-trusted cluster...")"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Deployer service account is [lacking permissions for get, list, watch nodes and endpoints](https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-ci-infra-deploy-prow/1532300407773073408). These are added by this PR.
Additionally, bootstrap-config.sh was adapted to use kustomize too.
