### PR TITLE
Fix release milestone check for gardener/gardener

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -225,23 +225,6 @@ tide:
     - do-not-merge/work-in-progress
     - needs-rebase
     - "cla: no"
-  - repos:
-    - gardener/gardener-extension-registry-cache
-    labels:
-    - lgtm
-    - approved
-    - "cla: yes"
-    missingLabels:
-    - do-not-merge/blocked-paths
-    - do-not-merge/contains-merge-commits
-    - do-not-merge/hold
-    - do-not-merge/invalid-commit-message
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/needs-kind
-    - do-not-merge/release-note-label-needed
-    - do-not-merge/work-in-progress
-    - needs-rebase
-    - "cla: no"
   #############################################################################
   ### Release Milestone section starts here
   ### Please uncomment when setting a Release Milestone for gardener/gardener
@@ -271,6 +254,23 @@ tide:
   ##############################################################################
   ### End of Release Milestone section
   ##############################################################################
+  - repos:
+    - gardener/gardener-extension-registry-cache
+    labels:
+    - lgtm
+    - approved
+    - "cla: yes"
+    missingLabels:
+    - do-not-merge/blocked-paths
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/needs-kind
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    - "cla: no"
 
   context_options:
     # Use branch protection options to define required and optional contexts


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind regression

**What this PR does / why we need it**:
Correct `excludedBranches` directive for `gardener/gardener` which was at the wrong repo (`gardener/gardener-extension-registry-cache`).