### PR TITLE
Make gardener upgrade e2e tests mandatory

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
@@ -3,7 +3,6 @@ presubmits:
   - name: pull-gardener-e2e-kind-ha-multi-zone-upgrade
     cluster: gardener-prow-build
     always_run: true
-    optional: true
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
@@ -3,7 +3,6 @@ presubmits:
   - name: pull-gardener-e2e-kind-ha-single-zone-upgrade
     cluster: gardener-prow-build
     always_run: true
-    optional: true
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
@@ -3,7 +3,6 @@ presubmits:
   - name: pull-gardener-e2e-kind-upgrade
     cluster: gardener-prow-build
     always_run: true
-    optional: true
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:
Make gardener upgrade e2e tests mandatory
