### PR TITLE
Add v3.5.0 equinix ccm to image copy

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -87,6 +87,7 @@ images:
   destination: eu.gcr.io/gardener-project/3rd/equinix/cloud-provider-equinix-metal
   tags:
   - v3.5.0
+  - v3.6.0
 - source: packethost/metabot
   destination: eu.gcr.io/gardener-project/3rd/packethost/metabot
   tags:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
Copies a new version of the equinix ccm to the gardener registry.
This is needed for https://github.com/gardener/gardener-extension-provider-equinix-metal/pull/254

