### PR TITLE
Add new prow jobs to run e2e HA tests

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -1,0 +1,79 @@
+presubmits:
+  gardener/gardener:
+  - name: pull-gardener-e2e-kind-ha-multi-zone
+    cluster: gardener-prow-build
+    always_run: true
+    skip_branches:
+    - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for gardener developments in pull requests
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20220916-2cde602c65-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - make ci-e2e-kind-ha-multi-zone
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: 12
+            memory: 9Gi
+        env:
+        - name: SKAFFOLD_UPDATE_CHECK
+          value: "false"
+        - name: SKAFFOLD_INTERACTIVE
+          value: "false"
+periodics:
+- name: ci-gardener-e2e-kind-ha-multi-zone
+  cluster: gardener-prow-build
+  interval: 4h
+  extra_refs:
+  - org: gardener
+    repo: gardener
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 60m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs end-to-end tests for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20220916-2cde602c65-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind-ha-multi-zone
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 18Gi
+        requests:
+          cpu: 12
+          memory: 9Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-single-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-single-ha-single-zone.yaml
@@ -1,0 +1,79 @@
+presubmits:
+  gardener/gardener:
+  - name: pull-gardener-e2e-kind-ha-single-zone
+    cluster: gardener-prow-build
+    always_run: true
+    skip_branches:
+    - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for gardener developments in pull requests
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20220916-2cde602c65-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - make ci-e2e-kind-ha-single-zone
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: 12
+            memory: 9Gi
+        env:
+        - name: SKAFFOLD_UPDATE_CHECK
+          value: "false"
+        - name: SKAFFOLD_INTERACTIVE
+          value: "false"
+periodics:
+- name: ci-gardener-e2e-kind-ha-single-zone
+  cluster: gardener-prow-build
+  interval: 4h
+  extra_refs:
+  - org: gardener
+    repo: gardener
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 60m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs end-to-end tests for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20220916-2cde602c65-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind-ha-single-zone
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          memory: 18Gi
+        requests:
+          cpu: 12
+          memory: 9Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"


### PR DESCRIPTION
/kind enhancement

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
This PR introduces two prow jobs to run HA e2e tests
 

- `pull-gardener-e2e-kind-ha-single-zone`

This will create a e2e kind setup with multiple kind workers to support **HA** `single-zone`  shoot's control-plane and it runs e2e tests.

- `pull-gardener-e2e-kind-ha-multi-zone`

This will create a e2e kind setup with multiple kind workers to support **HA** `multi-zone`  shoot's control-plane and it runs e2e tests.


**Special notes for your reviewer**:
This will be merged after  https://github.com/gardener/gardener/pull/6719

