### PR TITLE
Use strings for build variant names

### DIFF
--- a/images/golang-test/variants.yaml
+++ b/images/golang-test/variants.yaml
@@ -1,7 +1,7 @@
 variants:
-  1.18:
-    GOLANG_VERSION: 1.18.10
-  1.19:
-    GOLANG_VERSION: 1.19.5
-  1.20:
-    GOLANG_VERSION: 1.20.0
+  "1.18":
+    GOLANG_VERSION: "1.18.10"
+  "1.19":
+    GOLANG_VERSION: "1.19.5"
+  "1.20":
+    GOLANG_VERSION: "1.20.0"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
With this PR variant names are defined as strings.
Otherwise, the yaml unmarshaller might truncate trailing zeros as occurred [here](https://storage.googleapis.com/gardener-prow/logs/post-ci-infra-build-golang-test-image/1621394088739737601/artifacts/003-5e29a2dd-a38b-11ed-8b13-aa873ab98565-ci-infra-1.2-golang-test-build-log.txt?Expires=1675421027&GoogleAccessId=gardener-prow-storage%40gardener-project.iam.gserviceaccount.com&Signature=bwxJyXvasy4Ip%2FjZEU93fSu7THgObO%2Bcx2ejG4ofNg%2FMBnGMh%2F7GbOLGg339oaJ6IqKLCHGGJjP9TeghjE05MgdRPaKn1qF645KG9fpyzwENfqCAuCU5BVaJ%2F%2F6Hwu8%2BV4ExO8izceJjFcY3%2BV7OJ1Cxec2nXym3gC4PhFGk76sGTh7O8sIKI%2B%2Fl0L8fnWi7JL9KD%2BQnvak7gPnNbWTC%2B3Ozh4OwX1CjgFiSE3dqKn%2FpP73G6kgtLsqRxnPaauMvcjR5mCo1o9lUo5V%2F8eoG14XYAhsECwiUrjyvrSBoTWtw078tbLRdGJiOX6Z5NrpErKaQD4mvKumhYH9lh91F0g%3D%3D) for Go `1.20` which leads to wrong image tags.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
