### PR TITLE
Add release milestone check for gardener release v1.55 to tide

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -163,7 +163,6 @@ tide:
   queries:
   - repos:
     - gardener/ci-infra
-    - gardener/gardener
     labels:
     - lgtm
     - approved
@@ -195,6 +194,45 @@ tide:
     - do-not-merge/work-in-progress
     - needs-rebase
     - "cla: no"
+  - repos:
+    - gardener/gardener
+    labels:
+    - lgtm
+    - approved
+    - "cla: yes"
+    missingLabels:
+    - do-not-merge/blocked-paths
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/needs-kind
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    - "cla: no"
+    excludedBranches:
+    - master
+  - repos:
+    - gardener/gardener
+    labels:
+    - lgtm
+    - approved
+    - "cla: yes"
+    missingLabels:
+    - do-not-merge/blocked-paths
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/needs-kind
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    - "cla: no"
+    milestone: v1.55
+    includedBranches:
+    - master
 
   context_options:
     # Use branch protection options to define required and optional contexts


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR enables milestone check for gardener release `v1.55` in Tide.

**Special notes for your reviewer**:
/hold until release milestone has been created in `gardener/gardener`
