### PR TITLE
Update to golang-test image 1.18 in prow jobs for ci-infra repository

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,9 @@
 run:
   concurrency: 4
   deadline: 10m
+  # some of the linters don't work correctly with 1.18, ref https://github.com/golangci/golangci-lint/issues/2649
+  # we are not using generics, so let's pin this to 1.17 until 1.18 is fully supported
+  go: "1.17"
 
   skip-files:
   - ".*\\.pb\\.go$"

--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -273,7 +273,7 @@ periodics:
     description: Runs go tests for prow developments in ci-infra 
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220602-5b23dfb-1.17
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220602-5b23dfb-1.18
       command:
       - make
       args:

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -33,7 +33,7 @@ presubmits:
       description: Runs go tests for prow developments in ci-infra 
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220602-5b23dfb-1.17
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220602-5b23dfb-1.18
         command:
         - make
         args:

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -25,7 +25,7 @@ GOIMPORTS                  := $(TOOLS_BIN_DIR)/goimports
 GOLANGCI_LINT              := $(TOOLS_BIN_DIR)/golangci-lint
 
 # default tool versions
-GOLANGCI_LINT_VERSION ?= v1.42.1
+GOLANGCI_LINT_VERSION ?= v1.46.2
 
 export TOOLS_BIN_DIR := $(TOOLS_BIN_DIR)
 export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Simplifies testing of https://github.com/gardener/ci-infra/pull/284 which includes update to Go 1.18 for ci-infra developments.
