### PR TITLE
Add volume for custom docker `daemon.json` to docker-in-docker prowjob preset

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -351,11 +351,16 @@ presets:
   # krte (normal) path
   - name: docker-root
     emptyDir: {}
+  - name: docker-config
+    configMap:
+      name: dind-docker-config
   volumeMounts:
   - name: docker-graph
     mountPath: /docker-graph
   - name: docker-root
     mountPath: /var/lib/docker
+  - name: docker-config
+    mountPath: /etc/docker
 # volume mounts for kind
 - labels:
     preset-kind-volume-mounts: "true"


### PR DESCRIPTION
/kind enhancement
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
This PR adds the volume for the custom docker `daemon.json` which was introduced in #623 and removed in #633 again.
It is required for upgrading the worker group OS of our prow clusters to `gardenlinux@934`. 

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6016

**Special notes for your reviewer**:
/hold
until the node groups of the cluster are updated.
