### PR TITLE
Add missing tagging schemes for building `copy-images` image

### DIFF
--- a/config/jobs/ci-infra/build-job-images.yaml
+++ b/config/jobs/ci-infra/build-job-images.yaml
@@ -72,6 +72,8 @@ postsubmits:
         - --registry=eu.gcr.io/gardener-project/ci-infra
         - --target=copy-images
         - --dockerfile=images/copy-images/Dockerfile
+        - --add-date-sha-tag=true
+        - --add-fixed-tag=latest
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted
         # to multiple build pods in parallel.


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:

Follow up to https://github.com/gardener/ci-infra/pull/629

**Which issue(s) this PR fixes**:
From https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-ci-infra-build-copy-images-image/1637844844749524992:

```
time="2023-03-20T15:55:13Z" level=fatal msg="Invalid options: please choose at least one tagging scheme" func=main.main file="/code/prow/cmd/image-builder/main.go:186" severity=fatal
```