### PR TITLE
Addedd kubernetesui/dashboard v2.2.0 to copy-images.yaml

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -11,6 +11,7 @@ images:
 - source: kubernetesui/dashboard
   destination: eu.gcr.io/gardener-project/3rd/kubernetesui/dashboard
   tags:
+  - v2.2.0
   - v2.4.0
   - v2.5.1
 - source: kubernetesui/metrics-scraper


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Add missing kubernetesui/dashboard v2.2.0 to copy-images.yaml
Part of #619 
