### PR TITLE
Revert "Remove periodic single and multi-zone upgrade test jobs"

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
@@ -36,3 +36,43 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
+periodics:
+- name: ci-gardener-e2e-kind-ha-multi-zone-upgrade
+  cluster: gardener-prow-build
+  interval: 4h
+  extra_refs:
+  - org: gardener
+    repo: gardener
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 60m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs end-to-end Gardener upgrade tests on a Seed with 3 zones with a Shoot with failure tolerance type 'zone' for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
+    fork-per-release: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20230117-50d6df3625-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind-ha-multi-zone-upgrade
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 6
+          memory: 24Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
@@ -36,3 +36,43 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
+periodics:
+- name: ci-gardener-e2e-kind-ha-single-zone-upgrade
+  cluster: gardener-prow-build
+  interval: 4h
+  extra_refs:
+  - org: gardener
+    repo: gardener
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 60m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs end-to-end tests on a Seed with single zone with a Shoot with failure tolerance type 'node' for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
+    fork-per-release: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20230117-50d6df3625-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind-ha-single-zone-upgrade
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 6
+          memory: 24Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-62.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-62.yaml
@@ -1,46 +1,6 @@
 periodics:
 - annotations:
     created-by-job-forker: "true"
-    description: Runs end-to-end Gardener upgrade tests on a Seed with 3 zones with
-      a Shoot with failure tolerance type 'zone' for gardener developments periodically
-    testgrid-dashboards: gardener-gardener
-    testgrid-days-of-results: "60"
-  cluster: gardener-prow-build
-  decorate: true
-  decoration_config:
-    grace_period: 15m0s
-    timeout: 1h0m0s
-  extra_refs:
-  - base_ref: release-v1.62
-    org: gardener
-    repo: gardener
-  interval: 4h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  name: ci-gardener-e2e-kind-ha-multi-zone-upgrade-release-v1-62
-  spec:
-    containers:
-    - command:
-      - wrapper.sh
-      - bash
-      - -c
-      - make ci-e2e-kind-ha-multi-zone-upgrade
-      env:
-      - name: SKAFFOLD_UPDATE_CHECK
-        value: "false"
-      - name: SKAFFOLD_INTERACTIVE
-        value: "false"
-      image: gcr.io/k8s-staging-test-infra/krte:v20230117-50d6df3625-master
-      name: ""
-      resources:
-        requests:
-          cpu: "6"
-          memory: 24Gi
-      securityContext:
-        privileged: true
-- annotations:
-    created-by-job-forker: "true"
     description: Runs end-to-end tests on a Seed with 3 zones with a Shoot with failure
       tolerance type 'zone' for gardener developments periodically
     testgrid-dashboards: gardener-gardener
@@ -77,46 +37,6 @@ periodics:
         requests:
           cpu: "12"
           memory: 48Gi
-      securityContext:
-        privileged: true
-- annotations:
-    created-by-job-forker: "true"
-    description: Runs end-to-end tests on a Seed with single zone with a Shoot with
-      failure tolerance type 'node' for gardener developments periodically
-    testgrid-dashboards: gardener-gardener
-    testgrid-days-of-results: "60"
-  cluster: gardener-prow-build
-  decorate: true
-  decoration_config:
-    grace_period: 15m0s
-    timeout: 1h0m0s
-  extra_refs:
-  - base_ref: release-v1.62
-    org: gardener
-    repo: gardener
-  interval: 4h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  name: ci-gardener-e2e-kind-ha-single-zone-upgrade-release-v1-62
-  spec:
-    containers:
-    - command:
-      - wrapper.sh
-      - bash
-      - -c
-      - make ci-e2e-kind-ha-single-zone-upgrade
-      env:
-      - name: SKAFFOLD_UPDATE_CHECK
-        value: "false"
-      - name: SKAFFOLD_INTERACTIVE
-        value: "false"
-      image: gcr.io/k8s-staging-test-infra/krte:v20230117-50d6df3625-master
-      name: ""
-      resources:
-        requests:
-          cpu: "6"
-          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-62.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-62.yaml
@@ -1,6 +1,46 @@
 periodics:
 - annotations:
     created-by-job-forker: "true"
+    description: Runs end-to-end Gardener upgrade tests on a Seed with 3 zones with
+      a Shoot with failure tolerance type 'zone' for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
+  cluster: gardener-prow-build
+  decorate: true
+  decoration_config:
+    grace_period: 15m0s
+    timeout: 1h0m0s
+  extra_refs:
+  - base_ref: release-v1.62
+    org: gardener
+    repo: gardener
+  interval: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  name: ci-gardener-e2e-kind-ha-multi-zone-upgrade-release-v1-62
+  spec:
+    containers:
+    - command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind-ha-multi-zone-upgrade
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"
+      image: gcr.io/k8s-staging-test-infra/krte:v20230117-50d6df3625-master
+      name: ""
+      resources:
+        requests:
+          cpu: "6"
+          memory: 24Gi
+      securityContext:
+        privileged: true
+- annotations:
+    created-by-job-forker: "true"
     description: Runs end-to-end tests on a Seed with 3 zones with a Shoot with failure
       tolerance type 'zone' for gardener developments periodically
     testgrid-dashboards: gardener-gardener
@@ -37,6 +77,46 @@ periodics:
         requests:
           cpu: "12"
           memory: 48Gi
