### PR TITLE
Fix prow gcs-bucket name

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -19,7 +19,7 @@ plank:
         entrypoint: "gcr.io/k8s-prow/entrypoint:v20220704-55148688b2"
         sidecar: "gcr.io/k8s-prow/sidecar:v20220704-55148688b2"
       gcs_configuration:
-        bucket: "gs://gardener-prow"
+        bucket: "gardener-prow"
         path_strategy: explicit
       gcs_credentials_secret: "gardener-prow-storage"
       resources:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Testgrid config_merger is creating weird path names for prow job logs like starting with `gs:/gardener-prow` with a single `/`. This might be reason why testgrid is not showing any results right now.

The gcs bucket in testgrid configuration comes form `gcs_configuration.bucket` which currently has a `gs://` prefix.
This PR removes the `gs://` prefix from `config.yaml`. Other prow installations which are using testgrid with config merger like [kubernetes](https://github.com/kubernetes/test-infra/blob/55148688b205182c75acf55c2d179f731127758a/config/prow/config.yaml#L19) and [kubevirt](https://github.com/kubevirt/project-infra/blob/863856a9ff5ec463ee9269493f0c4adc92f08f6b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml#L17) are using the same scheme without a `gs://`prefix 
