### PR TITLE
Highlight standard ginkgo error from e2e tests

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -69,6 +69,8 @@ deck:
           - make:.*Error\b
           # This highlights the start of tests to skip noise in build log
           - "^> (Test|Test Cover|Integration Tests|E2E Tests)$"
+          # This is the standard ginkgo error in e2e tests
+          - "Expected success, but got an error"
       required_files:
         - ^.*build-log\.txt$
     - lens:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
In E2E we always assert `To(Succeed())`.
Ginkgo error messages start with ["Expected success, but got an error"](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/6090/pull-gardener-e2e-kind/1534949945625284608#1:build-log.txt%3A1931) in this case. 
