### PR TITLE
Adds a job to run cpm tests for ha shoots

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-migration-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration-ha-single-zone.yaml
@@ -1,0 +1,77 @@
+presubmits:
+  gardener/gardener:
+  - name: pull-gardener-e2e-kind-migration-ha-single-zone
+    cluster: gardener-prow-build
+    always_run: true
+    skip_branches:
+    - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs control plane migration end-to-end tests of single zone HA shoots for gardener developments in pull requests
+      fork-per-release: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20230421-ec4335b54b-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - make ci-e2e-kind-migration-ha-single-zone
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 6
+            memory: 24Gi
+        env:
+        - name: SKAFFOLD_UPDATE_CHECK
+          value: "false"
+        - name: SKAFFOLD_INTERACTIVE
+          value: "false"
+periodics:
+- name: ci-gardener-e2e-kind-migration-ha-single-zone
+  cluster: gardener-prow-build
+  interval: 4h
+  extra_refs:
+  - org: gardener
+    repo: gardener
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 60m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs control plane migration end-to-end tests of single zone HA shoots for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
+    fork-per-release: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20230421-ec4335b54b-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind-migration-ha-single-zone
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 6
+          memory: 24Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:
This PR adds a test job for control plane migration of single zone HA shoots between single zone HA seeds.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6529

**Special notes for your reviewer**:
