### PR TITLE
Increased CPU requests for gardener e2e tests

### DIFF
--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
@@ -36,7 +36,7 @@ presubmits:
           limits:
             memory: 18Gi
           requests:
-            cpu: 5
+            cpu: 12
             memory: 9Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
@@ -86,7 +86,7 @@ periodics:
         limits:
           memory: 18Gi
         requests:
-          cpu: 5
+          cpu: 12
           memory: 9Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -30,7 +30,7 @@ presubmits:
           limits:
             memory: 18Gi
           requests:
-            cpu: 6
+            cpu: 12
             memory: 9Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
@@ -71,7 +71,7 @@ periodics:
         limits:
           memory: 18Gi
         requests:
-          cpu: 6
+          cpu: 12
           memory: 9Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -29,7 +29,7 @@ presubmits:
           limits:
             memory: 18Gi
           requests:
-            cpu: 5
+            cpu: 12
             memory: 9Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
@@ -70,7 +70,7 @@ periodics:
         limits:
           memory: 18Gi
         requests:
-          cpu: 5
+          cpu: 12
           memory: 9Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -23,7 +23,7 @@ presubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: 10
+            cpu: 5
             memory: 8Gi
 periodics:
 - name: ci-gardener-integration
@@ -53,5 +53,5 @@ periodics:
         limits:
           memory: 16Gi
         requests:
-          cpu: 10
+          cpu: 5
           memory: 8Gi

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -29,7 +29,7 @@ presubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: 12
+            cpu: 7
             memory: 8Gi
 periodics:
 - name: ci-gardener-unit
@@ -65,5 +65,5 @@ periodics:
         limits:
           memory: 16Gi
         requests:
-          cpu: 12
+          cpu: 7
           memory: 8Gi

--- a/config/jobs/gardener/release/gardener-e2e-kind-migration-release.yaml
+++ b/config/jobs/gardener/release/gardener-e2e-kind-migration-release.yaml
@@ -34,7 +34,7 @@ presubmits:
           limits:
             memory: 18Gi
           requests:
-            cpu: 6
+            cpu: 12
             memory: 9Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
@@ -77,7 +77,7 @@ postsubmits:
           limits:
             memory: 18Gi
           requests:
-            cpu: 6
+            cpu: 12
             memory: 9Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK

--- a/config/jobs/gardener/release/gardener-e2e-kind-release.yaml
+++ b/config/jobs/gardener/release/gardener-e2e-kind-release.yaml
@@ -32,7 +32,7 @@ presubmits:
           limits:
             memory: 18Gi
           requests:
-            cpu: 5
+            cpu: 12
             memory: 9Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
@@ -85,7 +85,7 @@ presubmits:
           limits:
             memory: 18Gi
           requests:
-            cpu: 5
+            cpu: 12
             memory: 9Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
@@ -127,7 +127,7 @@ postsubmits:
           limits:
             memory: 18Gi
           requests:
-            cpu: 5
+            cpu: 12
             memory: 9Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
@@ -181,7 +181,7 @@ postsubmits:
           limits:
             memory: 18Gi
           requests:
-            cpu: 5
+            cpu: 12
             memory: 9Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK

--- a/config/jobs/gardener/release/gardener-integration-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-integration-tests-release.yaml
@@ -24,7 +24,7 @@ presubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: 10
+            cpu: 5
             memory: 8Gi
 postsubmits:
   gardener/gardener:
@@ -53,5 +53,5 @@ postsubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: 10
+            cpu: 5
             memory: 8Gi

--- a/config/jobs/gardener/release/gardener-unit-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-unit-tests-release.yaml
@@ -30,7 +30,7 @@ presubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: 12
+            cpu: 7
             memory: 8Gi
 postsubmits:
   gardener/gardener:
@@ -65,5 +65,5 @@ postsubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: 12
+            cpu: 7
             memory: 8Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
The idea of https://github.com/gardener/ci-infra/pull/312 that high CPU consumptions of integration and unit tests have been the reason for flakey e2e tests was wrong.
e2e Tests themselves are creating big CPU loads which are not visible using Kubernetes APIs (maybe because of the docker in docker approach), but you can see them on the nodes. With the current CPU requests of 5 there could be 2 e2e tests running on one node at the same time. This leads to incredible loads from 200-500. We should avoid that and ensure that only one e2e test is running on one node.

On the other side integration and unit tests are not on the critical path, so it would be ok if there are throttled. By doing so, we can avoid using an entire node per test.