### PR TITLE
Fix volumeMounts in copy-images prow job

### DIFF
--- a/config/jobs/ci-infra/copy-images.yaml
+++ b/config/jobs/ci-infra/copy-images.yaml
@@ -24,7 +24,7 @@ postsubmits:
         - ./config/images/images.yaml
         volumeMounts:
         - name: docker-config
-          path: /root/.docker
+          mountPath: /root/.docker
       volumes:
       - name: docker-config
         secret:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
This PR adds a `mountPath` to volume mounts definition of copy-images prow job.

**Which issue(s) this PR fixes**:
Fixes #631 

**Special notes for your reviewer**:
