### PR TITLE
Remove 'Check Release Milestone' check from branch protection for gar…

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -148,7 +148,6 @@ branch-protection:
           required_status_checks:
             contexts:
             - license/cla
-            - "Check Release Milestone"
           restrictions: # prevent everyone from pushing/merging (except admins and gardener-prow)
             apps:
             - gardener-prow


### PR DESCRIPTION
…dener/gardener

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/6627 removed the `Check Release Milestone` Github workflow, but it is still enforced by branchprotector.
This PR removes the workflow from branchprotector, that Tide is able to merge again.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
