### PR TITLE
Increase CPU requests of unit and integration tests

### DIFF
--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -23,7 +23,7 @@ presubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: 4
+            cpu: 10
             memory: 8Gi
 periodics:
 - name: ci-gardener-integration
@@ -53,5 +53,5 @@ periodics:
         limits:
           memory: 16Gi
         requests:
-          cpu: 4
+          cpu: 10
           memory: 8Gi

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -29,7 +29,7 @@ presubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: 5
+            cpu: 12
             memory: 8Gi
 periodics:
 - name: ci-gardener-unit
@@ -65,5 +65,5 @@ periodics:
         limits:
           memory: 16Gi
         requests:
-          cpu: 5
+          cpu: 12
           memory: 8Gi

--- a/config/jobs/gardener/release/gardener-integration-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-integration-tests-release.yaml
@@ -24,7 +24,7 @@ presubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: 4
+            cpu: 10
             memory: 8Gi
 postsubmits:
   gardener/gardener:
@@ -53,5 +53,5 @@ postsubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: 4
+            cpu: 10
             memory: 8Gi

--- a/config/jobs/gardener/release/gardener-unit-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-unit-tests-release.yaml
@@ -30,7 +30,7 @@ presubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: 5
+            cpu: 12
             memory: 8Gi
 postsubmits:
   gardener/gardener:
@@ -65,5 +65,5 @@ postsubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: 5
+            cpu: 12
             memory: 8Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Integration and unit tests consume much more CPU than they currently requesting. This leads to high loads on the nodes which might be the reason for e2e test with timeouts.
This PR increases their CPU requests according to their CPU consumption.

**Special notes for your reviewer**:
Another reason for the failing e2e tests could be disk IO limitations. We could investigate this when the CPU request issue is solved.