### PR TITLE
Create docker configuration for dind to enable using nodes with cgroupv2

### DIFF
--- a/config/prow/cluster/base/dind-docker-config_configmap.yaml
+++ b/config/prow/cluster/base/dind-docker-config_configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dind-docker-config
+  namespace: test-pods
+data:
+  daemon.json: |-
+    {
+      "cgroup-parent": "prowparent.slice"
+    }

--- a/config/prow/cluster/base/kustomization.yaml
+++ b/config/prow/cluster/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - cpu-limit-range_limitrange.yaml
 - mem-limit-range_limitrange.yaml
 - gce-ssd_storageclass.yaml
+- dind-docker-config_configmap.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -317,11 +317,16 @@ presets:
   # krte (normal) path
   - name: docker-root
     emptyDir: {}
+  - name: docker-config
+    configMap:
+      name: dind-docker-config
   volumeMounts:
   - name: docker-graph
     mountPath: /docker-graph
   - name: docker-root
     mountPath: /var/lib/docker
+  - name: docker-config
+    mountPath: /etc/docker
 # volume mounts for kind
 - labels:
     preset-kind-volume-mounts: "true"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR defines a docker `daemon.json` which enables us running docker in docker e2e tests on nodes with `cgroupv2` and mounts it into the respective pods.
It works on nodes using `cgroupv1` too, so we can already apply it in advance.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
