### PR TITLE
Enhance highlight regexes

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -59,7 +59,7 @@ deck:
         name: buildlog
         config:
           highlight_regexes:
-          - timed out
+          - "[tT]imed out"
           - "ERROR:"
           - (FAIL|Failure \[|FAILED)\b
           - panic\b


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:

On failure, gomega asynchronous assertions print something like:
```
  Timed out after 5.001s.
  Expected success, but got an error:
      <*errors.errorString | 0xc0000ad720>: {
```
e.g. https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind/1534856393104822272#1:build-log.txt%3A1857
