### PR TITLE
Grant push access to `ci` team and use merge method squash for `gardener/gardener-extension-registry-cache`

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -169,7 +169,8 @@ branch-protection:
             apps:
             - gardener-prow
             users: []
-            teams: []
+            teams:
+            - ci # allow CI users (e.g. concourse) to push (e.g. release commits)
           enforce_admins: true # protections apply to admins as well
 
 tide:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -278,6 +278,7 @@ tide:
   merge_method:
     gardener/ci-infra: squash
     gardener/gardener: squash
+    gardener/gardener-extension-registry-cache: squash
   pr_status_base_urls:
     '*': https://prow.gardener.cloud/pr
   blocker_label: tide/merge-blocker


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR grants push access to `ci` team, that the gardener robots are allowed to push release commits to main branch.

Additionally, it sets default merge method to `squash` for `gardener/gardener-extension-registry-cache` as it is already done for `gardener/gardener` and `gardener/ci-infra`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
