### PR TITLE
Allow collaborators to trigger things

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -7,7 +7,6 @@ triggers:
   - gardener/gardener-extension-registry-cache
   - gardener/gardener-extension-shoot-oidc-service
   - gardener/dependency-watchdog
-  only_org_members: true
 
 approve:
 - repos:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR removes restriction of `triggers` to org members and allows collaborators to trigger things ([ref](https://github.com/kubernetes/test-infra/blob/e60bb4596322bdce28609e212bb7b6a042ce27ea/prow/plugins/plugin-config-documented.yaml#L687-L689)). 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke @timebertt 
