### PR TITLE
Fix namespace of oauth2-proxy configmap generator

### DIFF
--- a/config/prow/cluster/oauth2-proxy/kustomization.yaml
+++ b/config/prow/cluster/oauth2-proxy/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 
 configMapGenerator:
 - name: oauth2-proxy
+  namespace: oauth2-proxy
   options:
     labels:
       app: oauth2-proxy    


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
This PR adds `oauth2-proxy` namespace to configmap generator of oauth2-proxy which is missing since https://github.com/gardener/ci-infra/pull/720

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
