### PR TITLE
Deflake cherrypicker tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.3
+	github.com/google/go-cmp v0.5.9
 	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.2
 	github.com/pkg/errors v0.9.1
@@ -68,7 +69,6 @@ require (
 	github.com/gomodule/redigo v1.8.5 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-containerregistry v0.8.1-0.20220216220642-00c59d91847c // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea // indirect

--- a/prow/external-plugins/cherrypicker/README.md
+++ b/prow/external-plugins/cherrypicker/README.md
@@ -1,6 +1,6 @@
 # Cherrypicker
 
-**Note: This is a fork of [cherrypicker from kubernetes/test-infra (commit bfe9048)](https://github.com/kubernetes/test-infra/tree/bfe9048d19d1be1807ceccc2025b1b83abb9a0ba/prow/external-plugins/cherrypicker) repository.
+**Note: This is a fork of [cherrypicker from kubernetes/test-infra (commit 847e2b5)](https://github.com/kubernetes/test-infra/tree/847e2b5c2458150451f0c09da2c76dd463cb4a9f/prow/external-plugins/cherrypicker) repository.
 It changes the release note regexp to fit the gardener release note format**
 
 Cherrypicker is an external prow plugin that can also run as a standalone bot.

--- a/prow/external-plugins/cherrypicker/main.go
+++ b/prow/external-plugins/cherrypicker/main.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/test-infra/pkg/flagutil"
 	"k8s.io/test-infra/prow/config/secret"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
-	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/pjutil"
@@ -106,7 +105,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
-	gitClient, err := o.github.GitClient(o.dryRun)
+	gitClient, err := o.github.GitClientFactory("", nil, o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting Git client.")
 	}
@@ -135,7 +134,7 @@ func main() {
 		botUser:        botUser,
 		email:          email,
 
-		gc:  git.ClientFactoryFrom(gitClient),
+		gc:  gitClient,
 		ghc: githubClient,
 		log: log,
 

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -521,7 +521,7 @@ func (s *Server) handle(logger *logrus.Entry, requestor string, comment *github.
 			return fmt.Errorf("failed to add label %s: %w", label, err)
 		}
 	}
-	if !s.prowAssignments {
+	if s.prowAssignments {
 		if err := s.ghc.AssignIssue(org, repo, createdNum, []string{requestor}); err != nil {
 			logger.WithError(err).Warn("failed to assign to new PR")
 			// Ignore returning errors on failure to assign as this is most likely

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -23,9 +23,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/git/localgit"
+	v2 "k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
 )
 
@@ -57,7 +59,17 @@ func (f *fghc) AddLabel(org, repo string, number int, label string) error {
 }
 
 func (f *fghc) AssignIssue(org, repo string, number int, logins []string) error {
+	var users []github.User
+	for _, login := range logins {
+		users = append(users, github.User{Login: login})
+	}
+
 	f.Lock()
+	for i := range f.prs {
+		if number == f.prs[i].Number {
+			f.prs[i].Assignees = append(f.prs[i].Assignees, users...)
+		}
+	}
 	defer f.Unlock()
 	return nil
 }
@@ -222,6 +234,28 @@ index 1ea52dc..5bd70a9 100644
 
 var body = "This PR updates the magic number.\n\n```feature developer\nUpdate the magic number from 42 to 49\n```"
 
+func makeFakeRepoWithCommit(clients localgit.Clients, t *testing.T) (*localgit.LocalGit, v2.ClientFactory) {
+	lg, c, err := clients()
+	if err != nil {
+		t.Fatalf("Making localgit: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := lg.Clean(); err != nil {
+			t.Errorf("Cleaning up localgit: %v", err)
+		}
+		if err := c.Clean(); err != nil {
+			t.Errorf("Cleaning up client: %v", err)
+		}
+	})
+	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
+		t.Fatalf("Making fake repo: %v", err)
+	}
+	if err := lg.AddCommit("foo", "bar", initialFiles); err != nil {
+		t.Fatalf("Adding initial commit: %v", err)
+	}
+	return lg, c
+}
+
 func TestCherryPickIC(t *testing.T) {
 	t.Parallel()
 	testCherryPickIC(localgit.New, t)
@@ -233,24 +267,7 @@ func TestCherryPickICV2(t *testing.T) {
 }
 
 func testCherryPickIC(clients localgit.Clients, t *testing.T) {
-	lg, c, err := clients()
-	if err != nil {
-		t.Fatalf("Making localgit: %v", err)
-	}
-	defer func() {
-		if err := lg.Clean(); err != nil {
-			t.Errorf("Cleaning up localgit: %v", err)
-		}
-		if err := c.Clean(); err != nil {
-			t.Errorf("Cleaning up client: %v", err)
-		}
-	}()
-	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
-		t.Fatalf("Making fake repo: %v", err)
-	}
-	if err := lg.AddCommit("foo", "bar", initialFiles); err != nil {
-		t.Fatalf("Adding initial commit: %v", err)
-	}
+	lg, c := makeFakeRepoWithCommit(clients, t)
 	if err := lg.CheckoutNewBranch("foo", "bar", "stage"); err != nil {
 		t.Fatalf("Checking out pull branch: %v", err)
 	}
@@ -333,24 +350,7 @@ func TestCherryPickPRV2(t *testing.T) {
 }
 
 func testCherryPickPR(clients localgit.Clients, t *testing.T) {
-	lg, c, err := clients()
-	if err != nil {
-		t.Fatalf("Making localgit: %v", err)
-	}
-	defer func() {
-		if err := lg.Clean(); err != nil {
-			t.Errorf("Cleaning up localgit: %v", err)
-		}
-		if err := c.Clean(); err != nil {
-			t.Errorf("Cleaning up client: %v", err)
-		}
-	}()
-	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
-		t.Fatalf("Making fake repo: %v", err)
-	}
-	if err := lg.AddCommit("foo", "bar", initialFiles); err != nil {
-		t.Fatalf("Adding initial commit: %v", err)
-	}
+	lg, c := makeFakeRepoWithCommit(clients, t)
 	expectedBranches := []string{"release-1.5", "release-1.6", "release-1.8"}
 	for _, branch := range expectedBranches {
 		if err := lg.CheckoutNewBranch("foo", "bar", branch); err != nil {
@@ -508,24 +508,7 @@ func TestCherryPickOfCherryPickPRV2(t *testing.T) {
 // function works as intended when the user performs a cherry-pick from
 // a branch that's already a cherry-pick branch
 func testCherryPickOfCherryPickPR(clients localgit.Clients, t *testing.T) {
-	lg, c, err := clients()
-	if err != nil {
-		t.Fatalf("Making localgit: %v", err)
-	}
-	defer func() {
-		if err := lg.Clean(); err != nil {
-			t.Errorf("Cleaning up localgit: %v", err)
-		}
-		if err := c.Clean(); err != nil {
-			t.Errorf("Cleaning up client: %v", err)
-		}
-	}()
-	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
-		t.Fatalf("Making fake repo: %v", err)
-	}
-	if err := lg.AddCommit("foo", "bar", initialFiles); err != nil {
-		t.Fatalf("Adding initial commit: %v", err)
-	}
+	lg, c := makeFakeRepoWithCommit(clients, t)
 	expectedBranches := []string{"release-1.5", "release-1.6", "release-1.8"}
 	for _, branch := range expectedBranches {
 		if err := lg.CheckoutNewBranch("foo", "bar", branch); err != nil {
@@ -651,24 +634,7 @@ func TestCherryPickPRWithLabelsV2(t *testing.T) {
 }
 
 func testCherryPickPRWithLabels(clients localgit.Clients, t *testing.T) {
-	lg, c, err := clients()
-	if err != nil {
-		t.Fatalf("Making localgit: %v", err)
-	}
-	defer func() {
-		if err := lg.Clean(); err != nil {
-			t.Errorf("Cleaning up localgit: %v", err)
-		}
-		if err := c.Clean(); err != nil {
-			t.Errorf("Cleaning up client: %v", err)
-		}
-	}()
-	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
-		t.Fatalf("Making fake repo: %v", err)
-	}
-	if err := lg.AddCommit("foo", "bar", initialFiles); err != nil {
-		t.Fatalf("Adding initial commit: %v", err)
-	}
+	lg, c := makeFakeRepoWithCommit(clients, t)
 	if err := lg.CheckoutNewBranch("foo", "bar", "release-1.5"); err != nil {
 		t.Fatalf("Checking out pull branch: %v", err)
 	}
@@ -937,6 +903,91 @@ func TestCherryPickCreateIssue(t *testing.T) {
 			t.Fatalf(errMsg("comment"), expectedComment, actualComment)
 		}
 
+	}
+}
+
+func TestCherryPickPRAssignments(t *testing.T) {
+	t.Parallel()
+	testCherryPickPRAssignments(localgit.New, t)
+}
+
+func TestCherryPickPRAssignmentsV2(t *testing.T) {
+	t.Parallel()
+	testCherryPickPRAssignments(localgit.NewV2, t)
+}
+
+func testCherryPickPRAssignments(clients localgit.Clients, t *testing.T) {
+	for _, prowAssignments := range []bool{true, false} {
+		lg, c := makeFakeRepoWithCommit(clients, t)
+		if err := lg.CheckoutNewBranch("foo", "bar", "stage"); err != nil {
+			t.Fatalf("Checking out pull branch: %v", err)
+		}
+
+		user := github.User{
+			Login: "wiseguy",
+		}
+		ghc := &fghc{
+			pr: &github.PullRequest{
+				Base: github.PullRequestBranch{
+					Ref: "master",
+				},
+				Merged: true,
+				Title:  "This is a fix for X",
+				Body:   body,
+			},
+			isMember: true,
+			patch:    patch,
+		}
+		ic := github.IssueCommentEvent{
+			Action: github.IssueCommentActionCreated,
+			Repo: github.Repo{
+				Owner: github.User{
+					Login: "foo",
+				},
+				Name:     "bar",
+				FullName: "foo/bar",
+			},
+			Issue: github.Issue{
+				Number:      2,
+				State:       "closed",
+				PullRequest: &struct{}{},
+			},
+			Comment: github.IssueComment{
+				User: user,
+				Body: "/cherrypick stage",
+			},
+		}
+
+		botUser := &github.UserData{Login: "ci-robot", Email: "ci-robot@users.noreply.github.com"}
+		getSecret := func() []byte {
+			return []byte("sha=abcdefg")
+		}
+
+		s := &Server{
+			botUser:        botUser,
+			gc:             c,
+			push:           func(forkName, newBranch string, force bool) error { return nil },
+			ghc:            ghc,
+			tokenGenerator: getSecret,
+			log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
+			repos:          []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
+
+			prowAssignments: prowAssignments,
+		}
+
+		if err := s.handleIssueComment(logrus.NewEntry(logrus.StandardLogger()), ic); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var expected []github.User
+		if prowAssignments {
+			expected = append(expected, user)
+		}
+
+		got := ghc.prs[0].Assignees
+		if !cmp.Equal(got, expected) {
+			t.Errorf("Expected (%d):\n+%v\nGot (%d):\n%+v\n", len(expected), expected, len(got), got)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind flake

**What this PR does / why we need it**:
All occurrences of the flake described in the issue have in common that the git binary exits with status 128, which a is very generic error code.
On my local machine I was not able to reproduce this error, even after hundreds of runs.
~~When I checked some prow pods I noticed that the prow `clonerefs` init container is using an `emptyDir` as volume for /tmp where `git` writes its temporary files.~~
~~As `git` create lots of files and `emptyDir` has some performance advantages compared to the layered container file system, this might have an impact. However, I have no proof yet.~~
In my further investigations I noticed, that the same PR number (2) is used over and over again in different test.
Parallel running `git` clients might mess up the file systems of each other, because apparently [the same path is used multiple times](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-ci-infra-prow-go-tests/1540332851621269504#1:build-log.txt%3A141-142) in a test.
Thus, this PR creates unique PR numbers in cherrypicker tests.

**Which issue(s) this PR fixes**:
Fixes #300 

**Special notes for your reviewer**:
