### PR TITLE
introduced prow job to run KIND e2e tests for DWD

### DIFF
--- a/config/jobs/dependency-watchdog/dependency-watchdog-e2e-kind.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-e2e-kind.yaml
@@ -1,6 +1,6 @@
 presubmits:
   gardener/dependency-watchdog:
-    - name: pull-dependency-watchdog-kind-unit-tests
+    - name: pull-dependency-watchdog-e2e-kind
       cluster: gardener-prow-build
       always_run: true
       skip_branches:
@@ -13,7 +13,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-kind-volume-mounts: "true"
       annotations:
-        description: Runs KIND cluster based unit tests for dependency watchdog developments in pull requests
+        description: Runs KIND cluster based e2e tests for dependency watchdog developments in pull requests
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/krte:v20221107-33c989e684-master
@@ -30,7 +30,7 @@ presubmits:
                 cpu: 12
                 memory: 18Gi
 periodics:
-  - name: ci-dependency-watchdog-kind-unit-tests
+  - name: ci-dependency-watchdog-e2e-kind
     cluster: gardener-prow-build
     interval: 4h
     extra_refs:
@@ -45,7 +45,7 @@ periodics:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     annotations:
-      description: Runs KIND cluster based unit tests for dependency watchdog developments periodically
+      description: Runs KIND cluster based e2e tests for dependency watchdog developments periodically
       testgrid-dashboards: gardener-dependency-watchdog
       testgrid-days-of-results: "60"
     spec:

--- a/config/jobs/dependency-watchdog/dependency-watchdog-kind-unit-tests.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-kind-unit-tests.yaml
@@ -1,0 +1,77 @@
+presubmits:
+  gardener/dependency-watchdog:
+    - name: pull-dependency-watchdog-kind-unit-tests
+      cluster: gardener-prow-build
+      always_run: true
+      skip_branches:
+        - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+      decorate: true
+      decoration_config:
+        timeout: 60m
+        grace_period: 15m
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+      annotations:
+        description: Runs KIND cluster based unit tests for dependency watchdog developments in pull requests
+        fork-per-release: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/krte:v20221107-33c989e684-master
+            command:
+              - wrapper.sh
+              - bash
+              - -c
+              - make kind-tests
+            # we need privileged mode in order to do docker in docker
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 12
+                memory: 18Gi
+            env:
+              - name: SKAFFOLD_UPDATE_CHECK
+                value: "false"
+              - name: SKAFFOLD_INTERACTIVE
+                value: "false"
+periodics:
+  - name: ci-dependency-watchdog-kind-unit-tests
+    cluster: gardener-prow-build
+    interval: 4h
+    extra_refs:
+      - org: gardener
+        repo: dependency-watchdog
+        base_ref: master
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs KIND cluster based unit tests for dependency watchdog developments periodically
+      testgrid-dashboards: gardener-dependency-watchdog
+      testgrid-days-of-results: "60"
+      fork-per-release: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/krte:v20221107-33c989e684-master
+          command:
+            - wrapper.sh
+            - bash
+            - -c
+            - make kind-tests
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 12
+              memory: 18Gi
+          env:
+            - name: SKAFFOLD_UPDATE_CHECK
+              value: "false"
+            - name: SKAFFOLD_INTERACTIVE
+              value: "false"

--- a/config/jobs/dependency-watchdog/dependency-watchdog-kind-unit-tests.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-kind-unit-tests.yaml
@@ -14,7 +14,6 @@ presubmits:
         preset-kind-volume-mounts: "true"
       annotations:
         description: Runs KIND cluster based unit tests for dependency watchdog developments in pull requests
-        fork-per-release: "true"
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/krte:v20221107-33c989e684-master
@@ -30,11 +29,6 @@ presubmits:
               requests:
                 cpu: 12
                 memory: 18Gi
-            env:
-              - name: SKAFFOLD_UPDATE_CHECK
-                value: "false"
-              - name: SKAFFOLD_INTERACTIVE
-                value: "false"
 periodics:
   - name: ci-dependency-watchdog-kind-unit-tests
     cluster: gardener-prow-build
@@ -54,7 +48,6 @@ periodics:
       description: Runs KIND cluster based unit tests for dependency watchdog developments periodically
       testgrid-dashboards: gardener-dependency-watchdog
       testgrid-days-of-results: "60"
-      fork-per-release: "true"
     spec:
       containers:
         - image: gcr.io/k8s-staging-test-infra/krte:v20221107-33c989e684-master
@@ -70,8 +63,3 @@ periodics:
             requests:
               cpu: 12
               memory: 18Gi
-          env:
-            - name: SKAFFOLD_UPDATE_CHECK
-              value: "false"
-            - name: SKAFFOLD_INTERACTIVE
-              value: "false"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
DWD has e2e tests that bring up a vanilla KIND cluster via go code. To start a KIND cluster a different image and a privileged container is required. This PR adds a separate job only to run KIND e2e tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
