### PR TITLE
Update shoot spec

### DIFF
--- a/config/clusters/shoot-workload.yaml
+++ b/config/clusters/shoot-workload.yaml
@@ -30,7 +30,7 @@ spec:
       enableBasicAuthentication: false
     kubeProxy:
       mode: IPTables
-    version: 1.21.9
+    version: 1.22.7
     verticalPodAutoscaler:
       enabled: true
   maintenance:
@@ -64,7 +64,7 @@ spec:
           type: n2d-standard-16
           image:
             name: gardenlinux
-            version: 576.3.0
+            version: 576.8.0
         maximum: 10
         minimum: 1
         maxSurge: 1

--- a/config/clusters/shoot.yaml
+++ b/config/clusters/shoot.yaml
@@ -32,7 +32,7 @@ spec:
       enableBasicAuthentication: false
     kubeProxy:
       mode: IPTables
-    version: 1.21.9
+    version: 1.22.7
     verticalPodAutoscaler:
       enabled: true
   maintenance:
@@ -63,10 +63,10 @@ spec:
           name: containerd
         name: worker
         machine:
-          type: e2-standard-4
+          type: n2d-standard-4
           image:
             name: gardenlinux
-            version: 576.3.0
+            version: 576.8.0
         maximum: 5
         minimum: 2
         maxSurge: 1
@@ -87,9 +87,9 @@ spec:
           type: n2d-standard-16
           image:
             name: gardenlinux
-            version: 576.3.0
+            version: 576.8.0
         maximum: 5
-        minimum: 1
+        minimum: 0
         maxSurge: 1
         maxUnavailable: 0
         taints:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
Catching up with cluster reality:
- Prow clusters are upgraded to `Kubernetes v1.22.7`.
- `image-builder` worker group of trusted cluster is now able to scale down to 0
- trusted cluster uses now `n2d` instead of `e2` machines for base worker group too because they offer more CPU power for the same price in GCP region `europe-west1`  