### PR TITLE
Add prow jobs for gardener-extension-registry-cache repo

### DIFF
--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-build-images.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-build-images.yaml
@@ -1,0 +1,47 @@
+postsubmits:
+  gardener/gardener-extension-registry-cache:
+  - name: post-gardener-extension-registry-cache-build-images
+    cluster: gardener-prow-trusted
+    branches:
+    - ^main$
+    annotations:
+      description: Gardener extension registry-cache image build on main branch
+      testgrid-dashboards: gardener-extension-registry-cache
+      testgrid-days-of-results: "60"
+    decorate: true
+    max_concurrency: 1
+    spec:
+      serviceAccountName: image-builder
+      containers:
+      - name: image-builder
+        image: eu.gcr.io/gardener-project/ci-infra/image-builder:v20220908-8116cd8
+        command:
+        - /image-builder
+        args:
+        - --log-level=info
+        - --docker-config-secret=gardener-prow-gcr-docker-config
+        - --registry=eu.gcr.io/gardener-project/gardener-extension-registry-cache
+        - --cache-registry=eu.gcr.io/gardener-project/ci-infra/kaniko-cache
+        - --target=gardener-extension-registry-cache
+        - --target=gardener-extension-registry-cache-admission
+        - --add-version-tag=true
+        - --add-version-sha-tag=true
+        - --add-fixed-tag=latest
+        # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
+        # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted
+        # to multiple build pods in parallel.
+        # For a proper scheduling the combined resource requests of all build pods are assigned to this pod, even though it does not
+        # use them. The resource requests of build pods themselves are "0"
+        resources:
+          requests:
+            cpu: 6
+            memory: 9Gi
+      # Node selector is copied to build pods
+      nodeSelector:
+        dedicated: high-cpu
+      # Tolerations are copied to build pods
+      tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "high-cpu"
+        effect: "NoSchedule"

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-build-images.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-build-images.yaml
@@ -20,7 +20,7 @@ postsubmits:
         args:
         - --log-level=info
         - --docker-config-secret=gardener-prow-gcr-docker-config
-        - --registry=eu.gcr.io/gardener-project/gardener-extension-registry-cache
+        - --registry=eu.gcr.io/gardener-project/gardener/extensions
         - --cache-registry=eu.gcr.io/gardener-project/ci-infra/kaniko-cache
         - --target=gardener-extension-registry-cache
         - --target=gardener-extension-registry-cache-admission

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-test-builds.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-test-builds.yaml
@@ -1,0 +1,22 @@
+presubmits:
+  gardener/gardener-extension-registry-cache:
+  - name: pull-gardener-extension-registry-cache-verify-image-build
+    cluster: gardener-prow-build
+    always_run: true
+    annotations:
+      description: Verify Gardener extension registry-cache image build on pull requests
+    decorate: true
+    spec:
+      containers:
+      - name: kaniko
+        image: gcr.io/kaniko-project/executor:v1.8.1
+        command:
+        - /kaniko/executor
+        args:
+        - --context=/home/prow/go/src/github.com/gardener/gardener-extension-registry-cache
+        - --dockerfile=Dockerfile
+        - --no-push
+        resources:
+          requests:
+            cpu: 6
+            memory: 9Gi

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
@@ -1,0 +1,63 @@
+presubmits:
+  gardener/gardener-extension-registry-cache:
+  - name: pull-gardener-extension-registry-cache-unit
+    cluster: gardener-prow-build
+    always_run: true
+    decorate: true
+    decoration_config:
+      timeout: 40m
+      grace_period: 10m
+    annotations:
+      description: Runs unit tests for Gardener extension registry-cache developments in pull requests
+    spec:
+      containers:
+      # Run all tests sequentially in one container or as separate prow jobs.
+      # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220908-2a8314f-1.19
+        command:
+        - make
+        args:
+        - check-generate
+        - check
+        - format
+        - test
+        resources:
+          limits:
+            memory: 16Gi
+          requests:
+            cpu: 4
+            memory: 8Gi
+periodics:
+- name: ci-gardener-extension-registry-cache-unit
+  cluster: gardener-prow-build
+  interval: 4h
+  extra_refs:
+  - org: gardener
+    repo: gardener-extension-registry-cache
+    base_ref: main
+  decorate: true
+  decoration_config:
+    timeout: 40m
+    grace_period: 10m
+  annotations:
+    description: Runs unit tests for Gardener extension registry-cache developments periodically
+    testgrid-dashboards: gardener-extension-registry-cache
+    testgrid-days-of-results: "60"
+  spec:
+    containers:
+    # Run all tests sequentially in one container or as separate prow jobs.
+    # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20220908-2a8314f-1.19
+      command:
+      - make
+      args:
+      - check-generate
+      - check
+      - format
+      - test
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          cpu: 4
+          memory: 8Gi

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -3,9 +3,11 @@ dashboard_groups:
   dashboard_names:
     - gardener-gardener
     - gardener-ci-infra
+    - gardener-extension-registry-cache
     - gardener-extension-shoot-oidc-service
 
 dashboards:
 - name: gardener-gardener
 - name: gardener-ci-infra
+- name: gardener-extension-registry-cache
 - name: gardener-extension-shoot-oidc-service


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds `prow` jobs for unit tests and image builds of `gardener-extension-registry-cache` repository.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
These are test runs of these jobs:
[ci-gardener-extension-registry-cache-unit](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-extension-registry-cache-unit/1575549905517154304)
[pull-gardener-extension-registry-cache-unit](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener-extension-registry-cache/1/pull-gardener-extension-registry-cache-unit/1575550327208284160)
[pull-gardener-extension-registry-cache-verify-image-build](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener-extension-registry-cache/1/pull-gardener-extension-registry-cache-verify-image-build/1575550679802449920)
[post-gardener-extension-registry-cache-build-images](https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-gardener-extension-registry-cache-build-images/1575551039292051456)
