### PR TITLE
Add release milestone check for gardener release v1.56 to tide

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -214,28 +214,28 @@ tide:
   ### Release Milestone section starts here
   ### Please uncomment when setting a Release Milestone for gardener/gardener
   #############################################################################
-  #   excludedBranches:
-  #   - master
-  # - repos:
-  #   - gardener/gardener
-  #   labels:
-  #   - lgtm
-  #   - approved
-  #   - "cla: yes"
-  #   missingLabels:
-  #   - do-not-merge/blocked-paths
-  #   - do-not-merge/contains-merge-commits
-  #   - do-not-merge/hold
-  #   - do-not-merge/invalid-commit-message
-  #   - do-not-merge/invalid-owners-file
-  #   - do-not-merge/needs-kind
-  #   - do-not-merge/release-note-label-needed
-  #   - do-not-merge/work-in-progress
-  #   - needs-rebase
-  #   - "cla: no"
-  #   milestone: v1.56
-  #   includedBranches:
-  #   - master
+    excludedBranches:
+    - master
+  - repos:
+    - gardener/gardener
+    labels:
+    - lgtm
+    - approved
+    - "cla: yes"
+    missingLabels:
+    - do-not-merge/blocked-paths
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/needs-kind
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    - "cla: no"
+    milestone: v1.56
+    includedBranches:
+    - master
   ##############################################################################
   ### End of Release Milestone section
   ##############################################################################


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
This PR enables milestone check for gardener release v1.56 in Tide.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
