### PR TITLE
Update fluent-operator in images.yaml

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -37,6 +37,7 @@ images:
   tags:
   - v1.7.0
   - v2.2.0
+  - v2.3.0
 - source: grafana/loki
   destination: eu.gcr.io/gardener-project/3rd/grafana/loki
   tags:


### PR DESCRIPTION
/kind enhancement
 
This PR brings the latest released version of [fluent operator 2.3.0](https://github.com/fluent/fluent-operator/releases/tag/v2.3.0)