### PR TITLE
Fix krte image of etcd-druid periodic e2e-test

### DIFF
--- a/config/jobs/etcd-druid/druid-e2e-kind.yaml
+++ b/config/jobs/etcd-druid/druid-e2e-kind.yaml
@@ -50,7 +50,7 @@ periodics:
       testgrid-days-of-results: "60"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/krte:v20230421-ec4335b54b-master
+        - image: gcr.io/k8s-staging-test-infra/krte:v20230613-63d85f5ed2-master
           command:
           - wrapper.sh
           - bash

--- a/config/jobs/etcd-druid/druid-e2e-kind.yaml
+++ b/config/jobs/etcd-druid/druid-e2e-kind.yaml
@@ -50,7 +50,7 @@ periodics:
       testgrid-days-of-results: "60"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/v20230421-ec4335b54b-master
+        - image: gcr.io/k8s-staging-test-infra/krte:v20230421-ec4335b54b-master
           command:
           - wrapper.sh
           - bash


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The image of etcd-druid periodic e2e-test is wrong, so it cannot be pulled.

**Which issue(s) this PR fixes**:
Fixes wrong image of #553

**Special notes for your reviewer**:
