### PR TITLE
Add new versions and manila-csi-plugin for openstack provider

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -99,9 +99,17 @@ images:
   - v1.22.2
   - v1.23.4
   - v1.24.5
+  - v1.24.6
   - v1.25.3
+  - v1.25.5
   - v1.26.0
-  # gardener-extension-registry-cache/charts/images.yaml
+  - v1.26.2
+- source: k8scloudprovider/manila-csi-plugin
+  destination: eu.gcr.io/gardener-project/3rd/k8scloudprovider/manila-csi-plugin
+  tags:
+  - v1.25.5
+  - v1.26.2
+# gardener-extension-registry-cache/charts/images.yaml
 - source: registry
   destination: eu.gcr.io/gardener-project/3rd/registry
   tags:


### PR DESCRIPTION
Added new images to images.yaml from the following repositories:

* gardener-extension-provider-openstack

/kind enhancement

What this PR does / why we need it:
This adds the last missing container images to Gardener GCR that are not yet copied from DockerHub.

related to
- https://github.com/gardener/gardener-extension-provider-openstack/pull/588
- https://github.com/gardener/gardener-extension-provider-openstack/pull/572
