### PR TITLE
Increase cpu limit of kube-rbac-proxy-main in kube-state-metrics deployment

### DIFF
--- a/config/prow/cluster/monitoring/base-prow/kubeStateMetrics-deployment.yaml
+++ b/config/prow/cluster/monitoring/base-prow/kubeStateMetrics-deployment.yaml
@@ -11,7 +11,7 @@ spec:
         resources:
           limits:
             # Increased CPU limit
-            cpu: 150m
+            cpu: 300m
       - name: kube-rbac-proxy-self
         resources:
           limits:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
There are many CPU throttling alerts for kube-rbac-proxy-main in kube-state-metrics deployment especially in build cluster. We are not lacking of CPU power in general, so this PR increases the limit.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
