### PR TITLE
Fix deployer permissions

### DIFF
--- a/config/prow/cluster/bootstrap-trusted/trusted_serviceaccounts.yaml
+++ b/config/prow/cluster/bootstrap-trusted/trusted_serviceaccounts.yaml
@@ -17,8 +17,17 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
   - namespaces
   - services
+  - services/finalizers
   - serviceaccounts
   - limitranges
   - persistentvolumeclaims
@@ -37,8 +46,11 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - endpoints
   - nodes
+  - nodes/metrics
+  - persistentvolumes
+  - replicationcontrollers
+  - resourcequotas
   verbs:
   - get
   - list
@@ -46,9 +58,21 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
   - pods
+  - services
+  - services/finalizers
   verbs:
   - delete
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -62,6 +86,28 @@ rules:
   - update
   - patch
 - apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - batch
   resources:
   - jobs
@@ -72,6 +118,14 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - policy
   resources:
@@ -86,6 +140,14 @@ rules:
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
   - validatingwebhookconfigurations
   verbs:
   - create
@@ -94,6 +156,26 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -111,6 +193,14 @@ rules:
 - apiGroups:
   - storage.k8s.io
   resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
   - storageclasses
   verbs:
   - create
@@ -125,6 +215,7 @@ rules:
   - ingresses
   - ingresses/status
   - ingressclasses
+  - networkpolicies
   verbs:
   - create
   - get
@@ -146,12 +237,20 @@ rules:
 - apiGroups:
   - monitoring.coreos.com
   resources:
+  - alertmanagerconfigs
   - alertmanagers
+  - alertmanagers/finalizers
+  - podmonitors
+  - probes
   - prometheuses
+  - prometheuses/finalizers
+  - prometheuses/status
   - prometheusrules
   - servicemonitors
-  - podmonitors
+  - thanosrulers
+  - thanosrulers/finalizers
   verbs:
+  - "*"
   - create
   - get
   - list
@@ -181,6 +280,10 @@ rules:
   - update
   - patch
   - delete
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
`deployer` service account did not have all permissions required to deploy kube-prometheus v0.11.0.
This PR adds the missing permissions.