### PR TITLE
Fix dependency-watchdog repos

### DIFF
--- a/config/jobs/dependency-watchdog/dependency-watchdog-build-dev-images.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-build-dev-images.yaml
@@ -1,5 +1,5 @@
 postsubmits:
-  gardener/gardener:
+  gardener/dependency-watchdog:
   - name: post-dependency-watchdog-build-dev-images
     cluster: gardener-prow-trusted
     skip_if_only_changed: '^VERSION$'

--- a/config/jobs/dependency-watchdog/dependency-watchdog-check-vulnerabilities.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-check-vulnerabilities.yaml
@@ -1,5 +1,5 @@
 presubmits:
-  gardener/gardener:
+  gardener/dependency-watchdog:
   - name: pull-dependency-watchdog-check-vulnerabilities
     cluster: gardener-prow-build
     skip_if_only_changed: "^docs/|\\.(md|yaml)$"

--- a/config/jobs/dependency-watchdog/dependency-watchdog-test-builds.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-test-builds.yaml
@@ -1,5 +1,5 @@
 presubmits:
-  gardener/gardener:
+  gardener/dependency-watchdog:
   - name: pull-dependency-watchdog-verify-image-build
     cluster: gardener-prow-build
     always_run: true

--- a/config/jobs/dependency-watchdog/dependency-watchdog-unit-tests.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-unit-tests.yaml
@@ -1,5 +1,5 @@
 presubmits:
-  gardener/gardener-extension-registry-cache:
+  gardener/dependency-watchdog:
   - name: pull-dependency-watchdog-unit
     cluster: gardener-prow-build
     always_run: true


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Some repos in https://github.com/gardener/ci-infra/pull/435 have been wrong 😓 