### PR TITLE
Fixed prow job `ci-gardener-e2e-kind-upgrade`

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
@@ -63,7 +63,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind
+      - make ci-e2e-kind-upgrade
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-62.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-62.yaml
@@ -265,7 +265,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind
+      - make ci-e2e-kind-upgrade
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"


### PR DESCRIPTION
/kind bug
<!--
Please select the kind of this pull request, e.g.:
/kind bug

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
Previously prow job `ci-gardener-e2e-kind-upgrade` calling wrong make target `make ci-e2e-kind` instead of `make ci-e2e-kind-upgrade`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc: @oliver-goetz @rfranzke 