### PR TITLE
Switch gardener jobs to go1.19

### DIFF
--- a/config/jobs/gardener/gardener-apidiff.yaml
+++ b/config/jobs/gardener/gardener-apidiff.yaml
@@ -10,7 +10,7 @@ presubmits:
     spec:
       containers:
       - name: test
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220816-52db243-1.18
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220816-52db243-1.19
         command:
         - make
         args:

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220816-52db243-1.18
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220816-52db243-1.19
         command:
         - make
         args:
@@ -44,7 +44,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220816-52db243-1.18
+      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220816-52db243-1.19
       command:
       - make
       args:

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -13,9 +13,9 @@ presubmits:
       description: Runs unit tests for gardener developments in pull requests
     spec:
       containers:
-      # Run all tests sequentially in one container or as separete prow jobs.
+      # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220816-52db243-1.18
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220816-52db243-1.19
         command:
         - make
         args:
@@ -49,9 +49,9 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    # Run all tests sequentially in one container or as separete prow jobs.
+    # Run all tests sequentially in one container or as separate prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220816-52db243-1.18
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220816-52db243-1.19
       command:
       - make
       args:

--- a/config/jobs/gardener/release/gardener-unit-tests-release.yaml
+++ b/config/jobs/gardener/release/gardener-unit-tests-release.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs unit tests for gardener releases in pull requests
     spec:
       containers:
-      # Run all tests sequentially in one container or as separete prow jobs.
+      # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
       - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220816-52db243-1.18
         command:
@@ -49,7 +49,7 @@ postsubmits:
       testgrid-days-of-results: "60"
     spec:
       containers:
-      # Run all tests sequentially in one container or as separete prow jobs.
+      # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
       - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220816-52db243-1.18
         command:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:

/kind task
Switch gardener jobs to go1.19

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6516

**Special notes for your reviewer**:

/hold
until https://github.com/gardener/gardener/pull/6522 is approved as unit tests / checks will fail on other tests because of https://github.com/gardener/gardener/issues/6516