### PR TITLE
Allow job-forker to configure its email used for git explicitly

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -100,6 +100,7 @@ periodics:
       - --recursive=true
       - --upstream-repository=gardener/ci-infra
       - --upstream-branch=master
+      - --git-email=gardener.ci.robot@gmail.com
       # Add skip-review to --labels-override when we tested it for a while
       - --labels-override=kind/enhancement
       volumeMounts:

--- a/prow/pkg/git/fakegit/fakegitclient.go
+++ b/prow/pkg/git/fakegit/fakegitclient.go
@@ -37,7 +37,7 @@ type FakeInteractor struct{}
 type FakeCommitClient struct{}
 
 // Commit is a fake for Commit
-func (gc *FakeCommitClient) Commit(repoClient git.RepoClient, message string) error {
+func (gc *FakeCommitClient) Commit(directory, name, email, message string, signoff bool) error {
 	return nil
 }
 


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
For the case the email of bot's GitHub user is not visible on public profile, there has to be an CLI option in job-forker to set it explicitly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
