### PR TITLE
Build `gardener-operator` images and execute its e2e tests

### DIFF
--- a/config/jobs/gardener/gardener-build-dev-images.yaml
+++ b/config/jobs/gardener/gardener-build-dev-images.yaml
@@ -32,6 +32,7 @@ postsubmits:
         - --target=seed-admission-controller
         - --target=resource-manager
         - --target=gardener-extension-provider-local
+        - --target=operator
         - --add-version-tag=true
         - --add-version-sha-tag=true
         - --inject-effective-version=true

--- a/config/jobs/gardener/gardener-e2e-kind-operator.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator.yaml
@@ -1,0 +1,78 @@
+presubmits:
+  gardener/gardener:
+  - name: pull-gardener-e2e-kind-operator
+    cluster: gardener-prow-build
+    always_run: true
+    optional: true
+    skip_branches:
+    - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for gardener-operator managing Garden resources on a kind cluster for gardener developments in pull requests
+      fork-per-release: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20221107-33c989e684-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - make ci-e2e-kind-operator
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 12
+            memory: 48Gi
+        env:
+        - name: SKAFFOLD_UPDATE_CHECK
+          value: "false"
+        - name: SKAFFOLD_INTERACTIVE
+          value: "false"
+periodics:
+- name: ci-gardener-e2e-kind-operator
+  cluster: gardener-prow-build
+  interval: 4h
+  extra_refs:
+  - org: gardener
+    repo: gardener
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 60m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs end-to-end tests for gardener-operator managing Garden resources on a kind cluster for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
+    fork-per-release: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20221107-33c989e684-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind-operator
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 12
+          memory: 48Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"

--- a/config/jobs/gardener/gardener-test-builds.yaml
+++ b/config/jobs/gardener/gardener-test-builds.yaml
@@ -52,6 +52,7 @@ presubmits:
         - --target=seed-admission-controller
         - --target=resource-manager
         - --target=gardener-extension-provider-local
+        - --target=operator
         - --add-version-sha-tag=true
         - --inject-effective-version=true
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/7009 introduces a new component, the `gardener-operator`. This PR

- makes Prow build its container image
- adds new related e2e tests running on each PR and periodically.

**Which issue(s) this PR fixes**:
~~/hold until https://github.com/gardener/gardener/pull/7009 is merged~~