### PR TITLE
Lower tide's sync period

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -159,7 +159,7 @@ branch-protection:
           allow_deletions: true # allow maintainers to delete outdated release branches
 
 tide:
-  sync_period: 2m
+  sync_period: 1m
   queries:
   - repos:
     - gardener/ci-infra


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:

Lower tide's sync period to `1m`, which is also the default ([ref](https://github.com/kubernetes/test-infra/blob/61ae301c157fd3a97e515132c3fe9f616a43c8b9/prow/config/prow-config-documented.yaml#L1331-L1332)).
This makes tide more responsive.
/kind enhancement