### PR TITLE
Increase timeout for periodic E2E test job `ci-gardener-e2e-kind-ha-multi-zone-upgrade-release-v1-65`

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
@@ -8,7 +8,7 @@ presubmits:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true
     decoration_config:
-      timeout: 60m
+      timeout: 1h30m0s
       grace_period: 15m
     labels:
       preset-dind-enabled: "true"
@@ -46,7 +46,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 60m
+    timeout: 1h30m0s
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-64.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-64.yaml
@@ -9,7 +9,7 @@ periodics:
   decorate: true
   decoration_config:
     grace_period: 15m0s
-    timeout: 1h0m0s
+    timeout: 1h30m0s
   extra_refs:
   - base_ref: release-v1.64
     org: gardener

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-65.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-65.yaml
@@ -9,7 +9,7 @@ periodics:
   decorate: true
   decoration_config:
     grace_period: 15m0s
-    timeout: 1h0m0s
+    timeout: 1h15m0s
   extra_refs:
   - base_ref: release-v1.65
     org: gardener

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-65.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-65.yaml
@@ -9,7 +9,7 @@ periodics:
   decorate: true
   decoration_config:
     grace_period: 15m0s
-    timeout: 1h15m0s
+    timeout: 1h30m0s
   extra_refs:
   - base_ref: release-v1.65
     org: gardener

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-66.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-66.yaml
@@ -9,7 +9,7 @@ periodics:
   decorate: true
   decoration_config:
     grace_period: 15m0s
-    timeout: 1h0m0s
+    timeout: 1h30m0s
   extra_refs:
   - base_ref: release-v1.66
     org: gardener


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
The periodic E2E test job `ci-gardener-e2e-kind-ha-multi-zone-upgrade-release-v1-65` has been failing while deleting seed/cluster, mostly due to an early exit error caused by a timeout. To address this issue, the timeout has been increased from 1 hour to 1 hour and 15 minutes. This issue only happens with this release job.

**Prow job links:**
- [1638419944154599424](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ha-multi-zone-upgrade-release-v1-65/1638419944154599424#1:build-log.txt%3A901-925)
- [1637936557220433920](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ha-multi-zone-upgrade-release-v1-65/1637936557220433920#1:build-log.txt%3A875-886)
- [1637755184073412608](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ha-multi-zone-upgrade-release-v1-65/1637755184073412608#1:build-log.txt%3A853-877)
- [1637694785298894848](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ha-multi-zone-upgrade-release-v1-65/1637694785298894848#1:build-log.txt%3A910-933)
- [1637513589453492224](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ha-multi-zone-upgrade-release-v1-65/1637513589453492224#1:build-log.txt%3A888-898)
- [1637332393373208576](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ha-multi-zone-upgrade-release-v1-65/1637332393373208576#1:build-log.txt%3A845-869)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc: @rfranzke 