+      securityContext:
+        privileged: true
+- annotations:
+    created-by-job-forker: "true"
+    description: Runs end-to-end tests on a Seed with single zone with a Shoot with
+      failure tolerance type 'node' for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
+  cluster: gardener-prow-build
+  decorate: true
+  decoration_config:
+    grace_period: 15m0s
+    timeout: 1h0m0s
+  extra_refs:
+  - base_ref: release-v1.62
+    org: gardener
+    repo: gardener
+  interval: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  name: ci-gardener-e2e-kind-ha-single-zone-upgrade-release-v1-62
+  spec:
+    containers:
+    - command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind-ha-single-zone-upgrade
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"
+      image: gcr.io/k8s-staging-test-infra/krte:v20230117-50d6df3625-master
+      name: ""
+      resources:
+        requests:
+          cpu: "6"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-63.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-63.yaml
@@ -1,6 +1,46 @@
 periodics:
 - annotations:
     created-by-job-forker: "true"
+    description: Runs end-to-end Gardener upgrade tests on a Seed with 3 zones with
+      a Shoot with failure tolerance type 'zone' for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
+  cluster: gardener-prow-build
+  decorate: true
+  decoration_config:
+    grace_period: 15m0s
+    timeout: 1h0m0s
+  extra_refs:
+  - base_ref: release-v1.63
+    org: gardener
+    repo: gardener
+  interval: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  name: ci-gardener-e2e-kind-ha-multi-zone-upgrade-release-v1-63
+  spec:
+    containers:
+    - command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind-ha-multi-zone-upgrade
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"
+      image: gcr.io/k8s-staging-test-infra/krte:v20230117-50d6df3625-master
+      name: ""
+      resources:
+        requests:
+          cpu: "6"
+          memory: 24Gi
+      securityContext:
+        privileged: true
+- annotations:
+    created-by-job-forker: "true"
     description: Runs end-to-end tests on a Seed with 3 zones with a Shoot with failure
       tolerance type 'zone' for gardener developments periodically
     testgrid-dashboards: gardener-gardener
@@ -37,6 +77,46 @@ periodics:
         requests:
           cpu: "12"
           memory: 48Gi
+      securityContext:
+        privileged: true
+- annotations:
+    created-by-job-forker: "true"
+    description: Runs end-to-end tests on a Seed with single zone with a Shoot with
+      failure tolerance type 'node' for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
+  cluster: gardener-prow-build
+  decorate: true
+  decoration_config:
+    grace_period: 15m0s
+    timeout: 1h0m0s
+  extra_refs:
+  - base_ref: release-v1.63
+    org: gardener
+    repo: gardener
+  interval: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  name: ci-gardener-e2e-kind-ha-single-zone-upgrade-release-v1-63
+  spec:
+    containers:
+    - command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind-ha-single-zone-upgrade
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"
+      image: gcr.io/k8s-staging-test-infra/krte:v20230117-50d6df3625-master
+      name: ""
+      resources:
+        requests:
+          cpu: "6"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-64.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-64.yaml
@@ -1,6 +1,46 @@
 periodics:
 - annotations:
     created-by-job-forker: "true"
+    description: Runs end-to-end Gardener upgrade tests on a Seed with 3 zones with
+      a Shoot with failure tolerance type 'zone' for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
+  cluster: gardener-prow-build
+  decorate: true
+  decoration_config:
+    grace_period: 15m0s
+    timeout: 1h0m0s
+  extra_refs:
+  - base_ref: release-v1.64
+    org: gardener
+    repo: gardener
+  interval: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  name: ci-gardener-e2e-kind-ha-multi-zone-upgrade-release-v1-64
+  spec:
+    containers:
+    - command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind-ha-multi-zone-upgrade
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"
+      image: gcr.io/k8s-staging-test-infra/krte:v20230207-ce569a5e37-master
+      name: ""
+      resources:
+        requests:
+          cpu: "6"
+          memory: 24Gi
+      securityContext:
+        privileged: true
+- annotations:
+    created-by-job-forker: "true"
     description: Runs end-to-end tests on a Seed with 3 zones with a Shoot with failure
       tolerance type 'zone' for gardener developments periodically
     testgrid-dashboards: gardener-gardener
@@ -37,6 +77,46 @@ periodics:
         requests:
           cpu: "12"
           memory: 48Gi
+      securityContext:
+        privileged: true
+- annotations:
+    created-by-job-forker: "true"
+    description: Runs end-to-end Gardener upgrade tests on a Seed with single zone with a Shoot with
+      failure tolerance type 'node' for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
+  cluster: gardener-prow-build
+  decorate: true
+  decoration_config:
+    grace_period: 15m0s
+    timeout: 1h0m0s
+  extra_refs:
+  - base_ref: release-v1.64
+    org: gardener
+    repo: gardener
+  interval: 4h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  name: ci-gardener-e2e-kind-ha-single-zone-upgrade-release-v1-64
+  spec:
+    containers:
+    - command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind-ha-single-zone-upgrade
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"
+      image: gcr.io/k8s-staging-test-infra/krte:v20230207-ce569a5e37-master
+      name: ""
+      resources:
+        requests:
+          cpu: "6"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:


### PR DESCRIPTION
Reverts gardener/ci-infra#570
Now tests are more stable.


cc: @rfranzke 