### PR TITLE
Add `only-org-members` flag to cherrypicker

### DIFF
--- a/prow/external-plugins/cherrypicker/main.go
+++ b/prow/external-plugins/cherrypicker/main.go
@@ -47,6 +47,7 @@ type options struct {
 	webhookSecretFile string
 	prowAssignments   bool
 	allowAll          bool
+	onlyOrgMembers    bool
 	issueOnConflict   bool
 	labelPrefix       string
 }
@@ -71,6 +72,7 @@ func gatherOptions() options {
 	fs.StringVar(&o.logLevel, "log-level", "debug", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
 	fs.BoolVar(&o.prowAssignments, "use-prow-assignments", true, "Use prow commands to assign cherrypicked PRs.")
 	fs.BoolVar(&o.allowAll, "allow-all", false, "Allow anybody to use automated cherrypicks by skipping GitHub organization membership checks.")
+	fs.BoolVar(&o.onlyOrgMembers, "only-org-members", false, "Allow only users with a GitHub organization membership to use automated cherrypicks. Otherwise, collaborators are allowed to use it too.")
 	fs.BoolVar(&o.issueOnConflict, "create-issue-on-conflict", false, "Create a GitHub issue and assign it to the requestor on cherrypick conflict.")
 	fs.StringVar(&o.labelPrefix, "label-prefix", defaultLabelPrefix, "Set a custom label prefix.")
 	for _, group := range []flagutil.OptionGroup{&o.github, &o.instrumentationOptions} {
@@ -141,6 +143,7 @@ func main() {
 		labels:          o.labels.Strings(),
 		prowAssignments: o.prowAssignments,
 		allowAll:        o.allowAll,
+		onlyOrgMembers:  o.onlyOrgMembers,
 		issueOnConflict: o.issueOnConflict,
 		labelPrefix:     o.labelPrefix,
 

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -107,6 +107,12 @@ func (f *fghc) IsMember(org, user string) (bool, error) {
 	return f.isMember, nil
 }
 
+func (f *fghc) IsCollaborator(org, repo, user string) (bool, error) {
+	f.Lock()
+	defer f.Unlock()
+	return f.isMember, nil
+}
+
 func (f *fghc) GetRepo(owner, name string) (github.FullRepo, error) {
 	f.Lock()
 	defer f.Unlock()
@@ -208,6 +214,17 @@ func (f *fghc) ListOrgMembers(org, role string) ([]github.TeamMember, error) {
 		return nil, fmt.Errorf("all is only supported role, not: %s", role)
 	}
 	return f.orgMembers, nil
+}
+
+func (f *fghc) ListCollaborators(org, repo string) ([]github.User, error) {
+	f.Lock()
+	defer f.Unlock()
+	githubUsers := []github.User{}
+	for _, user := range f.orgMembers {
+		githubUser := github.User{Login: user.Login}
+		githubUsers = append(githubUsers, githubUser)
+	}
+	return githubUsers, nil
 }
 
 func (f *fghc) CreateFork(org, repo string) (string, error) {


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds the `only-org-members` flag to cherrypicker, that it is able to allow cherry-picks for collaborators too.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke @timebertt 
