### PR TITLE
Add missing permissions for `kube-prometheus@v0.12.0` to `deployer` service account

### DIFF
--- a/config/prow/cluster/bootstrap-trusted/trusted_serviceaccounts.yaml
+++ b/config/prow/cluster/bootstrap-trusted/trusted_serviceaccounts.yaml
@@ -292,6 +292,12 @@ rules:
   - /metrics
   verbs:
   - get
+- apiGroups:
+  - "metrics.k8s.io"
+  resources:
+  - "*"
+  verbs:
+  - "*"
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
With https://github.com/gardener/ci-infra/pull/717 the `deployer` service account of the trusted cluster requires additional permissions for `metrics.k8s.io`.
Before they have been granted, the [deploy job failed](https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-ci-infra-deploy-prow/1656633135569309696).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
