### PR TITLE
Deactivate Release Milestone Check for gardener v1.61

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -229,28 +229,28 @@ tide:
   ### Release Milestone section starts here
   ### Please uncomment when setting a Release Milestone for gardener/gardener
   #############################################################################
-    excludedBranches:
-    - master
-  - repos:
-    - gardener/gardener
-    labels:
-    - lgtm
-    - approved
-    - "cla: yes"
-    missingLabels:
-    - do-not-merge/blocked-paths
-    - do-not-merge/contains-merge-commits
-    - do-not-merge/hold
-    - do-not-merge/invalid-commit-message
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/needs-kind
-    - do-not-merge/release-note-label-needed
-    - do-not-merge/work-in-progress
-    - needs-rebase
-    - "cla: no"
-    milestone: v1.61
-    includedBranches:
-    - master
+  #   excludedBranches:
+  #   - master
+  # - repos:
+  #   - gardener/gardener
+  #   labels:
+  #   - lgtm
+  #   - approved
+  #   - "cla: yes"
+  #   missingLabels:
+  #   - do-not-merge/blocked-paths
+  #   - do-not-merge/contains-merge-commits
+  #   - do-not-merge/hold
+  #   - do-not-merge/invalid-commit-message
+  #   - do-not-merge/invalid-owners-file
+  #   - do-not-merge/needs-kind
+  #   - do-not-merge/release-note-label-needed
+  #   - do-not-merge/work-in-progress
+  #   - needs-rebase
+  #   - "cla: no"
+  #   milestone: v1.62
+  #   includedBranches:
+  #   - master
   ##############################################################################
   ### End of Release Milestone section
   ##############################################################################


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Deactivate Release Milestone Check for gardener v1.61.
