### PR TITLE
Remove Milestone check from required statuses

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -148,7 +148,6 @@ branch-protection:
           required_status_checks:
             contexts:
             - license/cla
-            - "Check Release Milestone"
           restrictions: # prevent everyone from pushing/merging (except admins and gardener-prow)
             apps:
             - gardener-prow


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
/kind bug
Follow-up on https://github.com/gardener/gardener/pull/6627.
We need to remove the required status. Otherwise, no PRs can get merged.