### PR TITLE
Update kubectl image to v1.24.7

### DIFF
--- a/config/jobs/ci-infra/ci-infra-postsubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-postsubmits.yaml
@@ -27,7 +27,7 @@ postsubmits:
     spec:
       serviceAccountName: deployer
       containers:
-      - image: bitnami/kubectl:1.22.10
+      - image: bitnami/kubectl:1.24.7
         command:
         - config/prow/deploy.sh
         env:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Our kubectl image is outdated. This PR updates it to `v1.24.7`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
