### PR TITLE
Adjust CPU and memory requests of test jobs

### DIFF
--- a/config/jobs/dependency-watchdog/dependency-watchdog-e2e-kind.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-e2e-kind.yaml
@@ -27,7 +27,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                cpu: 12
+                cpu: 6
                 memory: 18Gi
 periodics:
   - name: ci-dependency-watchdog-e2e-kind
@@ -61,5 +61,5 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: 12
+              cpu: 6
               memory: 18Gi

--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
@@ -34,7 +34,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 12
+            cpu: 6
             memory: 18Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
@@ -82,7 +82,7 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 12
+          cpu: 6
           memory: 18Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
@@ -29,8 +29,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 12
-            memory: 48Gi
+            cpu: 6
+            memory: 24Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -69,8 +69,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 12
-          memory: 48Gi
+          cpu: 6
+          memory: 24Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -28,8 +28,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 12
-            memory: 48Gi
+            cpu: 6
+            memory: 24Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -68,8 +68,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 12
-          memory: 48Gi
+          cpu: 6
+          memory: 24Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
@@ -29,8 +29,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 12
-            memory: 48Gi
+            cpu: 6
+            memory: 24Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -69,8 +69,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 12
-          memory: 48Gi
+          cpu: 6
+          memory: 24Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
@@ -28,8 +28,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 12
-            memory: 48Gi
+            cpu: 6
+            memory: 24Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -68,8 +68,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 12
-          memory: 48Gi
+          cpu: 6
+          memory: 24Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -28,7 +28,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 12
+            cpu: 6
             memory: 18Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
@@ -68,7 +68,7 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 12
+          cpu: 6
           memory: 18Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK

--- a/config/jobs/gardener/gardener-e2e-kind-operator.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator.yaml
@@ -28,8 +28,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 12
-            memory: 48Gi
+            cpu: 6
+            memory: 24Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -68,8 +68,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 12
-          memory: 48Gi
+          cpu: 6
+          memory: 24Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
@@ -29,7 +29,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 12
+            cpu: 6
             memory: 18Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
@@ -69,7 +69,7 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 12
+          cpu: 6
           memory: 18Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -28,7 +28,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 12
+            cpu: 6
             memory: 18Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
@@ -68,7 +68,7 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 12
+          cpu: 6
           memory: 18Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -30,7 +30,7 @@ presubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: 7
+            cpu: 6
             memory: 8Gi
 periodics:
 - name: ci-gardener-unit
@@ -67,5 +67,5 @@ periodics:
         limits:
           memory: 16Gi
         requests:
-          cpu: 7
+          cpu: 6
           memory: 8Gi

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-60.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-60.yaml
@@ -35,8 +35,8 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
-          memory: 48Gi
+          cpu: "6"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:
@@ -75,8 +75,8 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
-          memory: 48Gi
+          cpu: "6"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:
@@ -115,7 +115,7 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
+          cpu: "6"
           memory: 18Gi
       securityContext:
         privileged: true
@@ -154,7 +154,7 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
+          cpu: "6"
           memory: 18Gi
       securityContext:
         privileged: true
@@ -221,7 +221,7 @@ periodics:
         limits:
           memory: 16Gi
         requests:
-          cpu: "7"
+          cpu: "6"
           memory: 8Gi
 postsubmits:
   gardener/gardener:
@@ -307,8 +307,8 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
-            memory: 48Gi
+            cpu: "6"
+            memory: 24Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -345,8 +345,8 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
-            memory: 48Gi
+            cpu: "6"
+            memory: 24Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -382,7 +382,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
+            cpu: "6"
             memory: 18Gi
         securityContext:
           privileged: true
@@ -418,7 +418,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
+            cpu: "6"
             memory: 18Gi
         securityContext:
           privileged: true
@@ -547,5 +547,5 @@ presubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: "7"
+            cpu: "6"
             memory: 8Gi

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-61.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-61.yaml
@@ -35,8 +35,8 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
-          memory: 48Gi
+          cpu: "6"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:
@@ -75,8 +75,8 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
-          memory: 48Gi
+          cpu: "6"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:
@@ -115,7 +115,7 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
+          cpu: "6"
           memory: 18Gi
       securityContext:
         privileged: true
