### PR TITLE
Bind prometheus pods to system-component nodes

### DIFF
--- a/config/prow/cluster/monitoring/base-prow/alertmanager-alertmanager.yaml
+++ b/config/prow/cluster/monitoring/base-prow/alertmanager-alertmanager.yaml
@@ -23,7 +23,15 @@ spec:
         resources:
           requests:
             storage: 10Gi
-  affinity: 
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: worker.gardener.cloud/system-components
+            operator: In
+            values:
+            - "true"
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
       - podAffinityTerm:

--- a/config/prow/cluster/monitoring/base-prow/blackboxExporter-deployment.yaml
+++ b/config/prow/cluster/monitoring/base-prow/blackboxExporter-deployment.yaml
@@ -17,3 +17,12 @@ spec:
           limits:
             # Increased CPU limit
             cpu: 50m
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: worker.gardener.cloud/system-components
+                operator: In
+                values:
+                - "true"

--- a/config/prow/cluster/monitoring/base-prow/grafana-deployment.yaml
+++ b/config/prow/cluster/monitoring/base-prow/grafana-deployment.yaml
@@ -41,3 +41,12 @@ spec:
         name: grafana-dashboard-controller-manager
       - $patch: delete 
         name: grafana-dashboard-scheduler
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: worker.gardener.cloud/system-components
+                operator: In
+                values:
+                - "true"

--- a/config/prow/cluster/monitoring/base-prow/kubeStateMetrics-deployment.yaml
+++ b/config/prow/cluster/monitoring/base-prow/kubeStateMetrics-deployment.yaml
@@ -17,3 +17,12 @@ spec:
           limits:
             # Increased CPU limit
             cpu: 100m
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: worker.gardener.cloud/system-components
+                operator: In
+                values:
+                - "true"

--- a/config/prow/cluster/monitoring/base-prow/kustomization.yaml
+++ b/config/prow/cluster/monitoring/base-prow/kustomization.yaml
@@ -24,6 +24,7 @@ patchesStrategicMerge:
 - kubeStateMetrics-deployment.yaml
 - nodeExporter-daemonset.yaml
 - prometheus.yaml
+- prometheusAdapter-deployment.yaml
 - prometheusOperator-deployment.yaml
 
 secretGenerator:

--- a/config/prow/cluster/monitoring/base-prow/prometheus.yaml
+++ b/config/prow/cluster/monitoring/base-prow/prometheus.yaml
@@ -20,7 +20,15 @@ spec:
         resources:
           requests:
             storage: 100Gi
-  affinity: 
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: worker.gardener.cloud/system-components
+            operator: In
+            values:
+            - "true" 
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
       - podAffinityTerm:

--- a/config/prow/cluster/monitoring/base-prow/prometheusAdapter-deployment.yaml
+++ b/config/prow/cluster/monitoring/base-prow/prometheusAdapter-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-adapter
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: worker.gardener.cloud/system-components
+                operator: In
+                values:
+                - "true"
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - metrics-adapter
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - prometheus-adapter
+                - key: app.kubernetes.io/part-of
+                  operator: In
+                  values:
+                  - kube-prometheus
+              topologyKey: kubernetes.io/hostname
+            weight: 100

--- a/config/prow/cluster/monitoring/base-prow/prometheusOperator-deployment.yaml
+++ b/config/prow/cluster/monitoring/base-prow/prometheusOperator-deployment.yaml
@@ -12,3 +12,12 @@ spec:
           limits:
             # Increased CPU limit
             cpu: 50m
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: worker.gardener.cloud/system-components
+                operator: In
+                values:
+                - "true"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR binds various `prometheus` pods to `worker.gardener.cloud/system-components` nodes, that they do not run on the same nodes as e2e tests. 
e2e tests can create such high loads on a node, that prometheus is not able to scrape properly meanwhile.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
