### PR TITLE
Generate `oauth2-proxy` deployments from oauth2-proxy-6.12.0 helm chart

### DIFF
--- a/config/prow/cluster/oauth2-proxy/helm/generate-oauth2-proxy-deployments.sh
+++ b/config/prow/cluster/oauth2-proxy/helm/generate-oauth2-proxy-deployments.sh
@@ -30,6 +30,6 @@ helm repo add oauth2-proxy https://oauth2-proxy.github.io/manifests
 helm repo update
 
 echo "Templating oauth2-proxy"
-helm template oauth2-proxy oauth2-proxy/oauth2-proxy -f $SCRIPT_DIR/values.yaml > $SCRIPT_DIR/../oauth2-proxy-deployment.yaml
+helm template -n oauth2-proxy oauth2-proxy oauth2-proxy/oauth2-proxy -f $SCRIPT_DIR/values.yaml > $SCRIPT_DIR/../oauth2-proxy-deployment.yaml
 
 echo "Done"

--- a/config/prow/cluster/oauth2-proxy/kustomization.yaml
+++ b/config/prow/cluster/oauth2-proxy/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: oauth2-proxy
-
 resources:
 - oauth2-proxy-namespace.yaml
 - oauth2-proxy-deployment.yaml

--- a/config/prow/cluster/oauth2-proxy/oauth2-proxy-deployment.yaml
+++ b/config/prow/cluster/oauth2-proxy/oauth2-proxy-deployment.yaml
@@ -5,7 +5,7 @@ kind: PodDisruptionBudget
 metadata:
   labels:
     app: oauth2-proxy    
-    helm.sh/chart: oauth2-proxy-6.10.1
+    helm.sh/chart: oauth2-proxy-6.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/instance: oauth2-proxy
     app.kubernetes.io/version: "7.4.0"
   name: oauth2-proxy
+  namespace: oauth2-proxy
 spec:
   selector:
     matchLabels:      
@@ -26,7 +27,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: oauth2-proxy    
-    helm.sh/chart: oauth2-proxy-6.10.1
+    helm.sh/chart: oauth2-proxy-6.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
@@ -34,6 +35,7 @@ metadata:
     app.kubernetes.io/instance: oauth2-proxy
     app.kubernetes.io/version: "7.4.0"
   name: oauth2-proxy
+  namespace: oauth2-proxy
 automountServiceAccountToken : true
 ---
 # Source: oauth2-proxy/templates/service.yaml
@@ -42,7 +44,7 @@ kind: Service
 metadata:
   labels:
     app: oauth2-proxy    
-    helm.sh/chart: oauth2-proxy-6.10.1
+    helm.sh/chart: oauth2-proxy-6.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
@@ -50,6 +52,7 @@ metadata:
     app.kubernetes.io/instance: oauth2-proxy
     app.kubernetes.io/version: "7.4.0"
   name: oauth2-proxy
+  namespace: oauth2-proxy
 spec:
   type: ClusterIP
   ports:
@@ -73,7 +76,7 @@ kind: Deployment
 metadata:
   labels:
     app: oauth2-proxy    
-    helm.sh/chart: oauth2-proxy-6.10.1
+    helm.sh/chart: oauth2-proxy-6.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
@@ -81,6 +84,7 @@ metadata:
     app.kubernetes.io/instance: oauth2-proxy
     app.kubernetes.io/version: "7.4.0"
   name: oauth2-proxy
+  namespace: oauth2-proxy
 spec:
   replicas: 2
   revisionHistoryLimit: 10
@@ -98,7 +102,7 @@ spec:
         checksum/redis-secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
       labels:
         app: oauth2-proxy        
-        helm.sh/chart: oauth2-proxy-6.10.1
+        helm.sh/chart: oauth2-proxy-6.12.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: authentication-proxy
         app.kubernetes.io/part-of: oauth2-proxy
@@ -216,7 +220,7 @@ kind: Ingress
 metadata:
   labels:
     app: oauth2-proxy    
-    helm.sh/chart: oauth2-proxy-6.10.1
+    helm.sh/chart: oauth2-proxy-6.12.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
@@ -224,6 +228,7 @@ metadata:
     app.kubernetes.io/instance: oauth2-proxy
     app.kubernetes.io/version: "7.4.0"
   name: oauth2-proxy
+  namespace: oauth2-proxy
   annotations:
     cert.gardener.cloud/issuer: ci-issuer
     cert.gardener.cloud/purpose: managed


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Generate `oauth2-proxy` deployments from oauth2-proxy-6.12.0 helm chart which supports namespaces now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
