### PR TITLE
copy-images: switch back to sh

### DIFF
--- a/config/images/copy-images.sh
+++ b/config/images/copy-images.sh
@@ -1,7 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
 set -o errexit
-set -o pipefail
 set -o nounset
 
 filepath="$1"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
My bad, alpine doesn't have bash but only sh. Shellcheck tells me the `pipefail` option is not defined in POSIX sh, so drop it.

**Which issue(s) this PR fixes**:
Follow-up to #640 

**Special notes for your reviewer**:
