### PR TITLE
Update to `gcr.io/kaniko-project/executor:v1.9.2`

### DIFF
--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
     spec:
       containers:
       - name: kaniko
-        image: gcr.io/kaniko-project/executor:v1.9.1
+        image: gcr.io/kaniko-project/executor:v1.9.2
         command:
         - /kaniko/executor
         args:

--- a/config/jobs/dependency-watchdog/dependency-watchdog-test-builds.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-test-builds.yaml
@@ -11,7 +11,7 @@ presubmits:
     spec:
       containers:
       - name: kaniko
-        image: gcr.io/kaniko-project/executor:v1.9.1
+        image: gcr.io/kaniko-project/executor:v1.9.2
         command:
         - /kaniko/executor
         args:

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-test-builds.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-test-builds.yaml
@@ -9,7 +9,7 @@ presubmits:
     spec:
       containers:
       - name: kaniko
-        image: gcr.io/kaniko-project/executor:v1.9.1
+        image: gcr.io/kaniko-project/executor:v1.9.2
         command:
         - /kaniko/executor
         args:

--- a/config/jobs/gardener/gardener-test-builds.yaml
+++ b/config/jobs/gardener/gardener-test-builds.yaml
@@ -12,7 +12,7 @@ presubmits:
     spec:
       containers:
       - name: kaniko
-        image: gcr.io/kaniko-project/executor:v1.9.1
+        image: gcr.io/kaniko-project/executor:v1.9.2
         command:
         - /kaniko/executor
         args:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-68.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-68.yaml
@@ -767,7 +767,7 @@ presubmits:
         - --no-push
         command:
         - /kaniko/executor
-        image: gcr.io/kaniko-project/executor:v1.9.1
+        image: gcr.io/kaniko-project/executor:v1.9.2
         name: kaniko
         resources:
           requests:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-69.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-69.yaml
@@ -767,7 +767,7 @@ presubmits:
         - --no-push
         command:
         - /kaniko/executor
-        image: gcr.io/kaniko-project/executor:v1.9.1
+        image: gcr.io/kaniko-project/executor:v1.9.2
         name: kaniko
         resources:
           requests:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-70.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-70.yaml
@@ -767,7 +767,7 @@ presubmits:
         - --no-push
         command:
         - /kaniko/executor
-        image: gcr.io/kaniko-project/executor:v1.9.1
+        image: gcr.io/kaniko-project/executor:v1.9.2
         name: kaniko
         resources:
           requests:

--- a/prow/cmd/image-builder/main.go
+++ b/prow/cmd/image-builder/main.go
@@ -110,7 +110,7 @@ func gatherOptions() options {
 	fs.StringVar(&o.buildVariant, "build-variant", "", "variant of a context which should be built. Builds all variants if empty")
 	fs.StringVar(&o.registry, "registry", "", "container registry where build artifacts are being pushed")
 	fs.StringVar(&o.cacheRegistry, "cache-registry", "", "container registry where cache artifacts are being pushed. Cache is disabled for empty value")
-	fs.StringVar(&o.kanikoImage, "kaniko-image", "gcr.io/kaniko-project/executor:v1.9.1", "kaniko image for kaniko build")
+	fs.StringVar(&o.kanikoImage, "kaniko-image", "gcr.io/kaniko-project/executor:v1.9.2", "kaniko image for kaniko build")
 	fs.BoolVar(&o.addVersionTag, "add-version-tag", false, "Add label from VERSION file of git root directory to image tags")
 	fs.BoolVar(&o.addVersionSHATag, "add-version-sha-tag", false, "Add label from VERSION file of git root directory plus SHA from git HEAD to image tags")
 	fs.BoolVar(&o.addDateSHATag, "add-date-sha-tag", false, "Using vYYYYMMDD-<rev short> scheme which is compatible to autobumper")


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement
/kind bug

**What this PR does / why we need it**:
kaniko v1.9.2 is released: [ref](https://github.com/GoogleContainerTools/kaniko/releases/tag/v1.9.2)

Additionally, the PR fixes a bug that https://github.com/gardener/ci-infra/pull/468 did not update the prow config, so kaniko still runs on v1.8.1 for https://github.com/gardener/gardener-extension-registry-cache

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
