### PR TITLE
Fix grafana network policy

### DIFF
--- a/config/prow/cluster/monitoring/base-prow/grafana-networkPolicy.yaml
+++ b/config/prow/cluster/monitoring/base-prow/grafana-networkPolicy.yaml
@@ -12,3 +12,6 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: ingress-nginx
+    ports:
+    - port: 3000
+      protocol: TCP

--- a/config/prow/cluster/monitoring/base-prow/grafana-networkPolicy.yaml
+++ b/config/prow/cluster/monitoring/base-prow/grafana-networkPolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx

--- a/config/prow/cluster/monitoring/base-prow/kustomization.yaml
+++ b/config/prow/cluster/monitoring/base-prow/kustomization.yaml
@@ -20,6 +20,7 @@ patchesStrategicMerge:
 - alertmanager-alertmanager.yaml
 - blackboxExporter-deployment.yaml
 - grafana-deployment.yaml
+- grafana-networkPolicy.yaml
 - kubeStateMetrics-deployment.yaml
 - nodeExporter-daemonset.yaml
 - prometheus.yaml


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Network policy for Grafana introduced with kube-prometheus v0.11.0 does not allow ingress traffic from ingress-nginx.
This PR allows ingress originated from the respective namespace.