### PR TITLE
Enforce push access for gardener-prow github app in branchprotector

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -62,6 +62,7 @@ periodics:
       args:
       - --config-path=config/prow/config.yaml
       - --confirm
+      - --enable-apps-restrictions=true
       - --job-config-path=config/jobs
       - --github-endpoint=http://ghproxy.prow.svc
       - --github-endpoint=https://api.github.com

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -134,11 +134,9 @@ branch-protection:
           required_status_checks:
             contexts:
             - license/cla
-          restrictions: # prevent everyone from pushing/merging
-            # NB: tide is running as GitHub App, which currently cannot be configured here to be excluded from branch
-            # protections (see https://github.com/kubernetes/test-infra/issues/24530).
-            # Hence, remember to manually add the `gardener-prow` GitHub App to all branch protection rules
-            # to allow tide to push/merge.
+          restrictions: # prevent everyone except gardener-prow from pushing/merging
+            apps:
+            - gardener-prow
             users: []
             teams: []
           enforce_admins: true # protections apply to admins as well
@@ -151,11 +149,9 @@ branch-protection:
             contexts:
             - license/cla
             - "Check Release Milestone"
-          restrictions: # prevent everyone from pushing/merging (except admins)
-            # NB: tide is running as GitHub App, which currently cannot be configured here to be excluded from branch
-            # protections (see https://github.com/kubernetes/test-infra/issues/24530).
-            # Hence, remember to manually add the `gardener-prow` GitHub App to all branch protection rules
-            # to allow tide to push/merge.
+          restrictions: # prevent everyone from pushing/merging (except admins and gardener-prow)
+            apps:
+            - gardener-prow
             users: []
             teams:
             - ci # allow CI users (e.g. concourse) to push (e.g. release commits)


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Now after https://github.com/kubernetes/test-infra/pull/26365 have been merged branchprotector is able to add gardener-prow github app to branch protecting rules.
