### PR TITLE
Promote `*-gardener-e2e-kind-migration` to required

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -6,7 +6,6 @@ presubmits:
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true
-    optional: true
     decoration_config:
       timeout: 60m
       grace_period: 15m

--- a/config/jobs/gardener/release/gardener-e2e-kind-migration-release.yaml
+++ b/config/jobs/gardener/release/gardener-e2e-kind-migration-release.yaml
@@ -7,7 +7,6 @@ presubmits:
     branches:
     - release-v\d+.\d+
     decorate: true
-    optional: true
     decoration_config:
       timeout: 60m
       grace_period: 15m


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:

/kind enhancement
Promote `*-gardener-e2e-kind-migration` to required

cc @plkokanov 