### PR TITLE
Check tree hash before removing lgtm label

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -39,6 +39,7 @@ lgtm:
   - gardener/gardener
   - gardener/gardener-extension-registry-cache
   review_acts_as_lgtm: true
+  store_tree_hash: true
 
 blunderbuss:
   max_request_count: 2


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Currently, `lgtm` is removed as soon as the PR author pushes squashed or re-arranged commits, even if the contents didn't change.
This setting allows PR authors to change the commit structure of a PR without requiring another `/lgtm`.

ref https://github.com/kubernetes/kubernetes/issues/103096
ref https://groups.google.com/a/kubernetes.io/g/dev/c/sdy4eloP7KY/m/pmBqYYixAAAJ
doc string: https://github.com/kubernetes/test-infra/blob/e31682a68b5002979117b38384f3a3cea7b26a9c/prow/plugins/plugin-config-documented.yaml#L499-L501