### PR TITLE
Reduce memory request of HA e2e tests

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -29,7 +29,7 @@ presubmits:
         resources:
           requests:
             cpu: 12
-            memory: 64Gi
+            memory: 48Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -68,7 +68,7 @@ periodics:
       resources:
         requests:
           cpu: 12
-          memory: 64Gi
+          memory: 48Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
@@ -29,7 +29,7 @@ presubmits:
         resources:
           requests:
             cpu: 12
-            memory: 64Gi
+            memory: 48Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -68,7 +68,7 @@ periodics:
       resources:
         requests:
           cpu: 12
-          memory: 64Gi
+          memory: 48Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR reduces memory request of HA e2e tests to 48GB that they can run on nodes with 64GB memory.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke 
