### PR TITLE
Fix trigger for copy-images job

### DIFF
--- a/config/jobs/ci-infra/copy-images.yaml
+++ b/config/jobs/ci-infra/copy-images.yaml
@@ -2,7 +2,7 @@ postsubmits:
   gardener/ci-infra:
   - name: post-ci-infra-copy-images
     cluster: gardener-prow-trusted
-    run_if_changed: '^images\/copy-images\/'
+    run_if_changed: '^config\/images\/'
     branches:
     - ^master$
     annotations:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Previous configuration looked at wrong folder changes.  
Part of #619 

