### PR TITLE
update fluent-bit container image to v2.1.4

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -32,6 +32,7 @@ images:
   tags:
   - v2.0.9
   - v2.0.10
+  - v2.1.4
 - source: kubesphere/fluent-operator
   destination: eu.gcr.io/gardener-project/3rd/kubesphere/fluent-operator
   tags:


### PR DESCRIPTION
/kind enhancement

This PR updates fluent-bit container image to the latest released version [v2.1.4](https://github.com/fluent/fluent-bit/releases/tag/v2.1.4)