### PR TITLE
Fix indent in `labels.yaml`

### DIFF
--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -86,6 +86,12 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
+      - name: area/ipcei
+        color: 0052cc
+        description: IPCEI (Important Project of Common European Interest)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
       - name: area/logging
         color: 0052cc
         description: Logging related
@@ -356,12 +362,6 @@ repos:
         addedBy: anyone
         previously:
           - name: discussion
-      - name: area/ipcei
-        color: 0052cc
-        description: IPCEI (Important Project of Common European Interest)
-        target: both
-        prowPlugin: label
-        addedBy: anyone
       # os
       - name: os/garden-linux
         color: 187c00
@@ -911,6 +911,12 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
+      - name: area/ipcei
+        color: 0052cc
+        description: IPCEI (Important Project of Common European Interest)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
       - name: area/logging
         color: 0052cc
         description: Logging related
@@ -1181,12 +1187,6 @@ repos:
         addedBy: anyone
         previously:
           - name: discussion
-      - name: area/ipcei
-        color: 0052cc
-        description: IPCEI (Important Project of Common European Interest)
-        target: both
-        prowPlugin: label
-        addedBy: anyone
       # os
       - name: os/garden-linux
         color: 187c00
@@ -1761,6 +1761,12 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
+      - name: area/ipcei
+        color: 0052cc
+        description: IPCEI (Important Project of Common European Interest)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
       - name: area/logging
         color: 0052cc
         description: Logging related
@@ -2031,12 +2037,6 @@ repos:
         addedBy: anyone
         previously:
           - name: discussion
-      - name: area/ipcei
-        color: 0052cc
-        description: IPCEI (Important Project of Common European Interest)
-        target: both
-        prowPlugin: label
-        addedBy: anyone
       # os
       - name: os/garden-linux
         color: 187c00
@@ -2410,909 +2410,909 @@ repos:
         prowPlugin: cla-assistant
         isExternalPlugin: true
         addedBy: prow
