### PR TITLE
Add release milestone check for gardener release v1.63 to tide

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -229,28 +229,28 @@ tide:
   ### Release Milestone section starts here
   ### Please uncomment when setting a Release Milestone for gardener/gardener
   #############################################################################
-  #   excludedBranches:
-  #   - master
-  # - repos:
-  #   - gardener/gardener
-  #   labels:
-  #   - lgtm
-  #   - approved
-  #   - "cla: yes"
-  #   missingLabels:
-  #   - do-not-merge/blocked-paths
-  #   - do-not-merge/contains-merge-commits
-  #   - do-not-merge/hold
-  #   - do-not-merge/invalid-commit-message
-  #   - do-not-merge/invalid-owners-file
-  #   - do-not-merge/needs-kind
-  #   - do-not-merge/release-note-label-needed
-  #   - do-not-merge/work-in-progress
-  #   - needs-rebase
-  #   - "cla: no"
-  #   milestone: v1.63
-  #   includedBranches:
-  #   - master
+    excludedBranches:
+    - master
+  - repos:
+    - gardener/gardener
+    labels:
+    - lgtm
+    - approved
+    - "cla: yes"
+    missingLabels:
+    - do-not-merge/blocked-paths
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/needs-kind
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    - "cla: no"
+    milestone: v1.63
+    includedBranches:
+    - master
   ##############################################################################
   ### End of Release Milestone section
   ##############################################################################


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it:**
This PR enables milestone check for gardener release v1.63 in Tide.