### PR TITLE
Github authentication for monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 This repository contains configuration files for the testing and automation needs of the Gardener project.
 
-## ⚠️ Warning 🚧
-
-This is currently under construction / in evaluation phase.
-
 ## CI Job Management
 
 Gardener uses a [`prow`](https://github.com/kubernetes/test-infra/blob/master/prow) instance at [prow.gardener.cloud](https://prow.gardener.cloud) to handle CI and automation for parts of the project.
@@ -87,6 +83,14 @@ The following commands assume you are using the combined `kubeconfig` generated 
       ```bash
       kubectl config use-context gardener-prow-trusted
       kubectl -n prow create secret generic oauth-cookie-secret --from-literal=secret=$(openssl rand -base64 32)
+      ```
+    - `oauth2-proxy`
+      ```bash
+      kubectl config use-context gardener-prow-trusted
+      kubectl -n oauth2-proxy create secret generic oauth2-proxy \
+      --from-literal=cookie-secret=$(openssl rand -base64 32) \
+      --from-literal=client-id=<Github OAuth2 Proxy App client-id> \
+      --from-literal=client-secret=<Github OAuth2 Proxy App client-secret>
       ```
     - `kubeconfig` (ref [test-infra guide](https://github.com/kubernetes/test-infra/blob/f8021394c8e493af2d3ec336a87888368d92e0c8/prow/getting_started_deploy.md#run-test-pods-in-different-clusters), needs to be present in the `prow` and `test-pods` namespace of the prow-trusted cluster)
       - add two contexts: the prow cluster as `gardener-prow-trusted` and the build/workload cluster as `gardener-prow-build`

--- a/config/prow/cluster/monitoring/build-cluster/grafana-ingress.yaml
+++ b/config/prow/cluster/monitoring/build-cluster/grafana-ingress.yaml
@@ -8,6 +8,8 @@ metadata:
     cert.gardener.cloud/purpose: managed
     dns.gardener.cloud/class: garden
     dns.gardener.cloud/dnsnames: monitoring-build.prow.gardener.cloud
+    nginx.ingress.kubernetes.io/auth-url: https://oauth2.prow.gardener.cloud/oauth2/auth
+    nginx.ingress.kubernetes.io/auth-signin: https://oauth2.prow.gardener.cloud/oauth2/start?rd=https%3A//monitoring-build.prow.gardener.cloud
 spec:
   rules:
   - host: monitoring-build.prow.gardener.cloud

--- a/config/prow/cluster/monitoring/trusted-cluster/grafana-ingress.yaml
+++ b/config/prow/cluster/monitoring/trusted-cluster/grafana-ingress.yaml
@@ -8,6 +8,8 @@ metadata:
     cert.gardener.cloud/purpose: managed
     dns.gardener.cloud/class: garden
     dns.gardener.cloud/dnsnames: monitoring.prow.gardener.cloud
+    nginx.ingress.kubernetes.io/auth-url: https://oauth2.prow.gardener.cloud/oauth2/auth
+    nginx.ingress.kubernetes.io/auth-signin: https://oauth2.prow.gardener.cloud/oauth2/start?rd=https%3A//monitoring.prow.gardener.cloud
 spec:
   rules:
   - host: monitoring.prow.gardener.cloud

--- a/config/prow/cluster/oauth2-proxy/config/oauth2_proxy.cfg
+++ b/config/prow/cluster/oauth2-proxy/config/oauth2_proxy.cfg
@@ -1,0 +1,13 @@
+## OAuth2 Proxy Config File
+## https://github.com/oauth2-proxy/oauth2-proxy
+reverse_proxy = true
+
+redirect_url = "https://oauth2.prow.gardener.cloud/oauth2/callback"
+
+pass_host_header = true
+pass_access_token = false
+
+cookie_name = "_gardener_prow"
+cookie_expire = "168h"
+cookie_secure = true
+cookie_httponly = true

--- a/config/prow/cluster/oauth2-proxy/helm/README.md
+++ b/config/prow/cluster/oauth2-proxy/helm/README.md
@@ -1,0 +1,4 @@
+`../oauth2-proxy-deployment.yaml` was generated from helm chart **oauth2-proxy/oauth2-proxy**.
+
+
+`generate-oauth2-proxy-deployments.sh` is templating and overwriting this configuration based on the latest version of the helm chart.

--- a/config/prow/cluster/oauth2-proxy/helm/generate-oauth2-proxy-deployments.sh
+++ b/config/prow/cluster/oauth2-proxy/helm/generate-oauth2-proxy-deployments.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script templates the oauth2-proxy helm chart for gardener-ci prow cluster
+# and replaces the old content of /config/prow/cluster/oauth2-proxy/oauth2-proxy with the freshly templated version
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+if ! which helm &>/dev/null; then
+  echo "helm not found, please install it"
+  exit 1
+fi
+
+echo "Adding & updating oauth2-proxy helm repository"
+helm repo add oauth2-proxy https://oauth2-proxy.github.io/manifests
+helm repo update
+
+echo "Templating oauth2-proxy"
+helm template oauth2-proxy oauth2-proxy/oauth2-proxy -f $SCRIPT_DIR/values.yaml > $SCRIPT_DIR/../oauth2-proxy-deployment.yaml
+
+echo "Done"

--- a/config/prow/cluster/oauth2-proxy/helm/values.yaml
+++ b/config/prow/cluster/oauth2-proxy/helm/values.yaml
@@ -1,0 +1,67 @@
+# Check values.yaml of oauth2-proxy for help https://github.com/oauth2-proxy/manifests/blob/main/helm/oauth2-proxy/values.yaml
+extraArgs:
+  whitelist-domain: .prow.gardener.cloud
+  cookie-domain: .prow.gardener.cloud
+  provider: github
+  github-org: gardener
+  email-domain: "*"
+  scope: "user:email"
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: worker.gardener.cloud/system-components
+          operator: In
+          values:
+          - "true"
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - ingress-nginx
+          - key: app.kubernetes.io/instance
+            operator: In
+            values:
+            - ingress-nginx
+          - key: app.kubernetes.io/component
+            operator: In
+            values:
+            - controller
+        topologyKey: kubernetes.io/hostname
+
+config:
+  existingSecret: oauth2-proxy
+  existingConfig: oauth2-proxy
+
+ingress:
+  enabled: true
+  path: /
+  pathType: Prefix
+  hosts:
+  - oauth2.prow.gardener.cloud
+  annotations:
+    cert.gardener.cloud/issuer: ci-issuer
+    cert.gardener.cloud/purpose: managed
+    dns.gardener.cloud/class: garden
+    dns.gardener.cloud/dnsnames: oauth2.prow.gardener.cloud
+  tls:
+  - secretName: oauth2-proxy-tls
+    hosts:
+    - oauth2.prow.gardener.cloud
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 300Mi
+  requests:
+    cpu: 100m
+    memory: 300Mi
+
+replicaCount: 2

--- a/config/prow/cluster/oauth2-proxy/helm/values.yaml
+++ b/config/prow/cluster/oauth2-proxy/helm/values.yaml
@@ -4,6 +4,7 @@ extraArgs:
   cookie-domain: .prow.gardener.cloud
   provider: github
   github-org: gardener
+  github-repo: gardener/ci-infra
   email-domain: "*"
   scope: "user:email"
 

--- a/config/prow/cluster/oauth2-proxy/helm/values.yaml
+++ b/config/prow/cluster/oauth2-proxy/helm/values.yaml
@@ -4,7 +4,7 @@ extraArgs:
   cookie-domain: .prow.gardener.cloud
   provider: github
   github-org: gardener
-  github-repo: gardener/ci-infra
+  github-user: timebertt
   email-domain: "*"
   scope: "user:email"
 

--- a/config/prow/cluster/oauth2-proxy/kustomization.yaml
+++ b/config/prow/cluster/oauth2-proxy/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: oauth2-proxy
+
+resources:
+- oauth2-proxy-namespace.yaml
+- oauth2-proxy-deployment.yaml
+
+configMapGenerator:
+- name: oauth2-proxy
+  options:
+    labels:
+      app: oauth2-proxy    
+      app.kubernetes.io/component: authentication-proxy
+      app.kubernetes.io/part-of: oauth2-proxy
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy
+      app.kubernetes.io/version: "7.4.0"
+  files:
+  - config/oauth2_proxy.cfg

--- a/config/prow/cluster/oauth2-proxy/oauth2-proxy-deployment.yaml
+++ b/config/prow/cluster/oauth2-proxy/oauth2-proxy-deployment.yaml
@@ -1,0 +1,246 @@
+---
+# Source: oauth2-proxy/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-6.10.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/version: "7.4.0"
+  name: oauth2-proxy
+spec:
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy
+  minAvailable: 1
+---
+# Source: oauth2-proxy/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-6.10.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/version: "7.4.0"
+  name: oauth2-proxy
+automountServiceAccountToken : true
+---
+# Source: oauth2-proxy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-6.10.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/version: "7.4.0"
+  name: oauth2-proxy
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      appProtocol: http
+      name: http
+    - port: 44180
+      protocol: TCP
+      appProtocol: http
+      targetPort: metrics
+      name: metrics
+  selector:    
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy
+---
+# Source: oauth2-proxy/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-6.10.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/version: "7.4.0"
+  name: oauth2-proxy
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: oauth2-proxy
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum/config-emails: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum/secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/google-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/redis-secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+      labels:
+        app: oauth2-proxy        
+        helm.sh/chart: oauth2-proxy-6.10.1
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: authentication-proxy
+        app.kubernetes.io/part-of: oauth2-proxy
+        app.kubernetes.io/name: oauth2-proxy
+        app.kubernetes.io/instance: oauth2-proxy
+        app.kubernetes.io/version: "7.4.0"
+    spec:
+      serviceAccountName: oauth2-proxy
+      automountServiceAccountToken : true
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.4.0"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --http-address=0.0.0.0:4180
+          - --https-address=0.0.0.0:4443
+          - --metrics-address=0.0.0.0:44180
+          - --cookie-domain=.prow.gardener.cloud
+          - --email-domain=*
+          - --github-org=gardener
+          - --provider=github
+          - --scope=user:email
+          - --whitelist-domain=.prow.gardener.cloud
+          - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
+        env:
+        - name: OAUTH2_PROXY_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy
+              key: client-id
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy
+              key: client-secret
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  oauth2-proxy
+              key: cookie-secret
+        ports:
+          - containerPort: 4180
+            name: http
+            protocol: TCP
+          - containerPort: 44180
+            protocol: TCP
+            name: metrics
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 0
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 0
+          timeoutSeconds: 5
+          successThreshold: 1
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        volumeMounts:
+        - mountPath: /etc/oauth2_proxy/oauth2_proxy.cfg
+          name: configmain
+          subPath: oauth2_proxy.cfg
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: oauth2-proxy
+        name: configmain
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: worker.gardener.cloud/system-components
+                operator: In
+                values:
+                - "true"
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - ingress-nginx
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - ingress-nginx
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      tolerations:
+        []
+---
+# Source: oauth2-proxy/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-6.10.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: oauth2-proxy
+    app.kubernetes.io/version: "7.4.0"
+  name: oauth2-proxy
+  annotations:
+    cert.gardener.cloud/issuer: ci-issuer
+    cert.gardener.cloud/purpose: managed
+    dns.gardener.cloud/class: garden
+    dns.gardener.cloud/dnsnames: oauth2.prow.gardener.cloud
+spec:
+  rules:
+    - host: "oauth2.prow.gardener.cloud"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: oauth2-proxy
+                port:
+                  number: 80
+  tls:
+    - hosts:
+      - oauth2.prow.gardener.cloud
+      secretName: oauth2-proxy-tls

--- a/config/prow/cluster/oauth2-proxy/oauth2-proxy-deployment.yaml
+++ b/config/prow/cluster/oauth2-proxy/oauth2-proxy-deployment.yaml
@@ -119,7 +119,7 @@ spec:
           - --cookie-domain=.prow.gardener.cloud
           - --email-domain=*
           - --github-org=gardener
-          - --github-repo=gardener/ci-infra
+          - --github-user=timebertt
           - --provider=github
           - --scope=user:email
           - --whitelist-domain=.prow.gardener.cloud

--- a/config/prow/cluster/oauth2-proxy/oauth2-proxy-deployment.yaml
+++ b/config/prow/cluster/oauth2-proxy/oauth2-proxy-deployment.yaml
@@ -119,6 +119,7 @@ spec:
           - --cookie-domain=.prow.gardener.cloud
           - --email-domain=*
           - --github-org=gardener
+          - --github-repo=gardener/ci-infra
           - --provider=github
           - --scope=user:email
           - --whitelist-domain=.prow.gardener.cloud

--- a/config/prow/cluster/oauth2-proxy/oauth2-proxy-namespace.yaml
+++ b/config/prow/cluster/oauth2-proxy/oauth2-proxy-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: oauth2-proxy

--- a/config/prow/deploy.sh
+++ b/config/prow/deploy.sh
@@ -85,6 +85,11 @@ kubectl apply --server-side=true -k "$SCRIPT_DIR/cluster/ingress-nginx"
 kubectl wait --for=condition=available deployment -l app.kubernetes.io/component=controller -n ingress-nginx --timeout 2m
 echo "$(color-green done)"
 
+echo "$(color-step "Deploying oauth2-proxy components to gardener-prow-trusted cluster...")"
+kubectl config use-context gardener-prow-trusted
+kubectl apply --server-side=true -k "$SCRIPT_DIR/cluster/oauth2-proxy"
+echo "$(color-green done)"
+
 echo "$(color-step "Deploying monitoring components to gardener-prow-trusted cluster...")"
 kubectl config use-context gardener-prow-trusted
 kubectl apply --server-side=true -k "$SCRIPT_DIR/cluster/monitoring/trusted-cluster"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR deploys `oauth2_proxy` v7.4.0 ([ref](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.4.0)) in the trusted cluster in order to enable Github authentication for the monitoring UIs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