-gardener/gardener-extension-shoot-oidc-service:
-  labels:
-    - color: b60205
-      description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
-      name: needs-ok-to-test
-      target: prs
-      prowPlugin: trigger
-      addedBy: prow
-    - color: 15dd18
-      description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
-      name: ok-to-test
-      target: prs
-      prowPlugin: trigger
-      addedBy: prow
-gardener/dependency-watchdog:
-  labels:
-    # area
-    - name: area/audit-logging
-      color: 0052cc
-      description: Audit logging related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/auto-scaling
-      color: 0052cc
-      description: Auto-scaling (CA/HPA/VPA/HVPA, predominantly control plane, but also otherwise) related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/backup
-      color: 0052cc
-      description: Backup related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/compliance
-      color: 0052cc
-      description: Compliance related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-      previously:
-        - name: 'area/certification'
-    - name: area/control-plane
-      color: 0052cc
-      description: Control plane related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/control-plane-migration
-      color: 0052cc
-      description: Control plane migration related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/cost
-      color: 0052cc
-      description: Cost related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/delivery
-      color: 0052cc
-      description: Delivery related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/dev-productivity
-      color: 0052cc
-      description: Developer productivity related (how to improve development)
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/disaster-recovery
-      color: 0052cc
-      description: Disaster recovery related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/documentation
-      color: 0052cc
-      description: Documentation related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-      previously:
-        - name: documentation
-    - name: area/high-availability
-      color: 0052cc
-      description: High availability related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/logging
-      color: 0052cc
-      description: Logging related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/metering
-      color: 0052cc
-      description: Metering related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/monitoring
-      color: 0052cc
-      description: Monitoring (including availability monitoring and alerting) related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/networking
-      color: 0052cc
-      description: Networking related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/open-source
-      color: 0052cc
-      description: Open Source (community, enablement, contributions, conferences, CNCF, etc.) related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/ops-productivity
-      color: 0052cc
-      description: Operator productivity related (how to improve operations)
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/os
-      color: 0052cc
-      description: Operator system related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/performance
-      color: 0052cc
-      description: Performance (across all domains, such as control plane, networking, storage, etc.) related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/quality
-      color: 0052cc
-      description: Output qualification (tests, checks, scans, automation in general, etc.) related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/robustness
-      color: 0052cc
-      description: Robustness, reliability, resilience related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/scalability
-      color: 0052cc
-      description: Scalability related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/security
-      color: 0052cc
-      description: Security related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/storage
-      color: 0052cc
-      description: Storage related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/testing
-      color: 0052cc
-      description: Testing related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/usability
-      color: 0052cc
-      description: Usability related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: area/user-management
-      color: 0052cc
-      description: User-management related
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    # component
-    - name: component/cicd
-      color: 25399e
-      description: Continuous integration/delivery (tooling and processes)
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: component/dashboard
-      color: 25399e
-      description: Gardener Dashboard
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: component/documentation
-      color: 25399e
-      description: Gardener Documentation
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: component/etcd-backup-restore
-      color: 25399e
-      description: ETCD Backup & Restore
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: component/etcd-druid
-      color: 25399e
-      description: ETCD Druid
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: component/gardenctl
-      color: 25399e
-      description: Gardener CLI
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: component/gardener
-      color: 25399e
-      description: Gardener
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: component/hvpa
-      color: 25399e
-      description: HVPA
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: component/kubify
-      color: 25399e
-      description: Kubify
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: component/landscaper
-      color: 25399e
-      description: Landscape Installer
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: component/mcm
-      color: 25399e
-      description: Machine Controller Manager (including Node Problem Detector, Cluster Auto Scaler, etc.)
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: component/tm
-      color: 25399e
-      description: Test machinery (tooling and processes)
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    # kind
-    - name: kind/epic
-      color: c7def8
-      description: Large multi-story topic
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-      previously:
-        - name: epic
-    - name: kind/bug
-      color: e11d21
-      description: Bug
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-      previously:
-        - name: bug
-    - name: kind/regression
-      color: e11d21
-      description: Bug that hit us already in the past and that is reappearing/requires a proper solution
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: kind/post-mortem
-      color: e11d21
-      description: Bug that requires deeper analysis after immediate issues were resolved (usually after downtime)
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: kind/impediment
-      color: eb6420
-      description: Something that impedes developers, operators, users or others in their work
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: kind/technical-debt
-      color: eb6420
-      description: Something that is only solved on the surface, but requires more (re)work to be done properly
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: kind/api-change
-      color: eb6420
-      description: API change with impact on API users
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: kind/enhancement
-      color: c7def8
-      description: Enhancement, improvement, extension
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-      previously:
-        - name: enhancement
-    - name: kind/poc
-      color: c7def8
-      description: Proof of concept or prototype
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: kind/task
-      color: c7def8
-      description: General task
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: kind/test
-      color: c7def8
-      description: Test
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: kind/flake
-      color: f7c6c7
-      description: Tracking or fixing a flaky test
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: kind/cleanup
-      color: c7def8
-      description: Something that is not needed anymore and can be cleaned up
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - name: kind/question
-      color: c7def8
-      description: Question (asking for help, advice, or technical detail)
-      target: issues
-      prowPlugin: label
-      addedBy: anyone
-      previously:
-        - name: question
-    - name: kind/discussion
-      color: c7def8
-      description: Discussion (engaging others in deciding about multiple options)
-      target: issues
-      prowPlugin: label
-      addedBy: anyone
-      previously:
-        - name: discussion
-    - name: area/ipcei
-      color: 0052cc
-      description: IPCEI (Important Project of Common European Interest)
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    # os
-    - name: os/garden-linux
-      color: 187c00
-      description: Related to Garden Linux OS
-      target: both
-      addedBy: anyone
-    - name: os/suse-chost
-      color: 187c00
-      description: Related to SUSE Container Host OS
-      target: both
-      addedBy: anyone
-    - name: os/ubuntu
-      color: 187c00
-      description: Related to Ubuntu OS
-      target: both
-      addedBy: anyone
-    # platform
-    - name: platform/alicloud
-      color: 006b75
-      description: Alicloud platform/infrastructure
-      target: both
-      addedBy: anyone
-    - name: platform/aws
-      color: 006b75
-      description: Amazon web services platform/infrastructure
-      target: both
-      addedBy: anyone
-    - name: platform/aws-gov
-      color: 006b75
-      description: Amazon web services (government) platform/infrastructure
-      target: both
-      addedBy: anyone
-    - name: platform/azure
-      color: 006b75
-      description: Microsoft Azure platform/infrastructure
-      target: both
-      addedBy: anyone
-    - name: platform/metal
-      color: 006b75
-      description: Bare metal platform/infrastructure
-      target: both
-      addedBy: anyone
-    - name: platform/kubevirt
-      color: 006b75
-      description: Container Native Virtualization (CNV) KubeVirt platform/infrastructure
-      target: both
-      addedBy: anyone
-    - name: platform/converged-cloud
-      color: 006b75
-      description: Converged Cloud (CC) platform/infrastructure
-      target: both
-      addedBy: anyone
-    - name: platform/gcp
-      color: 006b75
-      description: Google cloud platform/infrastructure
-      target: both
-      addedBy: anyone
-    - name: platform/gmp
-      color: 006b75
-      description: GMP (SEN) platform/infrastructure
-      target: both
-      addedBy: anyone
-    - name: platform/openstack
-      color: 006b75
-      description: OpenStack platform/infrastructure
-      target: both
-      addedBy: anyone
-    - name: platform/equinix-metal
-      color: 006b75
-      description: Equinix Metal platform/infrastructure (previously Packet)
-      target: both
-      addedBy: anyone
-    - name: platform/vsphere
-      color: 006b75
-      description: VMware vSphere platform/infrastructure
-      target: both
-      addedBy: anyone
-    # priority
-    - name: priority/1
-      color: e11d21
-      description: Priority (lower number equals higher priority)
-      target: issues
-      prowPlugin: label
-      addedBy: anyone
-    - name: priority/2
-      color: e54014
-      description: Priority (lower number equals higher priority)
-      target: issues
-      prowPlugin: label
-      addedBy: anyone
-    - name: priority/3
-      color: e96f0b
-      description: Priority (lower number equals higher priority)
-      target: issues
-      prowPlugin: label
-      addedBy: anyone
-    - name: priority/4
-      color: ec9a04
-      description: Priority (lower number equals higher priority)
-      target: issues
-      prowPlugin: label
-      addedBy: anyone
-    - name: priority/5
-      color: fbca04
-      description: Priority (lower number equals higher priority)
-      target: issues
-      prowPlugin: label
-      addedBy: anyone
-    # roadmap
-    - name: roadmap/cloud
-      color: 4c38a5
-      description: Roadmap for the (managed) cloud delivery, i.e. gardener.cloud.sap
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-      previously:
-        - name: roadmap/cloud-sap
-    - name: roadmap/standalone
-      color: 4c38a5
-      description: Roadmap for the (on-prem) standalone delivery, e.g. CDC, NS2, etc.
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-      previously:
-        - name: roadmap/on-prem
-    - name: roadmap/internal
-      color: 4c38a5
-      description: Roadmap for our team-internal goals, e.g. drive up seed utilization
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-      previously:
-        - name: roadmap/team-internal
-    # prow
-    - color: 0ffa16
-      description: Indicates a PR has been approved by an approver from all required OWNERS files.
-      name: approved
-      target: prs
-      prowPlugin: approve
-      addedBy: approvers
-    - color: fef2c0
-      description: Indicates a cherry-pick PR into a release branch has been approved by the release branch manager. # Consumed by the kubernetes/kubernetes cherry-pick-queue.
-      name: cherry-pick-approved
-      target: prs
-      addedBy: humans
-    - color: 8fc951
-      description: Indicates an issue or PR is ready to be actively worked on.
-      name: triage/accepted
-      target: both
-      prowPlugin: label
-      addedBy: org members
-    - color: d455d0
-      description: Indicates an issue is a duplicate of other open issue.
-      name: triage/duplicate
-      target: both
-      addedBy: humans
-    - color: d455d0
-      description: Indicates an issue needs more information in order to work on it.
-      name: triage/needs-information
-      target: both
-      addedBy: humans
-    - color: d455d0
-      description: Indicates an issue can not be reproduced as described.
-      name: triage/not-reproducible
-      target: both
-      addedBy: humans
-    - color: d455d0
-      description: Indicates an issue that can not or will not be resolved.
-      name: triage/unresolved
-      target: both
-      addedBy: humans
-    - color: e11d21
-      description: Indicates that a PR should not merge because it touches files in blocked paths.
-      name: do-not-merge/blocked-paths
-      target: prs
-      prowPlugin: blockade
-      addedBy: prow
-    - color: e11d21
-      description: Indicates that a PR is not yet approved to merge into a release branch.
-      name: do-not-merge/cherry-pick-not-approved
-      target: prs
-      addedBy: prow
-      prowPlugin: cherrypickunapproved
-    - color: e11d21
-      description: Indicates that a PR should not merge because someone has issued a /hold command.
-      name: do-not-merge/hold
-      target: prs
-      prowPlugin: hold
-      addedBy: anyone
-    - color: e11d21
-      description: Indicates that a PR should not merge because it has an invalid commit message.
-      name: do-not-merge/invalid-commit-message
-      target: prs
-      prowPlugin: invalidcommitmsg
-      addedBy: prow
-    - color: e11d21
-      description: Indicates that a PR should not merge because it has an invalid OWNERS file in it.
-      name: do-not-merge/invalid-owners-file
-      target: prs
-      prowPlugin: verify-owners
-      addedBy: prow
-    - color: e11d21
-      description: Indicates that a PR should not merge because it's missing one of the release note labels.
-      name: do-not-merge/release-note-label-needed
-      target: prs
-      prowPlugin: releasenote
-      addedBy: prow
-    - color: e11d21
-      description: Indicates that a PR should not merge because it is a work in progress.
-      name: do-not-merge/work-in-progress
-      target: prs
-      prowPlugin: wip
-      addedBy: prow
-    - color: e11d21
-      description: Indicates a PR which contains merge commits.
-      name: do-not-merge/contains-merge-commits
-      target: prs
-      prowPlugin: mergecommitblocker
-      addedBy: prow
-    - color: e11d21
-      description: Indicates a PR lacks a `kind/foo` label and requires one.
-      name: do-not-merge/needs-kind
-      target: prs
-      prowPlugin: require-matching-label
-      addedBy: prow
-    - color: 7057ff
-      description: Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.
-      name: 'good first issue'
-      target: issues
-      prowPlugin: help
-      addedBy: anyone
-    - color: 006b75
-      description: Denotes an issue that needs help from a contributor. Must meet "help wanted" guidelines.
-      name: 'help wanted'
-      target: issues
-      prowPlugin: help
-      addedBy: anyone
-    - color: 15dd18
-      description: Indicates that a PR is ready to be merged.
-      name: lgtm
-      target: prs
-      prowPlugin: lgtm
-      addedBy: reviewers or members
-    - color: d3e2f0
-      description: Indicates that an issue or PR should not be auto-closed due to staleness.
-      name: lifecycle/frozen
-      target: both
-      prowPlugin: lifecycle
-      addedBy: anyone
-    - color: 8fc951
-      description: Indicates that an issue or PR is actively being worked on by a contributor.
-      name: lifecycle/active
-      target: both
-      prowPlugin: lifecycle
-      addedBy: anyone
-    - color: "604460"
-      description: Denotes an issue or PR that has aged beyond stale and will be auto-closed.
-      name: lifecycle/rotten
-      target: both
-      prowPlugin: lifecycle
-      addedBy: anyone or prow
-    - color: "795548"
-      description: Denotes an issue or PR has remained open with no activity and has become stale.
-      name: lifecycle/stale
-      target: both
-      prowPlugin: lifecycle
-      addedBy: anyone or prow
-    - color: ededed
-      description: Indicates a PR lacks a `kind/foo` label and requires one.
-      name: needs-kind
-      target: prs
-      prowPlugin: require-matching-label
-      addedBy: prow
-    - color: b60205
-      description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
-      name: needs-ok-to-test
-      target: prs
-      prowPlugin: trigger
-      addedBy: prow
-    - color: e11d21
-      description: Indicates a PR cannot be merged because it has merge conflicts with HEAD.
-      name: needs-rebase
-      target: prs
-      prowPlugin: needs-rebase
-      isExternalPlugin: true
-      addedBy: prow
-    - color: 15dd18
-      description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
-      name: ok-to-test
-      target: prs
-      prowPlugin: trigger
-      addedBy: prow
-    - color: ee9900
-      description: Denotes a PR that changes 100-499 lines, ignoring generated files.
-      name: size/L
-      target: prs
-      prowPlugin: size
-      addedBy: prow
-    - color: eebb00
-      description: Denotes a PR that changes 30-99 lines, ignoring generated files.
-      name: size/M
-      target: prs
-      prowPlugin: size
-      addedBy: prow
-    - color: 77bb00
-      description: Denotes a PR that changes 10-29 lines, ignoring generated files.
-      name: size/S
-      target: prs
-      prowPlugin: size
-      addedBy: prow
-    - color: ee5500
-      description: Denotes a PR that changes 500-999 lines, ignoring generated files.
-      name: size/XL
-      target: prs
-      prowPlugin: size
-      addedBy: prow
-    - color: "009900"
-      description: Denotes a PR that changes 0-9 lines, ignoring generated files.
-      name: size/XS
-      target: prs
-      prowPlugin: size
-      addedBy: prow
-    - color: ee0000
-      description: Denotes a PR that changes 1000+ lines, ignoring generated files.
-      name: size/XXL
-      target: prs
-      prowPlugin: size
-      addedBy: prow
-    - color: ffaa00
-      description: Denotes a PR that should be squashed by tide when it merges.
-      name: tide/merge-method-squash
-      target: prs
-      addedBy: humans
-    - color: ffaa00
-      description: Denotes a PR that should be rebased by tide when it merges.
-      name: tide/merge-method-rebase
-      target: prs
-      addedBy: humans
-    - color: ffaa00
-      description: Denotes a PR that should use a standard merge by tide when it merges.
-      name: tide/merge-method-merge
-      target: prs
-      addedBy: humans
-    - color: e11d21
-      description: Denotes an issue that blocks the tide merge queue for a branch while it is open.
-      name: tide/merge-blocker
-      target: issues
-      addedBy: humans
-    - color: 66b5c1
-      description: Affects Garden clusters
-      name: topology/garden
-      target: both
-      addedBy: humans
-    - color: 66b5c1
-      description: Affects Soil clusters
-      name: topology/soil
-      target: both
-      addedBy: humans
-    - color: 66b5c1
-      description: Affects Seed clusters
-      name: topology/seed
-      target: both
-      addedBy: humans
-    - color: 66b5c1
-      description: Affects Shoot clusters
-      name: topology/shoot
-      target: both
-      addedBy: humans
-    - color: 66b5c1
-      description: Affects Plant clusters
-      name: topology/plant
-      target: both
-      addedBy: humans
-    - color: 0ffa16
-      description: Indicates a PR is trusted, used by tide for auto-merging PRs.
-      name: skip-review
-      target: prs
-      addedBy: autobump bot
-    - color: f9d0c4
-      description: ¯\\\_(ツ)_/¯
-      name: "¯\\_(ツ)_/¯"
-      target: both
-      prowPlugin: shrug
-      addedBy: humans
-    - color: e11d21
-      description: Indicates the PR's author has not signed the cla-assistant.io CLA.
-      name: 'cla: no'
-      target: prs
-      prowPlugin: cla-assistant
-      isExternalPlugin: true
-      addedBy: prow
-    - color: bfe5bf
-      description: Indicates the PR's author has signed the cla-assistant.io CLA.
-      name: 'cla: yes'
-      target: prs
-      prowPlugin: cla-assistant
-      isExternalPlugin: true
-      addedBy: prow
-    # cleanup old labels added by gardener-robot
-    - name: effort/1d
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: effort/1m
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: effort/1w
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: effort/1y
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: effort/2d
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: effort/2m
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: effort/2w
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: effort/3m
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: effort/6m
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: effort/9m
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: exp/beginner
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: exp/expert
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: exp/intermediate
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: kind/consulting
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: lifecycle/icebox
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: merge/keep-commits
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: merge/squash
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: needs/changes
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: needs/cherry-pick
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: needs/documentation
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: needs/help
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: needs/lgtm
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: needs/ok-to-test
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: needs/rebase
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: needs/release-notes
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: needs/review
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: needs/second-opinion
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: needs/tests
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: priority/blocker
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: priority/critical
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: reviewed/do-not-merge
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: reviewed/lgtm
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: reviewed/ok-to-test
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: status/accepted
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: status/author-action
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: status/blocked
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: status/closed
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: status/external-action
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: status/in-delivery
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: status/in-progress
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: status/new
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: status/on-hold
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: status/overdue
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: status/under-investigation
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: triage/consulting
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: triage/invalid
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: triage/upstream
-      deleteAfter: 2022-05-16T00:00:00Z
-    - name: triage/wont-fix
-      deleteAfter: 2022-05-16T00:00:00Z
-gardener/gardener-extension-networking-cilium:
-  labels:
-    - color: b60205
-      description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
-      name: needs-ok-to-test
-      target: prs
-      prowPlugin: trigger
-      addedBy: prow
-    - color: 15dd18
-      description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
-      name: ok-to-test
-      target: prs
-      prowPlugin: trigger
-      addedBy: prow
-gardener/gardener-extension-networking-calico:
-  labels:
-    - color: b60205
-      description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
-      name: needs-ok-to-test
-      target: prs
-      prowPlugin: trigger
-      addedBy: prow
-    - color: 15dd18
-      description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
-      name: ok-to-test
-      target: prs
-      prowPlugin: trigger
-      addedBy: prow
-gardener/landscaper:
-  labels:
-    - color: b60205
-      description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
-      name: needs-ok-to-test
-      target: prs
-      prowPlugin: trigger
-      addedBy: prow
-    - color: 15dd18
-      description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
-      name: ok-to-test
-      target: prs
-      prowPlugin: trigger
-      addedBy: prow
+  gardener/gardener-extension-shoot-oidc-service:
+    labels:
+      - color: b60205
+        description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
+        name: needs-ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow
+      - color: 15dd18
+        description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
+        name: ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow
+  gardener/dependency-watchdog:
+    labels:
+      # area
+      - name: area/audit-logging
+        color: 0052cc
+        description: Audit logging related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/auto-scaling
+        color: 0052cc
+        description: Auto-scaling (CA/HPA/VPA/HVPA, predominantly control plane, but also otherwise) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/backup
+        color: 0052cc
+        description: Backup related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/compliance
+        color: 0052cc
+        description: Compliance related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: 'area/certification'
+      - name: area/control-plane
+        color: 0052cc
+        description: Control plane related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/control-plane-migration
+        color: 0052cc
+        description: Control plane migration related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/cost
+        color: 0052cc
+        description: Cost related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/delivery
+        color: 0052cc
+        description: Delivery related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/dev-productivity
+        color: 0052cc
+        description: Developer productivity related (how to improve development)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/disaster-recovery
+        color: 0052cc
+        description: Disaster recovery related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/documentation
+        color: 0052cc
+        description: Documentation related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: documentation
+      - name: area/high-availability
+        color: 0052cc
+        description: High availability related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/ipcei
+        color: 0052cc
+        description: IPCEI (Important Project of Common European Interest)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/logging
+        color: 0052cc
+        description: Logging related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/metering
+        color: 0052cc
+        description: Metering related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/monitoring
+        color: 0052cc
+        description: Monitoring (including availability monitoring and alerting) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/networking
+        color: 0052cc
+        description: Networking related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/open-source
+        color: 0052cc
+        description: Open Source (community, enablement, contributions, conferences, CNCF, etc.) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/ops-productivity
+        color: 0052cc
+        description: Operator productivity related (how to improve operations)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/os
+        color: 0052cc
+        description: Operator system related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/performance
+        color: 0052cc
+        description: Performance (across all domains, such as control plane, networking, storage, etc.) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/quality
+        color: 0052cc
+        description: Output qualification (tests, checks, scans, automation in general, etc.) related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/robustness
+        color: 0052cc
+        description: Robustness, reliability, resilience related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/scalability
+        color: 0052cc
+        description: Scalability related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/security
+        color: 0052cc
+        description: Security related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/storage
+        color: 0052cc
+        description: Storage related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/testing
+        color: 0052cc
+        description: Testing related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/usability
+        color: 0052cc
+        description: Usability related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: area/user-management
+        color: 0052cc
+        description: User-management related
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      # component
+      - name: component/cicd
+        color: 25399e
+        description: Continuous integration/delivery (tooling and processes)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: component/dashboard
+        color: 25399e
+        description: Gardener Dashboard
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: component/documentation
+        color: 25399e
+        description: Gardener Documentation
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: component/etcd-backup-restore
+        color: 25399e
+        description: ETCD Backup & Restore
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: component/etcd-druid
+        color: 25399e
+        description: ETCD Druid
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: component/gardenctl
+        color: 25399e
+        description: Gardener CLI
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: component/gardener
+        color: 25399e
+        description: Gardener
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: component/hvpa
+        color: 25399e
+        description: HVPA
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: component/kubify
+        color: 25399e
+        description: Kubify
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: component/landscaper
+        color: 25399e
+        description: Landscape Installer
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: component/mcm
+        color: 25399e
+        description: Machine Controller Manager (including Node Problem Detector, Cluster Auto Scaler, etc.)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: component/tm
+        color: 25399e
+        description: Test machinery (tooling and processes)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      # kind
+      - name: kind/epic
+        color: c7def8
+        description: Large multi-story topic
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: epic
+      - name: kind/bug
+        color: e11d21
+        description: Bug
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: bug
+      - name: kind/regression
+        color: e11d21
+        description: Bug that hit us already in the past and that is reappearing/requires a proper solution
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: kind/post-mortem
+        color: e11d21
+        description: Bug that requires deeper analysis after immediate issues were resolved (usually after downtime)
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: kind/impediment
+        color: eb6420
+        description: Something that impedes developers, operators, users or others in their work
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: kind/technical-debt
+        color: eb6420
+        description: Something that is only solved on the surface, but requires more (re)work to be done properly
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: kind/api-change
+        color: eb6420
+        description: API change with impact on API users
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: kind/enhancement
+        color: c7def8
+        description: Enhancement, improvement, extension
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: enhancement
+      - name: kind/poc
+        color: c7def8
+        description: Proof of concept or prototype
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: kind/task
+        color: c7def8
+        description: General task
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: kind/test
+        color: c7def8
+        description: Test
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: kind/flake
+        color: f7c6c7
+        description: Tracking or fixing a flaky test
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: kind/cleanup
+        color: c7def8
+        description: Something that is not needed anymore and can be cleaned up
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: kind/question
+        color: c7def8
+        description: Question (asking for help, advice, or technical detail)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: question
+      - name: kind/discussion
+        color: c7def8
+        description: Discussion (engaging others in deciding about multiple options)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: discussion
+      # os
+      - name: os/garden-linux
+        color: 187c00
+        description: Related to Garden Linux OS
+        target: both
+        addedBy: anyone
+      - name: os/suse-chost
+        color: 187c00
+        description: Related to SUSE Container Host OS
+        target: both
+        addedBy: anyone
+      - name: os/ubuntu
+        color: 187c00
+        description: Related to Ubuntu OS
+        target: both
+        addedBy: anyone
+      # platform
+      - name: platform/alicloud
+        color: 006b75
+        description: Alicloud platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name: platform/aws
+        color: 006b75
+        description: Amazon web services platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name: platform/aws-gov
+        color: 006b75
+        description: Amazon web services (government) platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name: platform/azure
+        color: 006b75
+        description: Microsoft Azure platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name: platform/metal
+        color: 006b75
+        description: Bare metal platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name: platform/kubevirt
+        color: 006b75
+        description: Container Native Virtualization (CNV) KubeVirt platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name: platform/converged-cloud
+        color: 006b75
+        description: Converged Cloud (CC) platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name: platform/gcp
+        color: 006b75
+        description: Google cloud platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name: platform/gmp
+        color: 006b75
+        description: GMP (SEN) platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name: platform/openstack
+        color: 006b75
+        description: OpenStack platform/infrastructure
+        target: both
+        addedBy: anyone
+      - name: platform/equinix-metal
+        color: 006b75
+        description: Equinix Metal platform/infrastructure (previously Packet)
+        target: both
+        addedBy: anyone
+      - name: platform/vsphere
+        color: 006b75
+        description: VMware vSphere platform/infrastructure
+        target: both
+        addedBy: anyone
+      # priority
+      - name: priority/1
+        color: e11d21
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name: priority/2
+        color: e54014
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name: priority/3
+        color: e96f0b
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name: priority/4
+        color: ec9a04
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      - name: priority/5
+        color: fbca04
+        description: Priority (lower number equals higher priority)
+        target: issues
+        prowPlugin: label
+        addedBy: anyone
+      # roadmap
+      - name: roadmap/cloud
+        color: 4c38a5
+        description: Roadmap for the (managed) cloud delivery, i.e. gardener.cloud.sap
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: roadmap/cloud-sap
+      - name: roadmap/standalone
+        color: 4c38a5
+        description: Roadmap for the (on-prem) standalone delivery, e.g. CDC, NS2, etc.
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: roadmap/on-prem
+      - name: roadmap/internal
+        color: 4c38a5
+        description: Roadmap for our team-internal goals, e.g. drive up seed utilization
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+        previously:
+          - name: roadmap/team-internal
+      # prow
+      - color: 0ffa16
+        description: Indicates a PR has been approved by an approver from all required OWNERS files.
+        name: approved
+        target: prs
+        prowPlugin: approve
+        addedBy: approvers
+      - color: fef2c0
+        description: Indicates a cherry-pick PR into a release branch has been approved by the release branch manager. # Consumed by the kubernetes/kubernetes cherry-pick-queue.
+        name: cherry-pick-approved
+        target: prs
+        addedBy: humans
+      - color: 8fc951
+        description: Indicates an issue or PR is ready to be actively worked on.
+        name: triage/accepted
+        target: both
+        prowPlugin: label
+        addedBy: org members
+      - color: d455d0
+        description: Indicates an issue is a duplicate of other open issue.
+        name: triage/duplicate
+        target: both
+        addedBy: humans
+      - color: d455d0
+        description: Indicates an issue needs more information in order to work on it.
+        name: triage/needs-information
+        target: both
+        addedBy: humans
+      - color: d455d0
+        description: Indicates an issue can not be reproduced as described.
+        name: triage/not-reproducible
+        target: both
+        addedBy: humans
+      - color: d455d0
+        description: Indicates an issue that can not or will not be resolved.
+        name: triage/unresolved
+        target: both
+        addedBy: humans
+      - color: e11d21
+        description: Indicates that a PR should not merge because it touches files in blocked paths.
+        name: do-not-merge/blocked-paths
+        target: prs
+        prowPlugin: blockade
+        addedBy: prow
+      - color: e11d21
+        description: Indicates that a PR is not yet approved to merge into a release branch.
+        name: do-not-merge/cherry-pick-not-approved
+        target: prs
+        addedBy: prow
+        prowPlugin: cherrypickunapproved
+      - color: e11d21
+        description: Indicates that a PR should not merge because someone has issued a /hold command.
+        name: do-not-merge/hold
+        target: prs
+        prowPlugin: hold
+        addedBy: anyone
+      - color: e11d21
+        description: Indicates that a PR should not merge because it has an invalid commit message.
+        name: do-not-merge/invalid-commit-message
+        target: prs
+        prowPlugin: invalidcommitmsg
+        addedBy: prow
+      - color: e11d21
+        description: Indicates that a PR should not merge because it has an invalid OWNERS file in it.
+        name: do-not-merge/invalid-owners-file
+        target: prs
+        prowPlugin: verify-owners
+        addedBy: prow
+      - color: e11d21
+        description: Indicates that a PR should not merge because it's missing one of the release note labels.
+        name: do-not-merge/release-note-label-needed
+        target: prs
+        prowPlugin: releasenote
+        addedBy: prow
+      - color: e11d21
+        description: Indicates that a PR should not merge because it is a work in progress.
+        name: do-not-merge/work-in-progress
+        target: prs
+        prowPlugin: wip
+        addedBy: prow
+      - color: e11d21
+        description: Indicates a PR which contains merge commits.
+        name: do-not-merge/contains-merge-commits
+        target: prs
+        prowPlugin: mergecommitblocker
+        addedBy: prow
+      - color: e11d21
+        description: Indicates a PR lacks a `kind/foo` label and requires one.
+        name: do-not-merge/needs-kind
+        target: prs
+        prowPlugin: require-matching-label
+        addedBy: prow
+      - color: 7057ff
+        description: Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.
+        name: 'good first issue'
+        target: issues
+        prowPlugin: help
+        addedBy: anyone
+      - color: 006b75
+        description: Denotes an issue that needs help from a contributor. Must meet "help wanted" guidelines.
+        name: 'help wanted'
+        target: issues
+        prowPlugin: help
+        addedBy: anyone
+      - color: 15dd18
+        description: Indicates that a PR is ready to be merged.
+        name: lgtm
+        target: prs
+        prowPlugin: lgtm
+        addedBy: reviewers or members
+      - color: d3e2f0
+        description: Indicates that an issue or PR should not be auto-closed due to staleness.
+        name: lifecycle/frozen
+        target: both
+        prowPlugin: lifecycle
+        addedBy: anyone
+      - color: 8fc951
+        description: Indicates that an issue or PR is actively being worked on by a contributor.
+        name: lifecycle/active
+        target: both
+        prowPlugin: lifecycle
+        addedBy: anyone
+      - color: "604460"
+        description: Denotes an issue or PR that has aged beyond stale and will be auto-closed.
+        name: lifecycle/rotten
+        target: both
+        prowPlugin: lifecycle
+        addedBy: anyone or prow
+      - color: "795548"
+        description: Denotes an issue or PR has remained open with no activity and has become stale.
+        name: lifecycle/stale
+        target: both
+        prowPlugin: lifecycle
+        addedBy: anyone or prow
+      - color: ededed
+        description: Indicates a PR lacks a `kind/foo` label and requires one.
+        name: needs-kind
+        target: prs
+        prowPlugin: require-matching-label
+        addedBy: prow
+      - color: b60205
+        description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
+        name: needs-ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow
+      - color: e11d21
+        description: Indicates a PR cannot be merged because it has merge conflicts with HEAD.
+        name: needs-rebase
+        target: prs
+        prowPlugin: needs-rebase
+        isExternalPlugin: true
+        addedBy: prow
+      - color: 15dd18
+        description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
+        name: ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow
+      - color: ee9900
+        description: Denotes a PR that changes 100-499 lines, ignoring generated files.
+        name: size/L
+        target: prs
+        prowPlugin: size
+        addedBy: prow
+      - color: eebb00
+        description: Denotes a PR that changes 30-99 lines, ignoring generated files.
+        name: size/M
+        target: prs
+        prowPlugin: size
+        addedBy: prow
+      - color: 77bb00
+        description: Denotes a PR that changes 10-29 lines, ignoring generated files.
+        name: size/S
+        target: prs
+        prowPlugin: size
+        addedBy: prow
+      - color: ee5500
+        description: Denotes a PR that changes 500-999 lines, ignoring generated files.
+        name: size/XL
+        target: prs
+        prowPlugin: size
+        addedBy: prow
+      - color: "009900"
+        description: Denotes a PR that changes 0-9 lines, ignoring generated files.
+        name: size/XS
+        target: prs
+        prowPlugin: size
+        addedBy: prow
+      - color: ee0000
+        description: Denotes a PR that changes 1000+ lines, ignoring generated files.
+        name: size/XXL
+        target: prs
+        prowPlugin: size
+        addedBy: prow
+      - color: ffaa00
+        description: Denotes a PR that should be squashed by tide when it merges.
+        name: tide/merge-method-squash
+        target: prs
+        addedBy: humans
+      - color: ffaa00
+        description: Denotes a PR that should be rebased by tide when it merges.
+        name: tide/merge-method-rebase
+        target: prs
+        addedBy: humans
+      - color: ffaa00
+        description: Denotes a PR that should use a standard merge by tide when it merges.
+        name: tide/merge-method-merge
+        target: prs
+        addedBy: humans
+      - color: e11d21
+        description: Denotes an issue that blocks the tide merge queue for a branch while it is open.
+        name: tide/merge-blocker
+        target: issues
+        addedBy: humans
+      - color: 66b5c1
+        description: Affects Garden clusters
+        name: topology/garden
+        target: both
+        addedBy: humans
+      - color: 66b5c1
+        description: Affects Soil clusters
+        name: topology/soil
+        target: both
+        addedBy: humans
+      - color: 66b5c1
+        description: Affects Seed clusters
+        name: topology/seed
+        target: both
+        addedBy: humans
+      - color: 66b5c1
+        description: Affects Shoot clusters
+        name: topology/shoot
+        target: both
+        addedBy: humans
+      - color: 66b5c1
+        description: Affects Plant clusters
+        name: topology/plant
+        target: both
+        addedBy: humans
+      - color: 0ffa16
+        description: Indicates a PR is trusted, used by tide for auto-merging PRs.
+        name: skip-review
+        target: prs
+        addedBy: autobump bot
+      - color: f9d0c4
+        description: ¯\\\_(ツ)_/¯
+        name: "¯\\_(ツ)_/¯"
+        target: both
+        prowPlugin: shrug
+        addedBy: humans
+      - color: e11d21
+        description: Indicates the PR's author has not signed the cla-assistant.io CLA.
+        name: 'cla: no'
+        target: prs
+        prowPlugin: cla-assistant
+        isExternalPlugin: true
+        addedBy: prow
+      - color: bfe5bf
+        description: Indicates the PR's author has signed the cla-assistant.io CLA.
+        name: 'cla: yes'
+        target: prs
+        prowPlugin: cla-assistant
+        isExternalPlugin: true
+        addedBy: prow
+      # cleanup old labels added by gardener-robot
+      - name: effort/1d
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/1m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/1w
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/1y
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/2d
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/2m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/2w
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/3m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/6m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: effort/9m
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: exp/beginner
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: exp/expert
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: exp/intermediate
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: kind/consulting
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: lifecycle/icebox
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: merge/keep-commits
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: merge/squash
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/changes
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/cherry-pick
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/documentation
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/help
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/lgtm
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/ok-to-test
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/rebase
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/release-notes
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/review
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/second-opinion
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: needs/tests
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: priority/blocker
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: priority/critical
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: reviewed/do-not-merge
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: reviewed/lgtm
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: reviewed/ok-to-test
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/accepted
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/author-action
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/blocked
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/closed
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/external-action
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/in-delivery
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/in-progress
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/new
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/on-hold
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/overdue
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: status/under-investigation
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: triage/consulting
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: triage/invalid
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: triage/upstream
+        deleteAfter: 2022-05-16T00:00:00Z
+      - name: triage/wont-fix
+        deleteAfter: 2022-05-16T00:00:00Z
+  gardener/gardener-extension-networking-cilium:
+    labels:
+      - color: b60205
+        description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
+        name: needs-ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow
+      - color: 15dd18
+        description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
+        name: ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow
+  gardener/gardener-extension-networking-calico:
+    labels:
+      - color: b60205
+        description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
+        name: needs-ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow
+      - color: 15dd18
+        description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
+        name: ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow
+  gardener/landscaper:
+    labels:
+      - color: b60205
+        description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
+        name: needs-ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow
+      - color: 15dd18
+        description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
+        name: ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Starting in line `2413` in `labels.yaml` the indent is wrong, so the following lines are not respected in label sync.
This PR fixes the indent. Additionally, it moves the `area/ipcei` label to the right section. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
