### PR TITLE
Increase cpu limit of kube-rbac-proxy in prometheus-operator

### DIFF
--- a/config/prow/cluster/monitoring/base-prow/kustomization.yaml
+++ b/config/prow/cluster/monitoring/base-prow/kustomization.yaml
@@ -24,6 +24,7 @@ patchesStrategicMerge:
 - kubeStateMetrics-deployment.yaml
 - nodeExporter-daemonset.yaml
 - prometheus.yaml
+- prometheusOperator-deployment.yaml
 
 secretGenerator:
 - name: alertmanager-main

--- a/config/prow/cluster/monitoring/base-prow/prometheusOperator-deployment.yaml
+++ b/config/prow/cluster/monitoring/base-prow/prometheusOperator-deployment.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-operator
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        resources:
+          limits:
+            # Increased CPU limit
+            cpu: 50m


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
kube-rbac-proxy of prometheus-operator produces many slack warning about cpu-throttling.