### PR TITLE
Merge job-forker PRs automatically

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -101,8 +101,7 @@ periodics:
       - --upstream-repository=gardener/ci-infra
       - --upstream-branch=master
       - --git-email=gardener.ci.robot@gmail.com
-      # Add skip-review to --labels-override when we tested it for a while
-      - --labels-override=kind/enhancement
+      - --labels-override=kind/enhancement,skip-review
       volumeMounts:
       - name: github-token
         mountPath: /etc/github-token


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR sets the `skip-review` label in `job-forker` PRs that they can be merged automatically in the future. 

The PRs created by `job-forker` for the last to releases have been correct and there is `pull-ci-infra-prow-checkconfig` test, which checks job definitions too, as a second line of defence.

For reference, these are the latest PRs created by `job-forker`
- https://github.com/gardener/ci-infra/pull/512
- https://github.com/gardener/ci-infra/pull/498
- https://github.com/gardener/ci-infra/pull/496

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke 
/cc @ialidzhikov 
