### PR TITLE
Fix determination of open PRs in job-forker

### DIFF
--- a/prow/pkg/githubinteractor/github.go
+++ b/prow/pkg/githubinteractor/github.go
@@ -253,7 +253,8 @@ func (r *Repository) PushChanges(upstreamRepo, upstreamBranch, targetBranch, com
 
 	for _, pr := range prs {
 		log.Printf("PR: %v, Head: %v, Base: %v\n", pr.Title, pr.Head.Repo.FullName, pr.Base.Repo.FullName)
-		if pr.Head.Repo.FullName == fork.FullRepoName && pr.Base.Repo.FullName == upstreamRepo {
+		if pr.Head.Repo.FullName == fork.FullRepoName && pr.Head.Ref == targetBranch &&
+			pr.Base.Repo.FullName == upstreamRepo && pr.Base.Ref == upstreamBranch {
 			log.Printf("There is already an open PR")
 			prNumber = pr.Number
 			prExists = true


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The determination of open PRs in `job-forker` does not consider branches, so `job-forker` could pick the wrong PR ([example](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-job-forker-gardener-gardener/1593283969170804736#1:build-log.txt%3A34-36)).
With this PR `job-forkers` only considers open PRs with correct Head and Base Refs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
