### PR TITLE
Increase memory request of e2e tests

### DIFF
--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
@@ -33,11 +33,9 @@ presubmits:
         securityContext:
           privileged: true
         resources:
-          limits:
-            memory: 18Gi
           requests:
             cpu: 12
-            memory: 9Gi
+            memory: 18Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -83,11 +81,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
-        limits:
-          memory: 18Gi
         requests:
           cpu: 12
-          memory: 9Gi
+          memory: 18Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -27,11 +27,9 @@ presubmits:
         securityContext:
           privileged: true
         resources:
-          limits:
-            memory: 18Gi
           requests:
             cpu: 12
-            memory: 9Gi
+            memory: 64Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -68,11 +66,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
-        limits:
-          memory: 18Gi
         requests:
           cpu: 12
-          memory: 9Gi
+          memory: 64Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
@@ -27,11 +27,9 @@ presubmits:
         securityContext:
           privileged: true
         resources:
-          limits:
-            memory: 18Gi
           requests:
             cpu: 12
-            memory: 9Gi
+            memory: 64Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -68,11 +66,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
-        limits:
-          memory: 18Gi
         requests:
           cpu: 12
-          memory: 9Gi
+          memory: 64Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -26,11 +26,9 @@ presubmits:
         securityContext:
           privileged: true
         resources:
-          limits:
-            memory: 18Gi
           requests:
             cpu: 12
-            memory: 9Gi
+            memory: 18Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -67,11 +65,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
-        limits:
-          memory: 18Gi
         requests:
           cpu: 12
-          memory: 9Gi
+          memory: 18Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -26,11 +26,9 @@ presubmits:
         securityContext:
           privileged: true
         resources:
-          limits:
-            memory: 18Gi
           requests:
             cpu: 12
-            memory: 9Gi
+            memory: 18Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -67,11 +65,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
-        limits:
-          memory: 18Gi
         requests:
           cpu: 12
-          memory: 9Gi
+          memory: 18Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR increases memory requests of e2e test.
Most importantly is the increase for HA e2e tests to 64Gi, because they seem to request much more memory than the standard e2e tests.
Additionally, memory limits for e2e tests are removed. They are not enforced anyway, because the memory is not requested by the pod of the prow job itself, but the docker container it is starting.  

