### PR TITLE
Route InfoInhibitor alert to null-receiver

### DIFF
--- a/config/prow/cluster/monitoring/base-prow/alertmanager/config.yaml
+++ b/config/prow/cluster/monitoring/base-prow/alertmanager/config.yaml
@@ -12,6 +12,10 @@ route:
   - receiver: 'null-receiver'
     matchers:
       - alertname=Watchdog
+  # InfoInhibitor is very noisy
+  - receiver: 'null-receiver'
+    matchers:
+      - alertname=InfoInhibitor
   # Metrics not visible in shoot cluster
   - receiver: 'null-receiver'
     matchers:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
`InfoInhibitor` alert spams our Slack, so let's route it to `null-receiver`