### PR TITLE
Disable `lgtm_acts_as_approve` for ci-infra

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -10,11 +10,6 @@ triggers:
 approve:
 - repos:
   - gardener/ci-infra
-  lgtm_acts_as_approve: true
-  require_self_approval: true
-  commandHelpLink: "https://prow.gardener.cloud/command-help"
-  pr_process_link: "https://gardener.cloud/docs/contribute/#pull-request-checklist"
-- repos:
   - gardener/gardener
   lgtm_acts_as_approve: false
   require_self_approval: true


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind cleanup

**What this PR does / why we need it**:

Disable `lgtm_acts_as_approve` for ci-infra, use the same `approve` settings for ci-infra as for g/g to avoid confusion.
