### PR TITLE
Add git to cherrypicker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,18 @@ RUN apk add --no-cache ca-certificates
 RUN addgroup -g 65532 -S nonroot && adduser -u 65532 -S nonroot -G nonroot
 USER 65532
 
+FROM alpine:3.15.4 AS ssl_git_runner
+# Install SSL ca certificates
+RUN apk add --no-cache ca-certificates git
+# Create nonroot user and group to be used in executable containers
+RUN addgroup -g 65532 -S nonroot && adduser -u 65532 -S nonroot -G nonroot
+USER 65532
+
 # ----------------------
 # Executable containers
 # ----------------------
 
-FROM ssl_runner AS cherrypicker
+FROM ssl_git_runner AS cherrypicker
 LABEL app=cherrypicker
 WORKDIR /
 COPY --from=builder /build/cherrypicker /cherrypicker


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
cherrypicker is crash looping because it does not include a git binary.
```
k logs -n prow cherrypicker-9dd5dc76c-p6gcm                                                                                                                                                                                                
{"client":"github","component":"unset","file":"/code/vendor/k8s.io/test-infra/prow/github/client.go:910","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"Throttle(0, 0, *)","severity":"info","time":"2022-06-20T19:39:49Z"}
{"component":"unset","error":"exec: \"git\": executable file not found in $PATH","file":"/code/prow/external-plugins/cherrypicker/main.go:111","func":"main.main","level":"fatal","msg":"Error getting Git client.","severity":"fatal","time":"2022-06-20T19:39:49Z"}
``` 

This PR adds `git` to the cherrypicker image. It continues using the alpine image.
Another option could be using `gcr.io/k8s-prow/git` as it seems to be done in [kubernetes/test-infra](https://github.com/kubernetes/test-infra/blob/ae8821c9316a07a76d6334c2b6209db674ec7ed5/.ko.yaml#L38), but I prefer consistent base images.