### PR TITLE
Remove world-readable flag from upload testgrid job

### DIFF
--- a/config/jobs/ci-infra/build-ci-infra-images.yaml
+++ b/config/jobs/ci-infra/build-ci-infra-images.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - name: post-ci-infra-build-images
     cluster: gardener-prow-trusted
     # skip config/prow folder that build and autobumper do not end up in an endless loop
-    skip_if_only_changed: '^config\/|^hack\/(bootstrap|check)-config\.sh'
+    skip_if_only_changed: '^config\/|^hack\/(bootstrap|check|check-testgrid)-config\.sh'
     branches:
     - ^master$
     annotations:

--- a/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
+++ b/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
@@ -50,7 +50,6 @@ postsubmits:
         - --prowjob-url-prefix=https://github.com/gardener/ci-infra/tree/master/config/jobs
         - --update-description
         - --output=gs://gardener-prow/testgrid/config
-        - --world-readable=true
         - --oneshot
         resources:
           requests:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Upload TestGrid job fails with an ACL error.
https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-ci-infra-upload-testgrid-config/1539002165169754112
```
2022/06/20 21:48:10 could not write config: close: googleapi: Error 400: Cannot insert legacy ACL for an object when uniform bucket-level access is enabled. Read more at https://cloud.google.com/storage/docs/uniform-bucket-level-access, invalid
```

When removing `world-readable` flag it working.
https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-ci-infra-upload-testgrid-config/1539003128341336064

The resulting file is publicly available as desired.
https://console.cloud.google.com/storage/browser/gardener-prow/testgrid

