### PR TITLE
Change registry-cache build targets

### DIFF
--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-build-images.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-build-images.yaml
@@ -22,8 +22,8 @@ postsubmits:
         - --docker-config-secret=gardener-prow-gcr-docker-config
         - --registry=eu.gcr.io/gardener-project/gardener/extensions
         - --cache-registry=eu.gcr.io/gardener-project/ci-infra/kaniko-cache
-        - --target=gardener-extension-registry-cache
-        - --target=gardener-extension-registry-cache-admission
+        - --target=registry-cache
+        - --target=registry-cache-admission
         - --add-version-tag=true
         - --add-version-sha-tag=true
         - --add-fixed-tag=latest


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
https://github.com/gardener/gardener-extension-registry-cache/pull/2 changes the build targets in Dockerfile.
/cc @timebertt 
