### PR TITLE
Drop `gardener-seed-admission-controller`

### DIFF
--- a/config/jobs/gardener/gardener-build-dev-images.yaml
+++ b/config/jobs/gardener/gardener-build-dev-images.yaml
@@ -29,7 +29,6 @@ postsubmits:
         - --target=scheduler
         - --target=gardenlet
         - --target=admission-controller
-        - --target=seed-admission-controller
         - --target=resource-manager
         - --target=gardener-extension-provider-local
         - --target=operator

--- a/config/jobs/gardener/gardener-test-builds.yaml
+++ b/config/jobs/gardener/gardener-test-builds.yaml
@@ -49,7 +49,6 @@ presubmits:
         - --target=scheduler
         - --target=gardenlet
         - --target=admission-controller
-        - --target=seed-admission-controller
         - --target=resource-manager
         - --target=gardener-extension-provider-local
         - --target=operator


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/7053, the `gardener-seed-admission-controller` binary will be dropped from the `gardener/gardener` code base.