### PR TITLE
Use ci-infra cherrypicker

### DIFF
--- a/config/prow/cluster/cherrypicker_deployment.yaml
+++ b/config/prow/cluster/cherrypicker_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20220618-82a6661467
+        image: eu.gcr.io/gardener-project/ci-infra/cherrypicker:v20220620-00b0357
         imagePullPolicy: Always
         args:
         - --github-token-path=/etc/github/token


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
After https://github.com/gardener/ci-infra/pull/284 was merged and built, we can now use it.