### PR TITLE
Clean up copies for `openstack-cloud-controller-manager` and `cinder-csi-plugin`

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -88,9 +88,6 @@ images:
   - v1.21.0
   - v1.22.2
   - v1.23.4
-  - v1.24.6
-  - v1.25.5
-  - v1.26.2
 - source: k8scloudprovider/cinder-csi-plugin
   destination: eu.gcr.io/gardener-project/3rd/k8scloudprovider/cinder-csi-plugin
   tags:
@@ -98,9 +95,6 @@ images:
   - v1.21.0
   - v1.22.2
   - v1.23.4
-  - v1.24.5
-  - v1.25.3
-  - v1.26.0
   # gardener-extension-registry-cache/charts/images.yaml
 - source: registry
   destination: eu.gcr.io/gardener-project/3rd/registry


### PR DESCRIPTION
/kind cleanup

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
https://github.com/gardener/gardener-extension-provider-openstack/pull/593 proposes to eliminate the Gardener GCR copies for `openstack-cloud-controller-manager:{v1.24.6,v1.25.5,v1.26.2}` and `cinder-csi-plugin:{v1.24.5,v1.25.3,v1.26.0}`.

**Which issue(s) this PR fixes**:
See above

**Special notes for your reviewer**:
N/A