### PR TITLE
Update to Go 1.20.3 & 1.19.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir /build && GOBIN=/build \
 
 FROM gcr.io/distroless/static-debian11:nonroot AS base_nonroot
 
-FROM alpine:3.17.2 AS ssl_git_runner
+FROM alpine:3.17.3 AS ssl_git_runner
 # Install SSL ca certificates
 RUN apk add --no-cache ca-certificates git
 # Create nonroot user and group to be used in executable containers

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ----------------
 # Build container
 # ----------------
-ARG GOLANG_VERSION=1.19.7
+ARG GOLANG_VERSION=1.19.8
 
 FROM golang:${GOLANG_VERSION} AS builder
 LABEL stage=intermediate

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 REGISTRY          := $(shell cat .REGISTRY 2>/dev/null)
 PUSH_LATEST_TAG   := true
-GOLANG_VERSION    := 1.19.7
+GOLANG_VERSION    := 1.19.8
 VERSION           := v$(shell date '+%Y%m%d')-$(shell git rev-parse --short HEAD)
 
 IMG_GOLANG_TEST := golang-test

--- a/images/golang-test/variants.yaml
+++ b/images/golang-test/variants.yaml
@@ -2,6 +2,6 @@ variants:
   "1.18":
     GOLANG_VERSION: "1.18.10"
   "1.19":
-    GOLANG_VERSION: "1.19.7"
+    GOLANG_VERSION: "1.19.8"
   "1.20":
-    GOLANG_VERSION: "1.20.2"
+    GOLANG_VERSION: "1.20.3"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Go [1.20.3](https://go.dev/doc/devel/release#go1.20.3) and [1.19.8](https://go.dev/doc/devel/release#go1.19.8) are released.
Alongside, alpine is updated to [3.17.3](https://www.alpinelinux.org/posts/Alpine-3.17.3-released.html).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
