### PR TITLE
registry-cache-unit-tests: Use `make verify-extended` and reduce resouces

### DIFF
--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
@@ -18,10 +18,10 @@ presubmits:
         - verify-extended
         resources:
           limits:
-            memory: 16Gi
+            memory: 2Gi
           requests:
-            cpu: 4
-            memory: 8Gi
+            cpu: 2
+            memory: 1Gi
 periodics:
 - name: ci-gardener-extension-registry-cache-unit
   cluster: gardener-prow-build
@@ -47,7 +47,7 @@ periodics:
       - verify-extended
       resources:
         limits:
-          memory: 16Gi
+          memory: 2Gi
         requests:
-          cpu: 4
-          memory: 8Gi
+          cpu: 2
+          memory: 1Gi

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
@@ -11,16 +11,11 @@ presubmits:
       description: Runs unit tests for Gardener extension registry-cache developments in pull requests
     spec:
       containers:
-      # Run all tests sequentially in one container or as separate prow jobs.
-      # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
       - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230511-9a61f23-1.19
         command:
         - make
         args:
-        - check-generate
-        - check
-        - format
-        - test
+        - verify-extended
         resources:
           limits:
             memory: 16Gi
@@ -45,16 +40,11 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    # Run all tests sequentially in one container or as separate prow jobs.
-    # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
     - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230511-9a61f23-1.19
       command:
       - make
       args:
-      - check-generate
-      - check
-      - format
-      - test
+      - verify-extended
       resources:
         limits:
           memory: 16Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the registry-cache-unit-tests jobs in a way inspired by shoot-oidc-service jobs: https://github.com/gardener/ci-infra/blob/7a666e61f199138480e8dc2c5f28072801f27016/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A