### PR TITLE
Activate job-forker for gardener/gardener

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -76,6 +76,41 @@ periodics:
       secret:
         secretName: github-token
 
+- cron: "44 * * * *"  # Every hour a couple of minutes before branchprotector
+  name: ci-job-forker-gardener-gardener
+  cluster: gardener-prow-trusted
+  decorate: true
+  annotations:
+    description: Fork gardener/gardener prow jobs for release branches
+    testgrid-create-test-group: "false"
+  reporter_config:
+    slack:
+      channel: prow-alerts
+  spec:
+    containers:
+    - image: eu.gcr.io/gardener-project/ci-infra/job-forker:v20221103-fb04192
+      command:
+      - /job-forker
+      args:
+      - --github-token-path=/etc/github-token/token
+      - --github-endpoint=http://ghproxy
+      - --github-endpoint=https://api.github.com
+      - --dry-run=false
+      - --job-directory=config/jobs/gardener
+      - --recursive=true
+      - --upstream-repository=gardener/ci-infra
+      - --upstream-branch=master
+      # Add skip-review to --override-labels when we tested it for a while
+      - --override-labels=kind/enhancement
+      volumeMounts:
+      - name: github-token
+        mountPath: /etc/github-token
+        readOnly: true
+    volumes:
+    - name: github-token
+      secret:
+        secretName: github-token
+
 - cron: "30 * * * 1-5"
   name: ci-prow-autobump
   cluster: gardener-prow-trusted

--- a/config/jobs/gardener/gardener-build-dev-images.yaml
+++ b/config/jobs/gardener/gardener-build-dev-images.yaml
@@ -9,6 +9,7 @@ postsubmits:
       description: Gardener development image build on master branch
       testgrid-dashboards: gardener-gardener
       testgrid-days-of-results: "60"
+      fork-per-release: "true"
     decorate: true
     max_concurrency: 1
     spec:

--- a/config/jobs/gardener/gardener-e2e-kind-ha-node.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-node.yaml
@@ -15,6 +15,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       description: Runs end-to-end tests on a Seed with 3 zones with a Shoot with failure tolerance type 'node' for gardener developments in pull requests
+      fork-per-release: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20221007-a06f7d6a2c-master
@@ -54,6 +55,7 @@ periodics:
     description: Runs end-to-end tests on a Seed with 3 zones with a Shoot with failure tolerance type 'node' for gardener developments periodically
     testgrid-dashboards: gardener-gardener
     testgrid-days-of-results: "60"
+    fork-per-release: "true"
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/krte:v20221007-a06f7d6a2c-master

--- a/config/jobs/gardener/gardener-e2e-kind-ha-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-zone.yaml
@@ -15,6 +15,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       description: Runs end-to-end tests on a Seed with 3 zones with a Shoot with failure tolerance type 'zone' for gardener developments in pull requests
+      fork-per-release: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20221007-a06f7d6a2c-master
@@ -54,6 +55,7 @@ periodics:
     description: Runs end-to-end tests on a Seed with 3 zones with a Shoot with failure tolerance type 'zone' for gardener developments periodically
     testgrid-dashboards: gardener-gardener
     testgrid-days-of-results: "60"
+    fork-per-release: "true"
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/krte:v20221007-a06f7d6a2c-master

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -14,6 +14,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       description: Runs control plane migration end-to-end tests for gardener developments in pull requests
+      fork-per-release: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20221007-a06f7d6a2c-master
@@ -53,6 +54,7 @@ periodics:
     description: Runs control plane migration end-to-end tests for gardener developments periodically
     testgrid-dashboards: gardener-gardener
     testgrid-days-of-results: "60"
+    fork-per-release: "true"
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/krte:v20221007-a06f7d6a2c-master

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -14,6 +14,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     annotations:
       description: Runs end-to-end tests for gardener developments in pull requests
+      fork-per-release: "true"
     spec:
       containers:
       - image: gcr.io/k8s-staging-test-infra/krte:v20221007-a06f7d6a2c-master
@@ -53,6 +54,7 @@ periodics:
     description: Runs end-to-end tests for gardener developments periodically
     testgrid-dashboards: gardener-gardener
     testgrid-days-of-results: "60"
+    fork-per-release: "true"
   spec:
     containers:
     - image: gcr.io/k8s-staging-test-infra/krte:v20221007-a06f7d6a2c-master

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -11,6 +11,7 @@ presubmits:
       grace_period: 10m
     annotations:
       description: Runs integration tests for gardener developments in pull requests
+      fork-per-release: "true"
     spec:
       containers:
       - name: test-integration
@@ -41,6 +42,7 @@ periodics:
     description: Runs integration tests for gardener developments periodically
     testgrid-dashboards: gardener-gardener
     testgrid-days-of-results: "60"
+    fork-per-release: "true"
   spec:
     containers:
     - name: test-integration

--- a/config/jobs/gardener/gardener-test-builds.yaml
+++ b/config/jobs/gardener/gardener-test-builds.yaml
@@ -7,6 +7,7 @@ presubmits:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     annotations:
       description: Verify gardener image build on pull requests to master branch
+      fork-per-release: "true"
     decorate: true
     spec:
       containers:
@@ -28,6 +29,7 @@ presubmits:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     annotations:
       description: Publish gardener development images on pull requests
+      fork-per-release: "true"
     decorate: true
     optional: true
     spec:

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -11,6 +11,7 @@ presubmits:
       grace_period: 10m
     annotations:
       description: Runs unit tests for gardener developments in pull requests
+      fork-per-release: "true"
     spec:
       containers:
       # Run all tests sequentially in one container or as separate prow jobs.
@@ -47,6 +48,7 @@ periodics:
     description: Runs unit tests for gardener developments periodically
     testgrid-dashboards: gardener-gardener
     testgrid-days-of-results: "60"
+    fork-per-release: "true"
   spec:
     containers:
     # Run all tests sequentially in one container or as separate prow jobs.


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR activates job-forker for `gardener/gardener`. 
Job-forker runs every hour and copies prow jobs annotated by `fork-per-release: "true"` for all release branches in gardener/gardener, adapts the branch names and creates a PR in `gardener/ci-infra` for the changes. After they are forked, they are not updated anymore by job-forker, to avoid problems with changing tests or go versions.
Orphaned prow jobs for deleted release branches are deleted, again by opening a PR.

This will replace the prow-jobs in `config/jobs/gardener/release` directory.
When job-forker is running for the first time, it will create prow job forks for all release branches. I will adapt them manually, that they do not include wrong configurations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke maybe we can test it with the release v1.59 😄 
