### PR TITLE
Fix label-sync job

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -23,7 +23,7 @@ periodics:
       args:
       - --config=config/prow/labels.yaml
       - --confirm=true
-      - --only=gardener/ci-infra,gardener/gardener,gardener-extension-registry-cache,gardener/gardener-extension-shoot-oidc-service
+      - --only=gardener/ci-infra,gardener/gardener,gardener/gardener-extension-registry-cache,gardener/gardener-extension-shoot-oidc-service
       - --endpoint=http://ghproxy.prow.svc
       - --endpoint=https://api.github.com
       # TODO: switch to GitHub App Auth, once it's implemented in label_sync


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
This PR fixes the `label-sync` job which was broken by https://github.com/gardener/ci-infra/pull/414

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timebertt 