@@ -155,8 +155,8 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
-          memory: 48Gi
+          cpu: "6"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:
@@ -194,7 +194,7 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
+          cpu: "6"
           memory: 18Gi
       securityContext:
         privileged: true
@@ -261,7 +261,7 @@ periodics:
         limits:
           memory: 16Gi
         requests:
-          cpu: "7"
+          cpu: "6"
           memory: 8Gi
 postsubmits:
   gardener/gardener:
@@ -346,8 +346,8 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
-            memory: 48Gi
+            cpu: "6"
+            memory: 24Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -383,8 +383,8 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
-            memory: 48Gi
+            cpu: "6"
+            memory: 24Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -420,7 +420,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
+            cpu: "6"
             memory: 18Gi
         securityContext:
           privileged: true
@@ -457,8 +457,8 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
-            memory: 48Gi
+            cpu: "6"
+            memory: 24Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -493,7 +493,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
+            cpu: "6"
             memory: 18Gi
         securityContext:
           privileged: true
@@ -622,5 +622,5 @@ presubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: "7"
+            cpu: "6"
             memory: 8Gi

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-62.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-62.yaml
@@ -35,8 +35,8 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
-          memory: 48Gi
+          cpu: "6"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:
@@ -75,8 +75,8 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
-          memory: 48Gi
+          cpu: "6"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:
@@ -115,8 +115,8 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
-          memory: 48Gi
+          cpu: "6"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:
@@ -155,8 +155,8 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
-          memory: 48Gi
+          cpu: "6"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:
@@ -195,7 +195,7 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
+          cpu: "6"
           memory: 18Gi
       securityContext:
         privileged: true
@@ -235,8 +235,8 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
-          memory: 48Gi
+          cpu: "6"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:
@@ -275,7 +275,7 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
+          cpu: "6"
           memory: 18Gi
       securityContext:
         privileged: true
@@ -314,7 +314,7 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "12"
+          cpu: "6"
           memory: 18Gi
       securityContext:
         privileged: true
@@ -381,7 +381,7 @@ periodics:
         limits:
           memory: 16Gi
         requests:
-          cpu: "7"
+          cpu: "6"
           memory: 8Gi
 postsubmits:
   gardener/gardener:
@@ -468,8 +468,8 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
-            memory: 48Gi
+            cpu: "6"
+            memory: 24Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -505,8 +505,8 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
-            memory: 48Gi
+            cpu: "6"
+            memory: 24Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -543,8 +543,8 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
-            memory: 48Gi
+            cpu: "6"
+            memory: 24Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -580,8 +580,8 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
-            memory: 48Gi
+            cpu: "6"
+            memory: 24Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -617,7 +617,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
+            cpu: "6"
             memory: 18Gi
         securityContext:
           privileged: true
@@ -654,8 +654,8 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
-            memory: 48Gi
+            cpu: "6"
+            memory: 24Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -692,7 +692,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
+            cpu: "6"
             memory: 18Gi
         securityContext:
           privileged: true
@@ -728,7 +728,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            cpu: "12"
+            cpu: "6"
             memory: 18Gi
         securityContext:
           privileged: true
@@ -857,5 +857,5 @@ presubmits:
           limits:
             memory: 16Gi
           requests:
-            cpu: "7"
+            cpu: "6"
             memory: 8Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR reduces the CPU and memory requests of our prow jobs that they fit on a 8 CPU machine.
When running e2e tests CPU are just below 50% for most of the time. Thus, we are wasting CPU power here. However, there is a big peak of CPU and Load at the beginning of the tests. These high loads affect other e2e tests. We cannot limit CPU in Kubernetes because the e2e run docker in docker and do not care about these limits.

The new approach we would like to test is:
- Reduce the machine size of the nodes to 8 CPU machines
- Run only one e2e per node

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/hold
in order to synchronize merging with the reconfiguration of the prow cluster
