### PR TITLE
Report test failures and mergewarnings to Gardener Slack workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,18 @@ The following commands assume you are using the combined `kubeconfig` generated 
           user:
             token: <<service-account-token-with-cluster-admin-permissions>> # generated via gencred
         ```
-    - `slack-token` (according to [test-infra guide](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/crier/README.md#slack-reporter))
-    - `alertmanager-slack` (needs to be present in the `monitoring` namespace of the prow trusted and build cluster)
-      - Follow https://api.slack.com/incoming-webhooks and setup a webhook.
-      - Create the secret including the Webhook URL under key `api_url`.
+    - `slack-token` for the `Gardener Prow` Slack App in the [Gardener Project workspace](https://gardener-cloud.slack.com/)
+      - follow the [test-infra guide](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/crier/README.md#slack-reporter) for setting up the Slack App
+      - this is used by crier to report job status changes (e.g., test failures) to dedicated Slack channels
+      - generally, failures/errors of `periodic`, `postsubmit` and `batch` jobs are reported to [`#test-failures`](https://gardener-cloud.slack.com/archives/C046PHX7ACR)
+      - job status changes concerning the prow infrastructure itself (e.g., deploy and autobump jobs) are reported to [`#prow-alerts`](https://gardener-cloud.slack.com/archives/C04680KRF8D)
+      - this token is also used by hook (`slack` plugin) to post merge warnings to [`#prow-alerts`](https://gardener-cloud.slack.com/archives/C04680KRF8D)
+    - `alertmanager-slack`: URLs for incoming webhooks for the [#gardener-prow-alerts](https://sap-ti.slack.com/archives/C02P7MSTJHJ) channel in the SAP Slack workspace
+      - alertmanager instances in both clusters use an incoming webhook to post monitoring alerts to Slack
+      - different webhooks are used for the two instances
+      - for both clusters (prow-trusted and prow-build) do the following:
+        - follow https://api.slack.com/incoming-webhooks and set up a webhook for posting to `#gardener-prow-alerts`
+        - create a secret in the `monitoring` namespace of the respective cluster with the Webhook URL under key `api_url`
     - `grafana-admin` (admin user password)
       ```bash
       kubectl config use-context gardener-prow-trusted
@@ -155,7 +163,7 @@ A monitoring stack based on [kube-prometheus](https://github.com/prometheus-oper
 - kube-state-metrics
 - grafana
 
-Alertmanager will send Slack alerts in `#gardener-prow-alerts` (SAP-internal workspace).
+Alertmanager will send Slack alerts in [`#gardener-prow-alerts`](https://sap-ti.slack.com/archives/C02P7MSTJHJ) in the SAP Slack workspace.
 
 Grafana is available publicly at https://monitoring.prow.gardener.cloud (trusted cluster) and https://monitoring-build.prow.gardener.cloud (build cluster).
 

--- a/config/jobs/ci-infra/build-ci-infra-images.yaml
+++ b/config/jobs/ci-infra/build-ci-infra-images.yaml
@@ -14,7 +14,7 @@ postsubmits:
     max_concurrency: 1
     reporter_config:
       slack:
-        channel: "gardener-prow-alerts"
+        channel: prow-alerts
     spec:
       serviceAccountName: image-builder
       containers:

--- a/config/jobs/ci-infra/build-golang-test-image.yaml
+++ b/config/jobs/ci-infra/build-golang-test-image.yaml
@@ -13,7 +13,7 @@ postsubmits:
     max_concurrency: 1
     reporter_config:
       slack:
-        channel: "gardener-prow-alerts"
+        channel: prow-alerts
     spec:
       serviceAccountName: image-builder
       containers:

--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -11,7 +11,7 @@ periodics:
     base_ref: master
   reporter_config:
     slack:
-      channel: "gardener-prow-alerts"
+      channel: prow-alerts
   annotations:
     description: Runs label_sync to synchronize GitHub repo labels with the label config defined in config/prow/labels.yaml
     testgrid-create-test-group: "false"
@@ -86,7 +86,7 @@ periodics:
     base_ref: master
   reporter_config:
     slack:
-      channel: "gardener-prow-alerts"
+      channel: prow-alerts
   annotations:
     description: Runs autobumper to create/update a PR that bumps prow images to the latest published version
     testgrid-create-test-group: "false"
@@ -117,7 +117,7 @@ periodics:
     base_ref: master
   reporter_config:
     slack:
-      channel: "gardener-prow-alerts"
+      channel: prow-alerts
   annotations:
     description: Runs autobumper to create/update and auto-merge a PR that bumps prow images to the latest published version
     testgrid-create-test-group: "false"
@@ -148,7 +148,7 @@ periodics:
     base_ref: master
   reporter_config:
     slack:
-      channel: "gardener-prow-alerts"
+      channel: prow-alerts
   annotations:
     description: Runs autobumper to create/update a PR that bumps prowjob images to latest published version
     testgrid-create-test-group: "false"
@@ -179,7 +179,7 @@ periodics:
     base_ref: master
   reporter_config:
     slack:
-      channel: "gardener-prow-alerts"
+      channel: prow-alerts
   annotations:
     description: Runs autobumper to create/update and auto-merge a PR that bumps prowjob images to latest published version
     testgrid-create-test-group: "false"
@@ -213,7 +213,7 @@ periodics:
     base_ref: master
   reporter_config:
     slack:
-      channel: "gardener-prow-alerts"
+      channel: prow-alerts
   annotations:
     description: Runs checkconfig to validate job configs, config.yaml and friends. Used as heartbeat job for alerts.
     testgrid-create-test-group: "false"
@@ -245,7 +245,7 @@ periodics:
     base_ref: master
   reporter_config:
     slack:
-      channel: "gardener-prow-alerts"
+      channel: prow-alerts
   annotations:
     description: Runs checkconfig to validate job configs, config.yaml and friends. Used as heartbeat job for alerts.
     testgrid-create-test-group: "false"
@@ -276,7 +276,7 @@ periodics:
     base_ref: master
   reporter_config:
     slack:
-      channel: "gardener-prow-alerts"
+      channel: prow-alerts
   decorate: true
   annotations:
     description: Runs go tests for prow developments in ci-infra

--- a/config/jobs/ci-infra/ci-infra-postsubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
     max_concurrency: 1
     reporter_config:
       slack:
-        channel: "gardener-prow-alerts"
+        channel: prow-alerts
         job_states_to_report:
         - success
         - failure

--- a/config/jobs/common/issue-pr-lifecycle.yaml
+++ b/config/jobs/common/issue-pr-lifecycle.yaml
@@ -5,7 +5,7 @@ periodics:
   decorate: true
   reporter_config:
     slack:
-      channel: "gardener-prow-alerts" 
+      channel: prow-alerts
   annotations:
     description: Closes rotten issues after 30d of inactivity
     testgrid-create-test-group: "false"
@@ -52,7 +52,7 @@ periodics:
   decorate: true
   reporter_config:
     slack:
-      channel: "gardener-prow-alerts"
+      channel: prow-alerts
   annotations:
     description: Adds lifecycle/rotten to stale issues after 30d of inactivity
     testgrid-create-test-group: "false"
@@ -100,7 +100,7 @@ periodics:
   decorate: true
   reporter_config:
     slack:
-      channel: "gardener-prow-alerts"
+      channel: prow-alerts
   annotations:
     description: Adds lifecycle/stale to issues after 90d of inactivity
     testgrid-create-test-group: "false"

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -117,7 +117,7 @@ slack_reporter_configs:
     job_states_to_report:
       - failure
       - error
-    channel: gardener-test-failures
+    channel: test-failures
     report_template: |
       *Job:* {{.Spec.Job}} ({{.Spec.Type}})
       *Status:* {{.Status.State}}

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -54,13 +54,13 @@ slack:
   - repos:
     - gardener/ci-infra
     channels:
-    - gardener-prow-alerts
+    - prow-alerts
     exempt_users:
     - gardener-prow[bot]
   - repos:
     - gardener/gardener
     channels:
-    - gardener-prow-alerts
+    - prow-alerts
     exempt_users:
     - gardener-prow[bot]
     - gardener-robot-ci-1
@@ -69,7 +69,7 @@ slack:
   - repos:
     - gardener/gardener-extension-registry-cache
     channels:
-    - gardener-prow-alerts
+    - prow-alerts
     exempt_users:
     - gardener-prow[bot]
 


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Switch prow's config to report test failures and mergewarnings to the [Gardener Slack workspace](https://gardener-cloud.slack.com/) instead of the SAP Slack workspace.

**Special notes for your reviewer**:

This PR only includes the config change required for this move.
@oliver-goetz will update the Slack App token in the cluster together with merging this PR.
/hold