### PR TITLE
Update golangci to v1.50.1

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,6 @@
 run:
   concurrency: 4
   deadline: 10m
-  # some of the linters don't work correctly with 1.18, ref https://github.com/golangci/golangci-lint/issues/2649
-  # we are not using generics, so let's pin this to 1.17 until 1.18 is fully supported
-  go: "1.17"
 
   skip-files:
   - ".*\\.pb\\.go$"

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -25,7 +25,7 @@ GOIMPORTS                  := $(TOOLS_BIN_DIR)/goimports
 GOLANGCI_LINT              := $(TOOLS_BIN_DIR)/golangci-lint
 
 # default tool versions
-GOLANGCI_LINT_VERSION ?= v1.46.2
+GOLANGCI_LINT_VERSION ?= v1.50.1
 
 export TOOLS_BIN_DIR := $(TOOLS_BIN_DIR)
 export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Update `golangci` to v1.50.1: [ref](https://github.com/golangci/golangci-lint/releases/tag/v1.50.1)
The go 1.18 issue seems to be fixed, so there is no need to run it on go 1.17 anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
