### PR TITLE
Add govulncheck to CI for g/g repo

### DIFF
--- a/config/jobs/gardener/gardener-check-vulnerabilities.yaml
+++ b/config/jobs/gardener/gardener-check-vulnerabilities.yaml
@@ -30,6 +30,10 @@ periodics:
   decoration_config:
     timeout: 15m
     grace_period: 5m
+  annotations:
+    description: Runs go vulnerability checker for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
   spec:
     containers:
     - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220908-2a8314f-1.19

--- a/config/jobs/gardener/gardener-check-vulnerabilities.yaml
+++ b/config/jobs/gardener/gardener-check-vulnerabilities.yaml
@@ -1,0 +1,39 @@
+presubmits:
+  gardener/gardener:
+  - name: pull-gardener-check-vulnerabilities
+    cluster: gardener-prow-build
+    skip_if_only_changed: "^docs/|\\.(md|yaml)$"
+    decorate: true
+    decoration_config:
+      timeout: 15m
+      grace_period: 5m
+    optional: true
+    branches:
+    - ^master$
+    spec:
+      containers:
+      - name: test
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220908-2a8314f-1.19
+        command:
+        - make
+        args:
+        - check-vulnerabilities
+periodics:
+- name: ci-gardener-check-vulnerabilities
+  cluster: gardener-prow-build
+  interval: 24h
+  extra_refs:
+  - org: gardener
+    repo: gardener
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 15m
+    grace_period: 5m
+  spec:
+    containers:
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220908-2a8314f-1.19
+      command:
+      - make
+      args:
+      - check-vulnerabilities


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:
Adds an optional job on every PR as well as a periodic executed on every `24h` for gardener/gardener. This check will execute the new go vulnerability tool [govulncheck](https://go.dev/blog/vuln).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Depends on https://github.com/gardener/gardener/pull/6662