### PR TITLE
Stabilize prometheus in build cluster

### DIFF
--- a/config/prow/cluster/monitoring/build-cluster/prometheus.yaml
+++ b/config/prow/cluster/monitoring/build-cluster/prometheus.yaml
@@ -4,4 +4,13 @@ metadata:
   name: k8s
   namespace: monitoring
 spec:
+  containers:
+  - name: prometheus
+    # WAL replay in build cluster can take very long. Thus, we increase startup probe time to 2h
+    startupProbe:
+      failureThreshold: 480
+      periodSeconds: 15
+  resources:
+    requests:
+      memory: 14Gi
   retention: 30d

--- a/config/prow/cluster/monitoring/trusted-cluster/prometheus.yaml
+++ b/config/prow/cluster/monitoring/trusted-cluster/prometheus.yaml
@@ -4,7 +4,10 @@ metadata:
   name: k8s
   namespace: monitoring
 spec:
-  retention: 90d
   additionalScrapeConfigs:
     name: prometheus-prow-additional-scrape-configs
     key: additional-scrape-targets.yaml
+  retention: 90d
+  resources:
+    requests:
+      memory: 1400Mi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR stabilizes our prometheus deployment in the build cluster. Atm. WAL replay is often taking longer then the 15 minutes which is the default for the `startupProbe` of prometheus operator. In this case prometheus is stuck in a restart loop. The threshold is now set that prometheus has now 2 hours for WAL replay.

Additionally, the memory requests are set to realistic values.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ 
