### PR TITLE
Added prow job for KinD based druid e2e

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -23,7 +23,7 @@ periodics:
       args:
       - --config=config/prow/labels.yaml
       - --confirm=true
-      - --only=gardener/ci-infra,gardener/gardener,gardener/gardener-extension-registry-cache,gardener/gardener-extension-shoot-oidc-service,gardener/dependency-watchdog,gardener/gardener-extension-networking-cilium,gardener/gardener-extension-networking-calico
+      - --only=gardener/ci-infra,gardener/gardener,gardener/gardener-extension-registry-cache,gardener/gardener-extension-shoot-oidc-service,gardener/dependency-watchdog,gardener/etcd-druid,gardener/gardener-extension-networking-cilium,gardener/gardener-extension-networking-calico
       - --endpoint=http://ghproxy.prow.svc
       - --endpoint=https://api.github.com
       # TODO: switch to GitHub App Auth, once it's implemented in label_sync

--- a/config/jobs/etcd-druid/druid-e2e-kind.yaml
+++ b/config/jobs/etcd-druid/druid-e2e-kind.yaml
@@ -1,0 +1,65 @@
+presubmits:
+  gardener/etcd-druid:
+    - name: pull-etcd-druid-e2e-kind
+      cluster: gardener-prow-build
+      always_run: true
+      skip_branches:
+        - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+      decorate: true
+      decoration_config:
+        timeout: 60m
+        grace_period: 15m
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+      annotations:
+        description: Runs KIND cluster based e2e tests for etcd druid developments in pull requests
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/krte:v20221116-7c85504268-master
+            command:
+              - wrapper.sh
+              - bash
+              - -c
+              - make ci-e2e-kind
+            # we need privileged mode in order to do docker in docker
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 12
+                memory: 18Gi
+periodics:
+  - name: ci-etcd-druid-e2e-kind
+    cluster: gardener-prow-build
+    interval: 4h
+    extra_refs:
+      - org: gardener
+        repo: etcd-druid
+        base_ref: master
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs KIND cluster based e2e tests for etcd druid developments periodically
+      testgrid-dashboards: gardener-etcd-druid
+      testgrid-days-of-results: "60"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/krte:v20221116-7c85504268-master
+          command:
+            - wrapper.sh
+            - bash
+            - -c
+            - make ci-e2e-kind
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 12
+              memory: 18Gi

--- a/config/jobs/etcd-druid/druid-e2e-kind.yaml
+++ b/config/jobs/etcd-druid/druid-e2e-kind.yaml
@@ -27,8 +27,8 @@ presubmits:
               privileged: true
             resources:
               requests:
-                cpu: 12
-                memory: 18Gi
+                cpu: 6
+                memory: 8Gi
 periodics:
   - name: ci-etcd-druid-e2e-kind
     cluster: gardener-prow-build
@@ -61,5 +61,5 @@ periodics:
             privileged: true
           resources:
             requests:
-              cpu: 12
-              memory: 18Gi
+              cpu: 6
+              memory: 8Gi

--- a/config/jobs/etcd-druid/druid-e2e-kind.yaml
+++ b/config/jobs/etcd-druid/druid-e2e-kind.yaml
@@ -16,12 +16,12 @@ presubmits:
         description: Runs KIND cluster based e2e tests for etcd druid developments in pull requests
       spec:
         containers:
-          - image: gcr.io/k8s-staging-test-infra/krte:v20221116-7c85504268-master
+          - image: gcr.io/k8s-staging-test-infra/krte:v20230421-ec4335b54b-master
             command:
-              - wrapper.sh
-              - bash
-              - -c
-              - make ci-e2e-kind
+            - wrapper.sh
+            - bash
+            - -c
+            - make ci-e2e-kind
             # we need privileged mode in order to do docker in docker
             securityContext:
               privileged: true
@@ -50,12 +50,12 @@ periodics:
       testgrid-days-of-results: "60"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/krte:v20221116-7c85504268-master
+        - image: gcr.io/k8s-staging-test-infra/v20230421-ec4335b54b-master
           command:
-            - wrapper.sh
-            - bash
-            - -c
-            - make ci-e2e-kind
+          - wrapper.sh
+          - bash
+          - -c
+          - make ci-e2e-kind
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true

--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -3288,6 +3288,20 @@ repos:
         target: prs
         prowPlugin: trigger
         addedBy: prow
+  gardener/etcd-druid:
+    labels:
+      - color: b60205
+        description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
+        name: needs-ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow
+      - color: 15dd18
+        description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
+        name: ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow
   gardener/gardener-extension-networking-calico:
     labels:
       - color: b60205

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -7,6 +7,7 @@ triggers:
   - gardener/gardener-extension-registry-cache
   - gardener/gardener-extension-shoot-oidc-service
   - gardener/dependency-watchdog
+  - gardener/etcd-druid
   - gardener/gardener-extension-networking-cilium
   - gardener/gardener-extension-networking-calico
   - gardener/landscaper
@@ -289,6 +290,11 @@ plugins:
     - welcome
     - wip
     - yuks
+  gardener/etcd-druid:
+    plugins:
+    - override
+    - skip
+    - trigger
   gardener/gardener-extension-networking-cilium:
     plugins:
     - override

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -6,6 +6,7 @@ dashboard_groups:
     - gardener-extension-registry-cache
     - gardener-extension-shoot-oidc-service
     - gardener-dependency-watchdog
+    - gardener-etcd-druid
     - gardener-extension-networking-cilium
     - gardener-extension-networking-calico
 
@@ -15,5 +16,6 @@ dashboards:
 - name: gardener-extension-registry-cache
 - name: gardener-extension-shoot-oidc-service
 - name: gardener-dependency-watchdog
+- name: gardener-etcd-druid
 - name: gardener-extension-networking-cilium
 - name: gardener-extension-networking-calico


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement 
**What this PR does / why we need it**:
This PR enables to run KinD based Druid e2e tests through prow jobs

**Which issue(s) this PR fixes**:
Fixes #
https://github.com/gardener/etcd-druid/issues/465
**Special notes for your reviewer**:
