### PR TITLE
Allow concourse to create release commit for the registry-cache extension

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -165,13 +165,13 @@ branch-protection:
           required_status_checks:
             contexts:
             - license/cla
-          restrictions: # prevent everyone except gardener-prow from pushing/merging
+          restrictions: # prevent everyone from pushing/merging (except admins and gardener-prow)
             apps:
             - gardener-prow
             users: []
             teams:
             - ci # allow CI users (e.g. concourse) to push (e.g. release commits)
-          enforce_admins: true # protections apply to admins as well
+          enforce_admins: false # protections don't apply to admins
 
 tide:
   sync_period: 1m


### PR DESCRIPTION
/kind bug

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
Similar to https://github.com/gardener/ci-infra/pull/155.

**Which issue(s) this PR fixes**:
See above

**Special notes for your reviewer**:
