### PR TITLE
Adapt build of gardener-extension-registry-cache for concourse release jobs

### DIFF
--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-build-images.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-build-images.yaml
@@ -2,6 +2,7 @@ postsubmits:
   gardener/gardener-extension-registry-cache:
   - name: post-gardener-extension-registry-cache-build-images
     cluster: gardener-prow-trusted
+    skip_if_only_changed: '^VERSION$'
     branches:
     - ^main$
     annotations:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
When we enable the concourse release pipeline for `gardener-extension-registry-cache` repository with https://github.com/gardener/gardener-extension-registry-cache/pull/6 `prow` should not build images on `VERSION` file changes anymore. Otherwise, concourse and prow build artifacts would overwrite each other. 
We do the same for gardener/gardener.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
