### PR TITLE
Update shoot manifests with new route53 users

### DIFF
--- a/config/clusters/shoot-workload.yaml
+++ b/config/clusters/shoot-workload.yaml
@@ -13,8 +13,9 @@ spec:
   cloudProfileName: gcp
   dns:
     providers:
-      - secretName: aws-route53-ci
-        type: aws-route53
+    - secretName: gardener-cloud-route53-user
+      type: aws-route53
+      primary: false
   extensions:
     - type: shoot-cert-service
       providerConfig:

--- a/config/clusters/shoot.yaml
+++ b/config/clusters/shoot.yaml
@@ -13,8 +13,9 @@ spec:
   cloudProfileName: gcp
   dns:
     providers:
-      - secretName: aws-route53-ci
-        type: aws-route53
+    - secretName: gardener-cloud-route53-user
+      type: aws-route53
+      primary: false
   extensions:
     - type: shoot-cert-service
       providerConfig:
@@ -106,4 +107,3 @@ spec:
   purpose: production
   region: europe-west1
   secretBindingName: gcp-gardener-prow
-  


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

We added new dedicated route53 secrets/users to the `garden-ci` project. 
Update the shoot manifests accordingly to avoid overwriting it accidentally.
