### PR TITLE
Remove custom `daemon.json` from docker in docker preset

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -317,16 +317,11 @@ presets:
   # krte (normal) path
   - name: docker-root
     emptyDir: {}
-  - name: docker-config
-    configMap:
-      name: dind-docker-config
   volumeMounts:
   - name: docker-graph
     mountPath: /docker-graph
   - name: docker-root
     mountPath: /var/lib/docker
-  - name: docker-config
-    mountPath: /etc/docker
 # volume mounts for kind
 - labels:
     preset-kind-volume-mounts: "true"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The `cgroup-parent` setting added to `daemon.json` of e2e test in #623 prevents pods running in `machine-shoot-...` kindest-node pods from being started successfully. 
```
Error: failed to get sandbox container task: no running task found: task ee65eb9e787d7740af0ab5199e77c3158969a484775dfc5b55ccd064c81773b6 not found: not found
```
Thus, we have to revert this setting until 
- we use nodes with GL 934 in prow
- machine-controller-manager-provider-local uses a version of kindest-node which uses systemd cgroup driver 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
