### PR TITLE
Remove skip-collaborators for gardener/gardener

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -41,10 +41,6 @@ blunderbuss:
   max_request_count: 2
   use_status_availability: true
 
-owners:
-  skip_collaborators:
-  - "gardener"  # Rely on OWNERS file for the whole organization
-
 heart:
   commentregexp: ".*"
 


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR removes `skip-collaborators` option for `gardener/gardener` repository and allows collaborators to `/lgtm` PRs.

Collaborators of `gardener/gardener` repository have been reworked before. People from outside the gardener-core team who should be able to `/lgtm` PRs are assigned [gardener-collaborators](https://github.com/orgs/gardener/teams/gardener-collaborators) group. This group was added as collaborator for `gardener/gardener`. 

When this PR is merged we could remove members of `gardener-collaborators´ from OWNERs file in g/g, that they are not automatically assigned for a review by blunderbuss anymore.
