### PR TITLE
Introduce `release-handler` 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,3 +59,9 @@ LABEL app=image-builder
 WORKDIR /
 COPY --from=builder /build/image-builder /image-builder
 ENTRYPOINT [ "/image-builder" ]
+
+FROM ssl_git_runner AS release-handler
+LABEL app=release-handler
+WORKDIR /
+COPY --from=builder /build/release-handler /release-handler
+ENTRYPOINT [ "/release-handler" ]

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ IMG_JOB_FORKER := job-forker
 REG_JOB_FORKER := $(REGISTRY)/$(IMG_JOB_FORKER)
 IMG_MILESTONE_ACTIVATOR := milestone-activator
 REG_MILESTONE_ACTIVATOR  := $(REGISTRY)/$(IMG_MILESTONE_ACTIVATOR)
+IMG_RELEASE_HANDLER := release-handler
+REG_RELEASE_HANDLER  := $(REGISTRY)/$(IMG_RELEASE_HANDLER)
 
 
 #########################################
@@ -56,6 +58,7 @@ endif
 	@docker build --build-arg GOLANG_VERSION=$(GOLANG_VERSION) -t $(REG_IMAGE_BUILDER):$(VERSION) -t $(REG_IMAGE_BUILDER):latest -f Dockerfile --target $(IMG_IMAGE_BUILDER) .
 	@docker build --build-arg GOLANG_VERSION=$(GOLANG_VERSION) -t $(REG_JOB_FORKER):$(VERSION) -t $(REG_JOB_FORKER):latest -f Dockerfile --target $(IMG_JOB_FORKER) .
 	@docker build --build-arg GOLANG_VERSION=$(GOLANG_VERSION) -t $(REG_MILESTONE_ACTIVATOR):$(VERSION) -t $(REG_MILESTONE_ACTIVATOR):latest -f Dockerfile --target $(IMG_MILESTONE_ACTIVATOR) .
+	@docker build --build-arg GOLANG_VERSION=$(GOLANG_VERSION) -t $(REG_RELEASE_HANDLER):$(VERSION) -t $(REG_RELEASE_HANDLER):latest -f Dockerfile --target $(IMG_RELEASE_HANDLER) .
 
 .PHONY: docker-push
 docker-push:
@@ -69,11 +72,13 @@ endif
 	@if ! docker images $(REG_IMAGE_BUILDER) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(REG_IMAGE_BUILDER) version $(VERSION) is not yet built. Please run 'make docker-images'"; false; fi
 	@if ! docker images $(REG_JOB_FORKER) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(REG_JOB_FORKER) version $(VERSION) is not yet built. Please run 'make docker-images'"; false; fi
 	@if ! docker images $(REG_MILESTONE_ACTIVATOR) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(REG_MILESTONE_ACTIVATOR) version $(VERSION) is not yet built. Please run 'make docker-images'"; false; fi
+	@if ! docker images $(REG_RELEASE_HANDLER) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(REG_RELEASE_HANDLER) version $(VERSION) is not yet built. Please run 'make docker-images'"; false; fi
 	@docker push $(REG_CHERRYPICKER):$(VERSION)
 	@docker push $(REG_CLA_ASSISTANT):$(VERSION)
 	@docker push $(REG_IMAGE_BUILDER):$(VERSION)
 	@docker push $(REG_JOB_FORKER):$(VERSION)
 	@docker push $(REG_MILESTONE_ACTIVATOR):$(VERSION)
+	@docker push $(REG_RELEASE_HANDLER):$(VERSION)
 ifeq ("$(PUSH_LATEST_TAG)", "true")
 	@docker push $(REG_GOLANG_TEST):latest
 	@docker push $(REG_CHERRYPICKER):latest
@@ -81,6 +86,7 @@ ifeq ("$(PUSH_LATEST_TAG)", "true")
 	@docker push $(REG_IMAGE_BUILDER):latest
 	@docker push $(REG_JOB_FORKER):latest
 	@docker push $(REG_MILESTONE_ACTIVATOR):latest
+	@docker push $(REG_RELEASE_HANDLER):latest
 endif
 
 

--- a/config/jobs/ci-infra/build-ci-infra-images.yaml
+++ b/config/jobs/ci-infra/build-ci-infra-images.yaml
@@ -32,6 +32,7 @@ postsubmits:
         - --target=image-builder
         - --target=job-forker
         - --target=milestone-activator
+        - --target=release-handler
         - --add-date-sha-tag=true
         - --add-fixed-tag=latest
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule

--- a/config/jobs/gardener/gardener-release-handler.yaml
+++ b/config/jobs/gardener/gardener-release-handler.yaml
@@ -1,0 +1,36 @@
+postsubmits:
+  gardener/gardener:
+  - name: post-gardener-release-handler
+    cluster: gardener-prow-trusted
+    run_if_changed: '^VERSION$'
+    branches:
+    - ^master$
+    - ^release-v\d+.\d+
+    annotations:
+      description: Release-handler runs release tasks for Gardener
+      testgrid-dashboards: gardener-gardener
+      testgrid-days-of-results: "60"
+    decorate: true
+    max_concurrency: 1
+    spec:
+      containers:
+      - name: release-handler
+        image: eu.gcr.io/gardener-project/ci-infra/release-handler:v20230616-97d95c3
+        command:
+        - /release-handler
+        args:
+        - --dry-run=false
+        - --github-token-path=/etc/github-token/token
+        - --github-endpoint=http://ghproxy.prow.svc.cluster.local
+        - --github-endpoint=https://api.github.com
+        - --log-level=info
+        - --release-branch-prefix=release-
+        - --version-file-path=VERSION
+        volumeMounts:
+        - name: github-token
+          mountPath: /etc/github-token
+          readOnly: true
+      volumes:
+      - name: github-token
+        secret:
+          secretName: github-token

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gardener/ci-infra
 go 1.18
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/google/go-cmp v0.5.9
 	github.com/onsi/ginkgo/v2 v2.3.1

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20191009163259-e802c2cb94ae/go.mod h1:mjwGPas4yKduTyubHvD1Atl9r1rUq8DfVy+gkVvZ+oo=
 github.com/GoogleCloudPlatform/testgrid v0.0.123 h1:S5LE2LjkPsUlyt7blkIgwajiUfgFzv5s17+TkyKDfnI=
 github.com/GoogleCloudPlatform/testgrid v0.0.123/go.mod h1:4Ojwl21NNySkM1rG8hT9K2bugPX9fIrc2hC+GHegLR8=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/prow/cmd/release-handler/README.md
+++ b/prow/cmd/release-handler/README.md
@@ -1,0 +1,12 @@
+# Release-Handler
+## Functionality
+The `release-handler` handles release specific tasks of a repository. It runs as a `postsubmit` job in prow and identifies release activities by checking commited changes of a configurable `VERSION` file. The `VERSION` file must include a semver compatible version in its first line.
+
+Currently, it identifies four cases:
+- `newRelease`: when the version increases from a dev to a final version like `v1.75.0-dev -> v1.75.0`.
+- `nextDevCycle`: when the version increases from a final to a higher dev version like `v1.75.0 -> v1.75.1-dev`
+- `prepareNewPatchVersion`: when the version increases from one dev version to another with a higher patch version like `v1.75.0-dev -> v1.75.1-dev`
+- `prepareNewMajorMinorVersion`: when the version increases from one dev version to another with a higher major or minor version like `v1.75.0-dev -> v1.76.0-dev`
+
+When it identifies the `prepareNewMajorMinorVersion` case it creates a new release branch using a configurable pattern at the previous commit. The development could continue working on the main branch while the release verification activities are using the release branch.
+An example, when the version of the main branch increases from `v1.75.0-dev` to `v1.76.0-dev` release-handler creates a release branch for `v1.75`.

--- a/prow/cmd/release-handler/main.go
+++ b/prow/cmd/release-handler/main.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config/secret"
+	"k8s.io/test-infra/prow/flagutil"
+	gitv2 "k8s.io/test-infra/prow/git/v2"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+)
+
+type options struct {
+	releaseBranchPrefix string
+	versionFilePath     string
+
+	dryRun bool
+	github flagutil.GitHubOptions
+
+	org     string
+	repo    string
+	baseSHA string
+
+	logLevel string
+}
+
+func (o *options) validate() error {
+	if err := o.github.Validate(o.dryRun); err != nil {
+		return err
+	}
+	if o.releaseBranchPrefix == "" {
+		return fmt.Errorf("please provide a non empty --upstream-repository")
+	}
+	if o.versionFilePath == "" {
+		return fmt.Errorf("please provide a non empty --version-file-path")
+	}
+	if o.github.TokenPath == "" {
+		return fmt.Errorf("please provide a non empty --github-token-path")
+	}
+	return nil
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.StringVar(&o.releaseBranchPrefix, "release-branch-prefix", "release-", "prefix for release branches, release-handler maintains")
+	fs.StringVar(&o.versionFilePath, "version-file-path", "VERSION", "path to the file which defines the semver version")
+	fs.BoolVar(&o.dryRun, "dry-run", true, "DryRun")
+	fs.StringVar(&o.logLevel, "log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
+	o.github.AddFlags(fs)
+
+	err := fs.Parse(os.Args[1:])
+	if err != nil {
+		logrus.WithError(err).Fatal("Unable to parse command line flags")
+	}
+
+	jobSpec, err := downwardapi.ResolveSpecFromEnv()
+	if err != nil {
+		logrus.WithError(err).Fatal("Unable to resolve prow job spec")
+	}
+
+	switch jobSpec.Type {
+	case prowjobv1.PeriodicJob:
+		logrus.Fatal("Release-handler cannot be used in periodic prow jobs")
+	case prowjobv1.BatchJob:
+		logrus.Fatal("Release-handler cannot be used in batch prow jobs")
+	case prowjobv1.PostsubmitJob:
+		o.org = jobSpec.Refs.Org
+		o.repo = jobSpec.Refs.Repo
+		o.baseSHA = jobSpec.Refs.BaseSHA
+	case prowjobv1.PresubmitJob:
+		logrus.Fatal("Release-handler cannot be used in presubmit prow jobs")
+	}
+
+	return o
+}
+
+func constructClientFactoryOpts(githubClient github.Client, o options) (*gitv2.ClientFactoryOpts, error) {
+	if err := secret.Add(o.github.TokenPath); err != nil {
+		return nil, err
+	}
+	userGenerator := func() (string, error) {
+		user, err := githubClient.BotUser()
+		if err != nil {
+			return "", err
+		}
+		return user.Login, nil
+	}
+	gitUser := func() (string, string, error) {
+		user, err := githubClient.BotUser()
+		if err != nil {
+			return "", "", err
+		}
+		name := user.Name
+		email := user.Email
+		return name, email, nil
+	}
+
+	clientFactoryOpts := gitv2.ClientFactoryOpts{
+		Censor:   secret.Censor,
+		Username: userGenerator,
+		Token:    secret.GetTokenGenerator(o.github.TokenPath),
+		GitUser:  gitUser,
+	}
+
+	return &clientFactoryOpts, nil
+}
+
+func main() {
+	o := gatherOptions()
+	if err := o.validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid options")
+	}
+
+	logLevel, err := logrus.ParseLevel(o.logLevel)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to parse loglevel")
+	}
+	logrus.SetLevel(logLevel)
+
+	githubClient, err := o.github.GitHubClient(o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting Git client")
+	}
+
+	clientFactoryOpts, err := constructClientFactoryOpts(githubClient, o)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error constructing client factory opt")
+	}
+
+	clientFactory, err := gitv2.NewClientFactory(clientFactoryOpts.Apply)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error creating client factory")
+	}
+
+	releaseHandler := releaseHandler{
+		options:          o,
+		gitClientFactory: clientFactory,
+	}
+
+	err = releaseHandler.run()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error when running release-handler")
+	}
+}

--- a/prow/cmd/release-handler/release_handler_suite_test.go
+++ b/prow/cmd/release-handler/release_handler_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMilestoneActivator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ReleaseHandler Suite")
+}

--- a/prow/cmd/release-handler/releasehandler.go
+++ b/prow/cmd/release-handler/releasehandler.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/Masterminds/semver"
+	"github.com/sirupsen/logrus"
+	gitv2 "k8s.io/test-infra/prow/git/v2"
+)
+
+const (
+	compareVersionBranch = "release-handler-compare-versions"
+)
+
+type releaseHandler struct {
+	options          options
+	gitClientFactory gitv2.ClientFactory
+
+	repoClient gitv2.RepoClient
+}
+
+type versionChange string
+
+const (
+	prepareNewMajorMinorVersion versionChange = "prepareNewMajorMinorVersion"
+	prepareNewPatchVersion      versionChange = "prepareNewPatchVersion"
+	newRelease                  versionChange = "newRelease"
+	nextDevCycle                versionChange = "nextDevCycle"
+	undefinedVersionChange      versionChange = "undefinedVersionChange"
+)
+
+type versionClassification struct {
+	currentVersion  *semver.Version
+	previousVersion *semver.Version
+
+	versionChange versionChange
+}
+
+func (r *releaseHandler) run() error {
+	var err error
+	if r.repoClient == nil {
+		logrus.Infof("Initialize git repo client for github.com/%s/%s", r.options.org, r.options.repo)
+		r.repoClient, err = r.gitClientFactory.ClientFor(r.options.org, r.options.repo)
+		if err != nil {
+			return err
+		}
+	}
+
+	logrus.Info("Ensure base ref is checked out")
+	if err := r.checkOutBase(); err != nil {
+		return nil
+	}
+
+	versionFileChanged, err := r.isVersionFileUpdated()
+	if err != nil {
+		return err
+	}
+	if !versionFileChanged {
+		logrus.Infof("No changes in version file %q with last commit - exiting", r.options.versionFilePath)
+		return nil
+	}
+
+	versionClassification, err := r.compareVersions()
+	if err != nil {
+		return err
+	}
+
+	return r.handleVersionChange(versionClassification)
+}
+
+func (r *releaseHandler) isVersionFileUpdated() (bool, error) {
+	changes, err := r.repoClient.Diff("HEAD~1", "HEAD")
+	if err != nil {
+		return false, err
+	}
+	for _, change := range changes {
+		if change == r.options.versionFilePath {
+			logrus.Infof("Version file %q updated with last commit", r.options.versionFilePath)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (r *releaseHandler) checkOutBase() error {
+	logrus.Infof("Checking out base SHA %q", r.options.baseSHA)
+	return r.repoClient.Checkout(r.options.baseSHA)
+}
+
+func (r *releaseHandler) compareVersions() (*versionClassification, error) {
+	logrus.Infof("Reading version file %q from current commit", r.options.versionFilePath)
+	currentVersion, err := getSemverFromFile(path.Join(r.repoClient.Directory(), r.options.versionFilePath))
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Infof("Creating temporary new branch %q to compare version files", compareVersionBranch)
+	if err := r.repoClient.CheckoutNewBranch(compareVersionBranch); err != nil {
+		return nil, err
+	}
+
+	logrus.Info("Getting version file from previous commit")
+	if err := r.repoClient.ResetHard("HEAD~1"); err != nil {
+		return nil, err
+	}
+
+	logrus.Infof("Reading version file %q from previous commit", r.options.versionFilePath)
+	previousVersion, err := getSemverFromFile(path.Join(r.repoClient.Directory(), r.options.versionFilePath))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.checkOutBase(); err != nil {
+		return nil, err
+	}
+
+	logrus.Infof("Current version is %q - version of previous commit is %q", currentVersion, previousVersion)
+
+	return classifyVersionChange(currentVersion, previousVersion)
+}
+
+func (r *releaseHandler) createReleaseBranch(version *semver.Version) error {
+	releaseBranchName := fmt.Sprintf("%sv%d.%d", r.options.releaseBranchPrefix, version.Major(), version.Minor())
+	if exists := r.repoClient.BranchExists(releaseBranchName); exists {
+		logrus.Infof("Release branch %q is already existing - skip creation", releaseBranchName)
+		return nil
+	}
+	logrus.Infof("Creating new release branch %q", releaseBranchName)
+	if err := r.repoClient.CheckoutNewBranch(releaseBranchName); err != nil {
+		return err
+	}
+	logrus.Infof("Starting release branch at HEAD~1 which is the latest commit for %q", version)
+	if err := r.repoClient.ResetHard("HEAD~1"); err != nil {
+		return err
+	}
+	if !r.options.dryRun {
+		logrus.Info("Pushing release branch to upstream")
+		if err := r.repoClient.PushToCentral(releaseBranchName, false); err != nil {
+			return err
+		}
+		logrus.Infof("Release branch %q pushed", releaseBranchName)
+	} else {
+		logrus.Infof("Release branch %q created successfully", releaseBranchName)
+		logrus.Info("Dry-run mode - not pushing any changes")
+	}
+	return nil
+}
+
+func (r *releaseHandler) handleVersionChange(versionClassification *versionClassification) error {
+
+	switch c := versionClassification.versionChange; c {
+	case prepareNewMajorMinorVersion:
+		logrus.Infof("%q detected", c)
+		if err := r.createReleaseBranch(versionClassification.previousVersion); err != nil {
+			return err
+		}
+	default:
+		logrus.Infof("%q detected - nothing to do", c)
+	}
+
+	return nil
+}
+
+func classifyVersionChange(currentVersion, previousVersion *semver.Version) (*versionClassification, error) {
+	versionClassification := &versionClassification{currentVersion: currentVersion, previousVersion: previousVersion}
+
+	switch {
+	case currentVersion.Compare(previousVersion) != 1:
+		return nil, fmt.Errorf("version does not increase between %q and %q", previousVersion, currentVersion)
+	case currentVersion.Prerelease() == "":
+		versionClassification.versionChange = newRelease
+	case previousVersion.Prerelease() == "":
+		versionClassification.versionChange = nextDevCycle
+	case currentVersion.Major() > previousVersion.Major():
+		versionClassification.versionChange = prepareNewMajorMinorVersion
+	case currentVersion.Minor() > previousVersion.Minor():
+		versionClassification.versionChange = prepareNewMajorMinorVersion
+	case currentVersion.Patch() > previousVersion.Patch():
+		versionClassification.versionChange = prepareNewPatchVersion
+	default:
+		return nil, fmt.Errorf("updating version %q to version %q is not supported", previousVersion, currentVersion)
+	}
+
+	return versionClassification, nil
+}
+
+func getSemverFromFile(path string) (*semver.Version, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, strings.Trim(scanner.Text(), " "))
+	}
+	if len(lines) == 0 {
+		return nil, fmt.Errorf("version file %q is empty", path)
+	}
+	// semver version should be found in the first line
+	version, err := semver.NewVersion(lines[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid semver version in first line of file %q: %w", path, err)
+	}
+	return version, nil
+}

--- a/prow/cmd/release-handler/releasehandler_test.go
+++ b/prow/cmd/release-handler/releasehandler_test.go
@@ -1,0 +1,371 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path"
+
+	"github.com/Masterminds/semver"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/test-infra/prow/git/localgit"
+	gitv2 "k8s.io/test-infra/prow/git/v2"
+)
+
+var _ = Describe("ReleaseHandler", func() {
+	DescribeTable("#classifyVersionChange",
+		func(currentVersion, previousVersion string, versionChange versionChange, errorMsg string) {
+			cv := semver.MustParse(currentVersion)
+			pv := semver.MustParse(previousVersion)
+			v, err := classifyVersionChange(cv, pv)
+			if errorMsg == "" {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(v.currentVersion).To(Equal(cv))
+				Expect(v.previousVersion).To(Equal(pv))
+				Expect(v.versionChange).To(Equal(versionChange))
+			} else {
+				Expect(err).To(MatchError(ContainSubstring(errorMsg)))
+			}
+		},
+		Entry("new release", "v1.75.0", "v1.75.0-dev", newRelease, ""),
+		Entry("new release", "v1.75.1", "v1.75.0", newRelease, ""),
+		Entry("new release", "v1.76.0", "v1.75.0", newRelease, ""),
+		Entry("next dev cycle", "v1.75.1-dev", "v1.75.0", nextDevCycle, ""),
+		Entry("next dev cycle", "v1.76.0-dev", "v1.75.0", nextDevCycle, ""),
+		Entry("new major minor version", "v1.76.0-dev", "v1.75.0-dev", prepareNewMajorMinorVersion, ""),
+		Entry("new major minor version", "v1.77.0-dev", "v1.75.0-dev", prepareNewMajorMinorVersion, ""),
+		Entry("new patch version", "v1.75.1-dev", "v1.75.0-dev", prepareNewPatchVersion, ""),
+		Entry("new patch version", "v1.75.2-dev", "v1.75.0-dev", prepareNewPatchVersion, ""),
+		Entry("no change", "v1.75.0-dev", "v1.75.0-dev", undefinedVersionChange, "version does not increase"),
+		Entry("downgrade", "v1.75.0-dev", "v1.76.0-dev", undefinedVersionChange, "version does not increase"),
+	)
+
+	Describe("#getSemverFromFile", func() {
+		const (
+			validVersionFile              = "valid-version"
+			validDevVersionFile           = "valid-dev-version"
+			emptyVersionFile              = "empty-version"
+			invalidVersionFile            = "invalid-version"
+			invalidDevVersionFile         = "invalid-dev-version"
+			validVersionWithEmptyLineFile = "valid-version-empty-line"
+			validVersionInSecondLineFile  = "valid-version-in-second-line"
+
+			validVersionContent              = `v1.75.0`
+			validDevVersionContent           = `v1.75.0-dev`
+			emptyVersionContent              = ``
+			invalidVersionContent            = `foobar1.75.0`
+			invalidDevVersionContent         = `v1.75.0.0.0.0-dev`
+			validVersionWithEmptyLineContent = `v1.75.0
+
+`
+			validVersionInSecondLineContent = `foobar
+v1.75.0`
+		)
+
+		var (
+			testFileNames   map[string]string
+			testFileContent map[string]string
+		)
+
+		BeforeEach(func() {
+			By("Create test files")
+			testFileNames = map[string]string{}
+			testFileContent = map[string]string{
+				validVersionFile:              validVersionContent,
+				validDevVersionFile:           validDevVersionContent,
+				emptyVersionFile:              emptyVersionContent,
+				invalidVersionFile:            invalidVersionContent,
+				invalidDevVersionFile:         invalidDevVersionContent,
+				validVersionWithEmptyLineFile: validVersionWithEmptyLineContent,
+				validVersionInSecondLineFile:  validVersionInSecondLineContent,
+			}
+			for f, c := range testFileContent {
+				file, err := os.CreateTemp("", f)
+				Expect(err).NotTo(HaveOccurred())
+				testFileNames[f] = file.Name()
+				_, err = file.WriteString(c)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			DeferCleanup(func() {
+				By("Remove test files")
+				for _, f := range testFileNames {
+					err := os.Remove(f)
+					Expect(err).NotTo(HaveOccurred())
+				}
+			})
+		})
+
+		test := func(file, errorMsg string) {
+			version, err := getSemverFromFile(testFileNames[file])
+			if errorMsg == "" {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(version).ToNot(BeNil())
+			} else {
+				Expect(err).To(MatchError(ContainSubstring(errorMsg)))
+				Expect(version).To(BeNil())
+			}
+		}
+
+		It("should succeed for a valid version", func() {
+			test(validVersionFile, "")
+		})
+
+		It("should succeed for a valid dev version", func() {
+			test(validDevVersionFile, "")
+		})
+
+		It("should fail for an empty version", func() {
+			test(emptyVersionFile, "is empty")
+		})
+
+		It("should fail for an invalid version", func() {
+			test(invalidVersionFile, "invalid semver version in first line of file")
+		})
+
+		It("should fail for an invalid dev version", func() {
+			test(invalidDevVersionFile, "invalid semver version in first line of file")
+		})
+
+		It("should succeed for a valid version in first line and a empty second line", func() {
+			test(validVersionWithEmptyLineFile, "")
+		})
+
+		It("should fail for a version in the second line", func() {
+			test(validVersionInSecondLineFile, "invalid semver version in first line of file")
+		})
+	})
+
+	Describe("#releaseHandler", func() {
+		const (
+			currentDevVersion     = "v1.75.0-dev"
+			nextDevVersion        = "v1.76.0-dev"
+			nextPatchDevVersion   = "v1.75.1-dev"
+			currentReleaseVersion = "v1.75.0"
+			previousDevVersion    = "v1.74.0-dev"
+			invalidVersion        = "foobar"
+
+			versionFile = "VERSION"
+		)
+
+		var (
+			fakeGit           *localgit.LocalGit
+			fakeClientFactory gitv2.ClientFactory
+			rh                *releaseHandler
+
+			fakeOrg    = "foo"
+			fakeRepo   = "bar"
+			mainBranch = "main"
+		)
+
+		BeforeEach(func() {
+			var err error
+			fakeGit, fakeClientFactory, err = localgit.NewV2()
+			Expect(err).ToNot(HaveOccurred())
+			fakeGit.InitialBranch = mainBranch
+
+			rh = &releaseHandler{
+				gitClientFactory: fakeClientFactory,
+				options: options{
+					releaseBranchPrefix: "release-",
+					versionFilePath:     versionFile,
+					baseSHA:             mainBranch,
+				},
+			}
+
+			DeferCleanup(func() {
+				Expect(fakeGit.Clean()).To(Succeed())
+			})
+
+			rh.options.org = fakeOrg
+			rh.options.repo = fakeRepo
+			Expect(fakeGit.MakeFakeRepo(fakeOrg, fakeRepo)).To(Succeed())
+		})
+
+		addFileCommit := func(versionFileContent string) {
+			filename := versionFile
+			content := versionFileContent
+			if content == "" {
+				filename = "foo"
+				content = "bar"
+			}
+			Expect(fakeGit.AddCommit(fakeOrg, fakeRepo, map[string][]byte{filename: []byte(content)})).To(Succeed())
+		}
+
+		removeFileCommit := func(filenames []string) {
+			Expect(fakeGit.RmCommit(fakeOrg, fakeRepo, filenames)).To(Succeed())
+		}
+
+		Context("run", func() {
+			It("should succeed for a new minor dev version", func() {
+				addFileCommit(currentDevVersion)
+				addFileCommit(nextDevVersion)
+				Expect(rh.run()).To(Succeed())
+			})
+
+			It("should succeed for a new patch dev version", func() {
+				addFileCommit(currentDevVersion)
+				addFileCommit(nextPatchDevVersion)
+				Expect(rh.run()).To(Succeed())
+			})
+
+			It("should succeed for the current release", func() {
+				addFileCommit(currentDevVersion)
+				addFileCommit(currentReleaseVersion)
+				Expect(rh.run()).To(Succeed())
+			})
+
+			It("should succeed when the next dev cycle starts", func() {
+				addFileCommit(currentReleaseVersion)
+				addFileCommit(nextDevVersion)
+				Expect(rh.run()).To(Succeed())
+			})
+
+			It("should succeed when version file does not change", func() {
+				addFileCommit(currentDevVersion)
+				addFileCommit("")
+				Expect(rh.run()).To(Succeed())
+			})
+
+			It("should succeed when there is no version file", func() {
+				addFileCommit("")
+				Expect(rh.run()).To(Succeed())
+			})
+
+			It("should fail when downgrading the version", func() {
+				addFileCommit(currentDevVersion)
+				addFileCommit(previousDevVersion)
+				Expect(rh.run()).To(MatchError(ContainSubstring("version does not increase")))
+			})
+
+			It("should fail when there is only the initial commit", func() {
+				Expect(rh.run()).ToNot(Succeed())
+			})
+
+			It("should fail when the version file is created", func() {
+				addFileCommit(currentDevVersion)
+				Expect(rh.run()).To(MatchError(ContainSubstring("open")))
+			})
+
+			It("should fail when the version file is removed", func() {
+				addFileCommit(currentDevVersion)
+				removeFileCommit([]string{versionFile})
+				Expect(rh.run()).To(MatchError(ContainSubstring("open")))
+			})
+
+			It("should fail when the previous version file is invalid", func() {
+				addFileCommit(invalidVersion)
+				addFileCommit(currentDevVersion)
+				Expect(rh.run()).To(MatchError(ContainSubstring("Invalid Semantic Version")))
+			})
+
+			It("should fail when the current version file is invalid", func() {
+				addFileCommit(previousDevVersion)
+				addFileCommit(invalidVersion)
+				Expect(rh.run()).To(MatchError(ContainSubstring("Invalid Semantic Version")))
+			})
+		})
+
+		Context("compareVersions", func() {
+			JustBeforeEach(func() {
+				var err error
+				rh.repoClient, err = fakeClientFactory.ClientFromDir(fakeOrg, fakeRepo, path.Join(fakeGit.Dir, fakeOrg, fakeRepo))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rh.repoClient.Checkout(mainBranch)).To(Succeed())
+			})
+
+			It("should identify the next major/minor dev version", func() {
+				addFileCommit(currentDevVersion)
+				addFileCommit(nextDevVersion)
+				c, err := rh.compareVersions()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(c).To(Equal(&versionClassification{
+					currentVersion:  semver.MustParse(nextDevVersion),
+					previousVersion: semver.MustParse(currentDevVersion),
+					versionChange:   prepareNewMajorMinorVersion,
+				}))
+			})
+
+			It("should identify the next patch dev version", func() {
+				addFileCommit(currentDevVersion)
+				addFileCommit(nextPatchDevVersion)
+				c, err := rh.compareVersions()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(c).To(Equal(&versionClassification{
+					currentVersion:  semver.MustParse(nextPatchDevVersion),
+					previousVersion: semver.MustParse(currentDevVersion),
+					versionChange:   prepareNewPatchVersion,
+				}))
+			})
+
+			It("should identify the next release", func() {
+				addFileCommit(currentDevVersion)
+				addFileCommit(currentReleaseVersion)
+				c, err := rh.compareVersions()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(c).To(Equal(&versionClassification{
+					currentVersion:  semver.MustParse(currentReleaseVersion),
+					previousVersion: semver.MustParse(currentDevVersion),
+					versionChange:   newRelease,
+				}))
+			})
+
+			It("should identify the next dev cycle", func() {
+				addFileCommit(currentReleaseVersion)
+				addFileCommit(nextDevVersion)
+				c, err := rh.compareVersions()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(c).To(Equal(&versionClassification{
+					currentVersion:  semver.MustParse(nextDevVersion),
+					previousVersion: semver.MustParse(currentReleaseVersion),
+					versionChange:   nextDevCycle,
+				}))
+			})
+
+			It("should fail when version file does not change", func() {
+				addFileCommit(currentDevVersion)
+				addFileCommit("")
+				c, err := rh.compareVersions()
+				Expect(err).To(MatchError(ContainSubstring("version does not increase")))
+				Expect(c).To(BeNil())
+			})
+
+			It("should fail when downgrading the version", func() {
+				addFileCommit(currentDevVersion)
+				addFileCommit(previousDevVersion)
+				c, err := rh.compareVersions()
+				Expect(err).To(MatchError(ContainSubstring("version does not increase")))
+				Expect(c).To(BeNil())
+			})
+
+			It("should fail when the previous version file is invalid", func() {
+				addFileCommit(invalidVersion)
+				addFileCommit(currentDevVersion)
+				c, err := rh.compareVersions()
+				Expect(err).To(MatchError(ContainSubstring("Invalid Semantic Version")))
+				Expect(c).To(BeNil())
+			})
+
+			It("should fail when the current version file is invalid", func() {
+				addFileCommit(previousDevVersion)
+				addFileCommit(invalidVersion)
+				c, err := rh.compareVersions()
+				Expect(err).To(MatchError(ContainSubstring("Invalid Semantic Version")))
+				Expect(c).To(BeNil())
+			})
+		})
+	})
+})

--- a/vendor/github.com/Masterminds/semver/.travis.yml
+++ b/vendor/github.com/Masterminds/semver/.travis.yml
@@ -1,0 +1,29 @@
+language: go
+
+go:
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x
+  - tip
+
+# Setting sudo access to false will let Travis CI use containers rather than
+# VMs to run the tests. For more details see:
+# - http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+# - http://docs.travis-ci.com/user/workers/standard-infrastructure/
+sudo: false
+
+script:
+  - make setup
+  - make test
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/06e3328629952dabe3e0
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always

--- a/vendor/github.com/Masterminds/semver/CHANGELOG.md
+++ b/vendor/github.com/Masterminds/semver/CHANGELOG.md
@@ -1,0 +1,109 @@
+# 1.5.0 (2019-09-11)
+
+## Added
+
+- #103: Add basic fuzzing for `NewVersion()` (thanks @jesse-c)
+
+## Changed
+
+- #82: Clarify wildcard meaning in range constraints and update tests for it (thanks @greysteil)
+- #83: Clarify caret operator range for pre-1.0.0 dependencies (thanks @greysteil)
+- #72: Adding docs comment pointing to vert for a cli
+- #71: Update the docs on pre-release comparator handling
+- #89: Test with new go versions (thanks @thedevsaddam)
+- #87: Added $ to ValidPrerelease for better validation (thanks @jeremycarroll)
+
+## Fixed
+
+- #78: Fix unchecked error in example code (thanks @ravron)
+- #70: Fix the handling of pre-releases and the 0.0.0 release edge case
+- #97: Fixed copyright file for proper display on GitHub
+- #107: Fix handling prerelease when sorting alphanum and num 
+- #109: Fixed where Validate sometimes returns wrong message on error
+
+# 1.4.2 (2018-04-10)
+
+## Changed
+- #72: Updated the docs to point to vert for a console appliaction
+- #71: Update the docs on pre-release comparator handling
+
+## Fixed
+- #70: Fix the handling of pre-releases and the 0.0.0 release edge case
+
+# 1.4.1 (2018-04-02)
+
+## Fixed
+- Fixed #64: Fix pre-release precedence issue (thanks @uudashr)
+
+# 1.4.0 (2017-10-04)
+
+## Changed
+- #61: Update NewVersion to parse ints with a 64bit int size (thanks @zknill)
+
+# 1.3.1 (2017-07-10)
+
+## Fixed
+- Fixed #57: number comparisons in prerelease sometimes inaccurate
+
+# 1.3.0 (2017-05-02)
+
+## Added
+- #45: Added json (un)marshaling support (thanks @mh-cbon)
+- Stability marker. See https://masterminds.github.io/stability/
+
+## Fixed
+- #51: Fix handling of single digit tilde constraint (thanks @dgodd)
+
+## Changed
+- #55: The godoc icon moved from png to svg
+
+# 1.2.3 (2017-04-03)
+
+## Fixed
+- #46: Fixed 0.x.x and 0.0.x in constraints being treated as *
+
+# Release 1.2.2 (2016-12-13)
+
+## Fixed
+- #34: Fixed issue where hyphen range was not working with pre-release parsing.
+
+# Release 1.2.1 (2016-11-28)
+
+## Fixed
+- #24: Fixed edge case issue where constraint "> 0" does not handle "0.0.1-alpha"
+  properly.
+
+# Release 1.2.0 (2016-11-04)
+
+## Added
+- #20: Added MustParse function for versions (thanks @adamreese)
+- #15: Added increment methods on versions (thanks @mh-cbon)
+
+## Fixed
+- Issue #21: Per the SemVer spec (section 9) a pre-release is unstable and
+  might not satisfy the intended compatibility. The change here ignores pre-releases
+  on constraint checks (e.g., ~ or ^) when a pre-release is not part of the
+  constraint. For example, `^1.2.3` will ignore pre-releases while
+  `^1.2.3-alpha` will include them.
+
+# Release 1.1.1 (2016-06-30)
+
+## Changed
+- Issue #9: Speed up version comparison performance (thanks @sdboyer)
+- Issue #8: Added benchmarks (thanks @sdboyer)
+- Updated Go Report Card URL to new location
+- Updated Readme to add code snippet formatting (thanks @mh-cbon)
+- Updating tagging to v[SemVer] structure for compatibility with other tools.
+
+# Release 1.1.0 (2016-03-11)
+
+- Issue #2: Implemented validation to provide reasons a versions failed a
+  constraint.
+
+# Release 1.0.1 (2015-12-31)
+
+- Fixed #1: * constraint failing on valid versions.
+
+# Release 1.0.0 (2015-10-20)
+
+- Initial release

--- a/vendor/github.com/Masterminds/semver/LICENSE.txt
+++ b/vendor/github.com/Masterminds/semver/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (C) 2014-2019, Matt Butcher and Matt Farina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/Masterminds/semver/Makefile
+++ b/vendor/github.com/Masterminds/semver/Makefile
@@ -1,0 +1,36 @@
+.PHONY: setup
+setup:
+	go get -u gopkg.in/alecthomas/gometalinter.v1
+	gometalinter.v1 --install
+
+.PHONY: test
+test: validate lint
+	@echo "==> Running tests"
+	go test -v
+
+.PHONY: validate
+validate:
+	@echo "==> Running static validations"
+	@gometalinter.v1 \
+	  --disable-all \
+	  --enable deadcode \
+	  --severity deadcode:error \
+	  --enable gofmt \
+	  --enable gosimple \
+	  --enable ineffassign \
+	  --enable misspell \
+	  --enable vet \
+	  --tests \
+	  --vendor \
+	  --deadline 60s \
+	  ./... || exit_code=1
+
+.PHONY: lint
+lint:
+	@echo "==> Running linters"
+	@gometalinter.v1 \
+	  --disable-all \
+	  --enable golint \
+	  --vendor \
+	  --deadline 60s \
+	  ./... || :

--- a/vendor/github.com/Masterminds/semver/README.md
+++ b/vendor/github.com/Masterminds/semver/README.md
@@ -1,0 +1,194 @@
+# SemVer
+
+The `semver` package provides the ability to work with [Semantic Versions](http://semver.org) in Go. Specifically it provides the ability to:
+
+* Parse semantic versions
+* Sort semantic versions
+* Check if a semantic version fits within a set of constraints
+* Optionally work with a `v` prefix
+
+[![Stability:
+Active](https://masterminds.github.io/stability/active.svg)](https://masterminds.github.io/stability/active.html)
+[![Build Status](https://travis-ci.org/Masterminds/semver.svg)](https://travis-ci.org/Masterminds/semver) [![Build status](https://ci.appveyor.com/api/projects/status/jfk66lib7hb985k8/branch/master?svg=true&passingText=windows%20build%20passing&failingText=windows%20build%20failing)](https://ci.appveyor.com/project/mattfarina/semver/branch/master) [![GoDoc](https://godoc.org/github.com/Masterminds/semver?status.svg)](https://godoc.org/github.com/Masterminds/semver) [![Go Report Card](https://goreportcard.com/badge/github.com/Masterminds/semver)](https://goreportcard.com/report/github.com/Masterminds/semver)
+
+If you are looking for a command line tool for version comparisons please see
+[vert](https://github.com/Masterminds/vert) which uses this library.
+
+## Parsing Semantic Versions
+
+To parse a semantic version use the `NewVersion` function. For example,
+
+```go
+    v, err := semver.NewVersion("1.2.3-beta.1+build345")
+```
+
+If there is an error the version wasn't parseable. The version object has methods
+to get the parts of the version, compare it to other versions, convert the
+version back into a string, and get the original string. For more details
+please see the [documentation](https://godoc.org/github.com/Masterminds/semver).
+
+## Sorting Semantic Versions
+
+A set of versions can be sorted using the [`sort`](https://golang.org/pkg/sort/)
+package from the standard library. For example,
+
+```go
+    raw := []string{"1.2.3", "1.0", "1.3", "2", "0.4.2",}
+    vs := make([]*semver.Version, len(raw))
+	for i, r := range raw {
+		v, err := semver.NewVersion(r)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		vs[i] = v
+	}
+
+	sort.Sort(semver.Collection(vs))
+```
+
+## Checking Version Constraints
+
+Checking a version against version constraints is one of the most featureful
+parts of the package.
+
+```go
+    c, err := semver.NewConstraint(">= 1.2.3")
+    if err != nil {
+        // Handle constraint not being parseable.
+    }
+
+    v, _ := semver.NewVersion("1.3")
+    if err != nil {
+        // Handle version not being parseable.
+    }
+    // Check if the version meets the constraints. The a variable will be true.
+    a := c.Check(v)
+```
+
+## Basic Comparisons
+
+There are two elements to the comparisons. First, a comparison string is a list
+of comma separated and comparisons. These are then separated by || separated or
+comparisons. For example, `">= 1.2, < 3.0.0 || >= 4.2.3"` is looking for a
+comparison that's greater than or equal to 1.2 and less than 3.0.0 or is
+greater than or equal to 4.2.3.
+
+The basic comparisons are:
+
+* `=`: equal (aliased to no operator)
+* `!=`: not equal
+* `>`: greater than
+* `<`: less than
+* `>=`: greater than or equal to
+* `<=`: less than or equal to
+
+## Working With Pre-release Versions
+
+Pre-releases, for those not familiar with them, are used for software releases
+prior to stable or generally available releases. Examples of pre-releases include
+development, alpha, beta, and release candidate releases. A pre-release may be
+a version such as `1.2.3-beta.1` while the stable release would be `1.2.3`. In the
+order of precidence, pre-releases come before their associated releases. In this
+example `1.2.3-beta.1 < 1.2.3`.
+
+According to the Semantic Version specification pre-releases may not be
+API compliant with their release counterpart. It says,
+
+> A pre-release version indicates that the version is unstable and might not satisfy the intended compatibility requirements as denoted by its associated normal version.
+
+SemVer comparisons without a pre-release comparator will skip pre-release versions.
+For example, `>=1.2.3` will skip pre-releases when looking at a list of releases
+while `>=1.2.3-0` will evaluate and find pre-releases.
+
+The reason for the `0` as a pre-release version in the example comparison is
+because pre-releases can only contain ASCII alphanumerics and hyphens (along with
+`.` separators), per the spec. Sorting happens in ASCII sort order, again per the spec. The lowest character is a `0` in ASCII sort order (see an [ASCII Table](http://www.asciitable.com/))
+
+Understanding ASCII sort ordering is important because A-Z comes before a-z. That
+means `>=1.2.3-BETA` will return `1.2.3-alpha`. What you might expect from case
+sensitivity doesn't apply here. This is due to ASCII sort ordering which is what
+the spec specifies.
+
+## Hyphen Range Comparisons
+
+There are multiple methods to handle ranges and the first is hyphens ranges.
+These look like:
+
+* `1.2 - 1.4.5` which is equivalent to `>= 1.2, <= 1.4.5`
+* `2.3.4 - 4.5` which is equivalent to `>= 2.3.4, <= 4.5`
+
+## Wildcards In Comparisons
+
+The `x`, `X`, and `*` characters can be used as a wildcard character. This works
+for all comparison operators. When used on the `=` operator it falls
+back to the pack level comparison (see tilde below). For example,
+
+* `1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
+* `>= 1.2.x` is equivalent to `>= 1.2.0`
+* `<= 2.x` is equivalent to `< 3`
+* `*` is equivalent to `>= 0.0.0`
+
+## Tilde Range Comparisons (Patch)
+
+The tilde (`~`) comparison operator is for patch level ranges when a minor
+version is specified and major level changes when the minor number is missing.
+For example,
+
+* `~1.2.3` is equivalent to `>= 1.2.3, < 1.3.0`
+* `~1` is equivalent to `>= 1, < 2`
+* `~2.3` is equivalent to `>= 2.3, < 2.4`
+* `~1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
+* `~1.x` is equivalent to `>= 1, < 2`
+
+## Caret Range Comparisons (Major)
+
+The caret (`^`) comparison operator is for major level changes. This is useful
+when comparisons of API versions as a major change is API breaking. For example,
+
+* `^1.2.3` is equivalent to `>= 1.2.3, < 2.0.0`
+* `^0.0.1` is equivalent to `>= 0.0.1, < 1.0.0`
+* `^1.2.x` is equivalent to `>= 1.2.0, < 2.0.0`
+* `^2.3` is equivalent to `>= 2.3, < 3`
+* `^2.x` is equivalent to `>= 2.0.0, < 3`
+
+# Validation
+
+In addition to testing a version against a constraint, a version can be validated
+against a constraint. When validation fails a slice of errors containing why a
+version didn't meet the constraint is returned. For example,
+
+```go
+    c, err := semver.NewConstraint("<= 1.2.3, >= 1.4")
+    if err != nil {
+        // Handle constraint not being parseable.
+    }
+
+    v, _ := semver.NewVersion("1.3")
+    if err != nil {
+        // Handle version not being parseable.
+    }
+
+    // Validate a version against a constraint.
+    a, msgs := c.Validate(v)
+    // a is false
+    for _, m := range msgs {
+        fmt.Println(m)
+
+        // Loops over the errors which would read
+        // "1.3 is greater than 1.2.3"
+        // "1.3 is less than 1.4"
+    }
+```
+
+# Fuzzing
+
+ [dvyukov/go-fuzz](https://github.com/dvyukov/go-fuzz) is used for fuzzing.
+
+1. `go-fuzz-build`
+2. `go-fuzz -workdir=fuzz`
+
+# Contribute
+
+If you find an issue or want to contribute please file an [issue](https://github.com/Masterminds/semver/issues)
+or [create a pull request](https://github.com/Masterminds/semver/pulls).

--- a/vendor/github.com/Masterminds/semver/appveyor.yml
+++ b/vendor/github.com/Masterminds/semver/appveyor.yml
@@ -1,0 +1,44 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\Masterminds\semver
+shallow_clone: true
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+install:
+  - go version
+  - go env
+  - go get -u gopkg.in/alecthomas/gometalinter.v1
+  - set PATH=%PATH%;%GOPATH%\bin
+  - gometalinter.v1.exe --install
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - "gometalinter.v1 \
+    --disable-all \
+    --enable deadcode \
+    --severity deadcode:error \
+    --enable gofmt \
+    --enable gosimple \
+    --enable ineffassign \
+    --enable misspell \
+    --enable vet \
+    --tests \
+    --vendor \
+    --deadline 60s \
+    ./... || exit_code=1"
+  - "gometalinter.v1 \
+    --disable-all \
+    --enable golint \
+    --vendor \
+    --deadline 60s \
+    ./... || :"
+  - go test -v
+
+deploy: off

--- a/vendor/github.com/Masterminds/semver/collection.go
+++ b/vendor/github.com/Masterminds/semver/collection.go
@@ -1,0 +1,24 @@
+package semver
+
+// Collection is a collection of Version instances and implements the sort
+// interface. See the sort package for more details.
+// https://golang.org/pkg/sort/
+type Collection []*Version
+
+// Len returns the length of a collection. The number of Version instances
+// on the slice.
+func (c Collection) Len() int {
+	return len(c)
+}
+
+// Less is needed for the sort interface to compare two Version objects on the
+// slice. If checks if one is less than the other.
+func (c Collection) Less(i, j int) bool {
+	return c[i].LessThan(c[j])
+}
+
+// Swap is needed for the sort interface to replace the Version objects
+// at two different positions in the slice.
+func (c Collection) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}

--- a/vendor/github.com/Masterminds/semver/constraints.go
+++ b/vendor/github.com/Masterminds/semver/constraints.go
@@ -1,0 +1,423 @@
+package semver
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Constraints is one or more constraint that a semantic version can be
+// checked against.
+type Constraints struct {
+	constraints [][]*constraint
+}
+
+// NewConstraint returns a Constraints instance that a Version instance can
+// be checked against. If there is a parse error it will be returned.
+func NewConstraint(c string) (*Constraints, error) {
+
+	// Rewrite - ranges into a comparison operation.
+	c = rewriteRange(c)
+
+	ors := strings.Split(c, "||")
+	or := make([][]*constraint, len(ors))
+	for k, v := range ors {
+		cs := strings.Split(v, ",")
+		result := make([]*constraint, len(cs))
+		for i, s := range cs {
+			pc, err := parseConstraint(s)
+			if err != nil {
+				return nil, err
+			}
+
+			result[i] = pc
+		}
+		or[k] = result
+	}
+
+	o := &Constraints{constraints: or}
+	return o, nil
+}
+
+// Check tests if a version satisfies the constraints.
+func (cs Constraints) Check(v *Version) bool {
+	// loop over the ORs and check the inner ANDs
+	for _, o := range cs.constraints {
+		joy := true
+		for _, c := range o {
+			if !c.check(v) {
+				joy = false
+				break
+			}
+		}
+
+		if joy {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Validate checks if a version satisfies a constraint. If not a slice of
+// reasons for the failure are returned in addition to a bool.
+func (cs Constraints) Validate(v *Version) (bool, []error) {
+	// loop over the ORs and check the inner ANDs
+	var e []error
+
+	// Capture the prerelease message only once. When it happens the first time
+	// this var is marked
+	var prerelesase bool
+	for _, o := range cs.constraints {
+		joy := true
+		for _, c := range o {
+			// Before running the check handle the case there the version is
+			// a prerelease and the check is not searching for prereleases.
+			if c.con.pre == "" && v.pre != "" {
+				if !prerelesase {
+					em := fmt.Errorf("%s is a prerelease version and the constraint is only looking for release versions", v)
+					e = append(e, em)
+					prerelesase = true
+				}
+				joy = false
+
+			} else {
+
+				if !c.check(v) {
+					em := fmt.Errorf(c.msg, v, c.orig)
+					e = append(e, em)
+					joy = false
+				}
+			}
+		}
+
+		if joy {
+			return true, []error{}
+		}
+	}
+
+	return false, e
+}
+
+var constraintOps map[string]cfunc
+var constraintMsg map[string]string
+var constraintRegex *regexp.Regexp
+
+func init() {
+	constraintOps = map[string]cfunc{
+		"":   constraintTildeOrEqual,
+		"=":  constraintTildeOrEqual,
+		"!=": constraintNotEqual,
+		">":  constraintGreaterThan,
+		"<":  constraintLessThan,
+		">=": constraintGreaterThanEqual,
+		"=>": constraintGreaterThanEqual,
+		"<=": constraintLessThanEqual,
+		"=<": constraintLessThanEqual,
+		"~":  constraintTilde,
+		"~>": constraintTilde,
+		"^":  constraintCaret,
+	}
+
+	constraintMsg = map[string]string{
+		"":   "%s is not equal to %s",
+		"=":  "%s is not equal to %s",
+		"!=": "%s is equal to %s",
+		">":  "%s is less than or equal to %s",
+		"<":  "%s is greater than or equal to %s",
+		">=": "%s is less than %s",
+		"=>": "%s is less than %s",
+		"<=": "%s is greater than %s",
+		"=<": "%s is greater than %s",
+		"~":  "%s does not have same major and minor version as %s",
+		"~>": "%s does not have same major and minor version as %s",
+		"^":  "%s does not have same major version as %s",
+	}
+
+	ops := make([]string, 0, len(constraintOps))
+	for k := range constraintOps {
+		ops = append(ops, regexp.QuoteMeta(k))
+	}
+
+	constraintRegex = regexp.MustCompile(fmt.Sprintf(
+		`^\s*(%s)\s*(%s)\s*$`,
+		strings.Join(ops, "|"),
+		cvRegex))
+
+	constraintRangeRegex = regexp.MustCompile(fmt.Sprintf(
+		`\s*(%s)\s+-\s+(%s)\s*`,
+		cvRegex, cvRegex))
+}
+
+// An individual constraint
+type constraint struct {
+	// The callback function for the restraint. It performs the logic for
+	// the constraint.
+	function cfunc
+
+	msg string
+
+	// The version used in the constraint check. For example, if a constraint
+	// is '<= 2.0.0' the con a version instance representing 2.0.0.
+	con *Version
+
+	// The original parsed version (e.g., 4.x from != 4.x)
+	orig string
+
+	// When an x is used as part of the version (e.g., 1.x)
+	minorDirty bool
+	dirty      bool
+	patchDirty bool
+}
+
+// Check if a version meets the constraint
+func (c *constraint) check(v *Version) bool {
+	return c.function(v, c)
+}
+
+type cfunc func(v *Version, c *constraint) bool
+
+func parseConstraint(c string) (*constraint, error) {
+	m := constraintRegex.FindStringSubmatch(c)
+	if m == nil {
+		return nil, fmt.Errorf("improper constraint: %s", c)
+	}
+
+	ver := m[2]
+	orig := ver
+	minorDirty := false
+	patchDirty := false
+	dirty := false
+	if isX(m[3]) {
+		ver = "0.0.0"
+		dirty = true
+	} else if isX(strings.TrimPrefix(m[4], ".")) || m[4] == "" {
+		minorDirty = true
+		dirty = true
+		ver = fmt.Sprintf("%s.0.0%s", m[3], m[6])
+	} else if isX(strings.TrimPrefix(m[5], ".")) {
+		dirty = true
+		patchDirty = true
+		ver = fmt.Sprintf("%s%s.0%s", m[3], m[4], m[6])
+	}
+
+	con, err := NewVersion(ver)
+	if err != nil {
+
+		// The constraintRegex should catch any regex parsing errors. So,
+		// we should never get here.
+		return nil, errors.New("constraint Parser Error")
+	}
+
+	cs := &constraint{
+		function:   constraintOps[m[1]],
+		msg:        constraintMsg[m[1]],
+		con:        con,
+		orig:       orig,
+		minorDirty: minorDirty,
+		patchDirty: patchDirty,
+		dirty:      dirty,
+	}
+	return cs, nil
+}
+
+// Constraint functions
+func constraintNotEqual(v *Version, c *constraint) bool {
+	if c.dirty {
+
+		// If there is a pre-release on the version but the constraint isn't looking
+		// for them assume that pre-releases are not compatible. See issue 21 for
+		// more details.
+		if v.Prerelease() != "" && c.con.Prerelease() == "" {
+			return false
+		}
+
+		if c.con.Major() != v.Major() {
+			return true
+		}
+		if c.con.Minor() != v.Minor() && !c.minorDirty {
+			return true
+		} else if c.minorDirty {
+			return false
+		}
+
+		return false
+	}
+
+	return !v.Equal(c.con)
+}
+
+func constraintGreaterThan(v *Version, c *constraint) bool {
+
+	// If there is a pre-release on the version but the constraint isn't looking
+	// for them assume that pre-releases are not compatible. See issue 21 for
+	// more details.
+	if v.Prerelease() != "" && c.con.Prerelease() == "" {
+		return false
+	}
+
+	return v.Compare(c.con) == 1
+}
+
+func constraintLessThan(v *Version, c *constraint) bool {
+	// If there is a pre-release on the version but the constraint isn't looking
+	// for them assume that pre-releases are not compatible. See issue 21 for
+	// more details.
+	if v.Prerelease() != "" && c.con.Prerelease() == "" {
+		return false
+	}
+
+	if !c.dirty {
+		return v.Compare(c.con) < 0
+	}
+
+	if v.Major() > c.con.Major() {
+		return false
+	} else if v.Minor() > c.con.Minor() && !c.minorDirty {
+		return false
+	}
+
+	return true
+}
+
+func constraintGreaterThanEqual(v *Version, c *constraint) bool {
+
+	// If there is a pre-release on the version but the constraint isn't looking
+	// for them assume that pre-releases are not compatible. See issue 21 for
+	// more details.
+	if v.Prerelease() != "" && c.con.Prerelease() == "" {
+		return false
+	}
+
+	return v.Compare(c.con) >= 0
+}
+
+func constraintLessThanEqual(v *Version, c *constraint) bool {
+	// If there is a pre-release on the version but the constraint isn't looking
+	// for them assume that pre-releases are not compatible. See issue 21 for
+	// more details.
+	if v.Prerelease() != "" && c.con.Prerelease() == "" {
+		return false
+	}
+
+	if !c.dirty {
+		return v.Compare(c.con) <= 0
+	}
+
+	if v.Major() > c.con.Major() {
+		return false
+	} else if v.Minor() > c.con.Minor() && !c.minorDirty {
+		return false
+	}
+
+	return true
+}
+
+// ~*, ~>* --> >= 0.0.0 (any)
+// ~2, ~2.x, ~2.x.x, ~>2, ~>2.x ~>2.x.x --> >=2.0.0, <3.0.0
+// ~2.0, ~2.0.x, ~>2.0, ~>2.0.x --> >=2.0.0, <2.1.0
+// ~1.2, ~1.2.x, ~>1.2, ~>1.2.x --> >=1.2.0, <1.3.0
+// ~1.2.3, ~>1.2.3 --> >=1.2.3, <1.3.0
+// ~1.2.0, ~>1.2.0 --> >=1.2.0, <1.3.0
+func constraintTilde(v *Version, c *constraint) bool {
+	// If there is a pre-release on the version but the constraint isn't looking
+	// for them assume that pre-releases are not compatible. See issue 21 for
+	// more details.
+	if v.Prerelease() != "" && c.con.Prerelease() == "" {
+		return false
+	}
+
+	if v.LessThan(c.con) {
+		return false
+	}
+
+	// ~0.0.0 is a special case where all constraints are accepted. It's
+	// equivalent to >= 0.0.0.
+	if c.con.Major() == 0 && c.con.Minor() == 0 && c.con.Patch() == 0 &&
+		!c.minorDirty && !c.patchDirty {
+		return true
+	}
+
+	if v.Major() != c.con.Major() {
+		return false
+	}
+
+	if v.Minor() != c.con.Minor() && !c.minorDirty {
+		return false
+	}
+
+	return true
+}
+
+// When there is a .x (dirty) status it automatically opts in to ~. Otherwise
+// it's a straight =
+func constraintTildeOrEqual(v *Version, c *constraint) bool {
+	// If there is a pre-release on the version but the constraint isn't looking
+	// for them assume that pre-releases are not compatible. See issue 21 for
+	// more details.
+	if v.Prerelease() != "" && c.con.Prerelease() == "" {
+		return false
+	}
+
+	if c.dirty {
+		c.msg = constraintMsg["~"]
+		return constraintTilde(v, c)
+	}
+
+	return v.Equal(c.con)
+}
+
+// ^* --> (any)
+// ^2, ^2.x, ^2.x.x --> >=2.0.0, <3.0.0
+// ^2.0, ^2.0.x --> >=2.0.0, <3.0.0
+// ^1.2, ^1.2.x --> >=1.2.0, <2.0.0
+// ^1.2.3 --> >=1.2.3, <2.0.0
+// ^1.2.0 --> >=1.2.0, <2.0.0
+func constraintCaret(v *Version, c *constraint) bool {
+	// If there is a pre-release on the version but the constraint isn't looking
+	// for them assume that pre-releases are not compatible. See issue 21 for
+	// more details.
+	if v.Prerelease() != "" && c.con.Prerelease() == "" {
+		return false
+	}
+
+	if v.LessThan(c.con) {
+		return false
+	}
+
+	if v.Major() != c.con.Major() {
+		return false
+	}
+
+	return true
+}
+
+var constraintRangeRegex *regexp.Regexp
+
+const cvRegex string = `v?([0-9|x|X|\*]+)(\.[0-9|x|X|\*]+)?(\.[0-9|x|X|\*]+)?` +
+	`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`
+
+func isX(x string) bool {
+	switch x {
+	case "x", "*", "X":
+		return true
+	default:
+		return false
+	}
+}
+
+func rewriteRange(i string) string {
+	m := constraintRangeRegex.FindAllStringSubmatch(i, -1)
+	if m == nil {
+		return i
+	}
+	o := i
+	for _, v := range m {
+		t := fmt.Sprintf(">= %s, <= %s", v[1], v[11])
+		o = strings.Replace(o, v[0], t, 1)
+	}
+
+	return o
+}

--- a/vendor/github.com/Masterminds/semver/doc.go
+++ b/vendor/github.com/Masterminds/semver/doc.go
@@ -1,0 +1,115 @@
+/*
+Package semver provides the ability to work with Semantic Versions (http://semver.org) in Go.
+
+Specifically it provides the ability to:
+
+    * Parse semantic versions
+    * Sort semantic versions
+    * Check if a semantic version fits within a set of constraints
+    * Optionally work with a `v` prefix
+
+Parsing Semantic Versions
+
+To parse a semantic version use the `NewVersion` function. For example,
+
+    v, err := semver.NewVersion("1.2.3-beta.1+build345")
+
+If there is an error the version wasn't parseable. The version object has methods
+to get the parts of the version, compare it to other versions, convert the
+version back into a string, and get the original string. For more details
+please see the documentation at https://godoc.org/github.com/Masterminds/semver.
+
+Sorting Semantic Versions
+
+A set of versions can be sorted using the `sort` package from the standard library.
+For example,
+
+    raw := []string{"1.2.3", "1.0", "1.3", "2", "0.4.2",}
+    vs := make([]*semver.Version, len(raw))
+	for i, r := range raw {
+		v, err := semver.NewVersion(r)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		vs[i] = v
+	}
+
+	sort.Sort(semver.Collection(vs))
+
+Checking Version Constraints
+
+Checking a version against version constraints is one of the most featureful
+parts of the package.
+
+    c, err := semver.NewConstraint(">= 1.2.3")
+    if err != nil {
+        // Handle constraint not being parseable.
+    }
+
+    v, err := semver.NewVersion("1.3")
+    if err != nil {
+        // Handle version not being parseable.
+    }
+    // Check if the version meets the constraints. The a variable will be true.
+    a := c.Check(v)
+
+Basic Comparisons
+
+There are two elements to the comparisons. First, a comparison string is a list
+of comma separated and comparisons. These are then separated by || separated or
+comparisons. For example, `">= 1.2, < 3.0.0 || >= 4.2.3"` is looking for a
+comparison that's greater than or equal to 1.2 and less than 3.0.0 or is
+greater than or equal to 4.2.3.
+
+The basic comparisons are:
+
+    * `=`: equal (aliased to no operator)
+    * `!=`: not equal
+    * `>`: greater than
+    * `<`: less than
+    * `>=`: greater than or equal to
+    * `<=`: less than or equal to
+
+Hyphen Range Comparisons
+
+There are multiple methods to handle ranges and the first is hyphens ranges.
+These look like:
+
+    * `1.2 - 1.4.5` which is equivalent to `>= 1.2, <= 1.4.5`
+    * `2.3.4 - 4.5` which is equivalent to `>= 2.3.4, <= 4.5`
+
+Wildcards In Comparisons
+
+The `x`, `X`, and `*` characters can be used as a wildcard character. This works
+for all comparison operators. When used on the `=` operator it falls
+back to the pack level comparison (see tilde below). For example,
+
+    * `1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
+    * `>= 1.2.x` is equivalent to `>= 1.2.0`
+    * `<= 2.x` is equivalent to `<= 3`
+    * `*` is equivalent to `>= 0.0.0`
+
+Tilde Range Comparisons (Patch)
+
+The tilde (`~`) comparison operator is for patch level ranges when a minor
+version is specified and major level changes when the minor number is missing.
+For example,
+
+    * `~1.2.3` is equivalent to `>= 1.2.3, < 1.3.0`
+    * `~1` is equivalent to `>= 1, < 2`
+    * `~2.3` is equivalent to `>= 2.3, < 2.4`
+    * `~1.2.x` is equivalent to `>= 1.2.0, < 1.3.0`
+    * `~1.x` is equivalent to `>= 1, < 2`
+
+Caret Range Comparisons (Major)
+
+The caret (`^`) comparison operator is for major level changes. This is useful
+when comparisons of API versions as a major change is API breaking. For example,
+
+    * `^1.2.3` is equivalent to `>= 1.2.3, < 2.0.0`
+    * `^1.2.x` is equivalent to `>= 1.2.0, < 2.0.0`
+    * `^2.3` is equivalent to `>= 2.3, < 3`
+    * `^2.x` is equivalent to `>= 2.0.0, < 3`
+*/
+package semver

--- a/vendor/github.com/Masterminds/semver/version.go
+++ b/vendor/github.com/Masterminds/semver/version.go
@@ -1,0 +1,425 @@
+package semver
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// The compiled version of the regex created at init() is cached here so it
+// only needs to be created once.
+var versionRegex *regexp.Regexp
+var validPrereleaseRegex *regexp.Regexp
+
+var (
+	// ErrInvalidSemVer is returned a version is found to be invalid when
+	// being parsed.
+	ErrInvalidSemVer = errors.New("Invalid Semantic Version")
+
+	// ErrInvalidMetadata is returned when the metadata is an invalid format
+	ErrInvalidMetadata = errors.New("Invalid Metadata string")
+
+	// ErrInvalidPrerelease is returned when the pre-release is an invalid format
+	ErrInvalidPrerelease = errors.New("Invalid Prerelease string")
+)
+
+// SemVerRegex is the regular expression used to parse a semantic version.
+const SemVerRegex string = `v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?` +
+	`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`
+
+// ValidPrerelease is the regular expression which validates
+// both prerelease and metadata values.
+const ValidPrerelease string = `^([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*)$`
+
+// Version represents a single semantic version.
+type Version struct {
+	major, minor, patch int64
+	pre                 string
+	metadata            string
+	original            string
+}
+
+func init() {
+	versionRegex = regexp.MustCompile("^" + SemVerRegex + "$")
+	validPrereleaseRegex = regexp.MustCompile(ValidPrerelease)
+}
+
+// NewVersion parses a given version and returns an instance of Version or
+// an error if unable to parse the version.
+func NewVersion(v string) (*Version, error) {
+	m := versionRegex.FindStringSubmatch(v)
+	if m == nil {
+		return nil, ErrInvalidSemVer
+	}
+
+	sv := &Version{
+		metadata: m[8],
+		pre:      m[5],
+		original: v,
+	}
+
+	var temp int64
+	temp, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing version segment: %s", err)
+	}
+	sv.major = temp
+
+	if m[2] != "" {
+		temp, err = strconv.ParseInt(strings.TrimPrefix(m[2], "."), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing version segment: %s", err)
+		}
+		sv.minor = temp
+	} else {
+		sv.minor = 0
+	}
+
+	if m[3] != "" {
+		temp, err = strconv.ParseInt(strings.TrimPrefix(m[3], "."), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing version segment: %s", err)
+		}
+		sv.patch = temp
+	} else {
+		sv.patch = 0
+	}
+
+	return sv, nil
+}
+
+// MustParse parses a given version and panics on error.
+func MustParse(v string) *Version {
+	sv, err := NewVersion(v)
+	if err != nil {
+		panic(err)
+	}
+	return sv
+}
+
+// String converts a Version object to a string.
+// Note, if the original version contained a leading v this version will not.
+// See the Original() method to retrieve the original value. Semantic Versions
+// don't contain a leading v per the spec. Instead it's optional on
+// implementation.
+func (v *Version) String() string {
+	var buf bytes.Buffer
+
+	fmt.Fprintf(&buf, "%d.%d.%d", v.major, v.minor, v.patch)
+	if v.pre != "" {
+		fmt.Fprintf(&buf, "-%s", v.pre)
+	}
+	if v.metadata != "" {
+		fmt.Fprintf(&buf, "+%s", v.metadata)
+	}
+
+	return buf.String()
+}
+
+// Original returns the original value passed in to be parsed.
+func (v *Version) Original() string {
+	return v.original
+}
+
+// Major returns the major version.
+func (v *Version) Major() int64 {
+	return v.major
+}
+
+// Minor returns the minor version.
+func (v *Version) Minor() int64 {
+	return v.minor
+}
+
+// Patch returns the patch version.
+func (v *Version) Patch() int64 {
+	return v.patch
+}
+
+// Prerelease returns the pre-release version.
+func (v *Version) Prerelease() string {
+	return v.pre
+}
+
+// Metadata returns the metadata on the version.
+func (v *Version) Metadata() string {
+	return v.metadata
+}
+
+// originalVPrefix returns the original 'v' prefix if any.
+func (v *Version) originalVPrefix() string {
+
+	// Note, only lowercase v is supported as a prefix by the parser.
+	if v.original != "" && v.original[:1] == "v" {
+		return v.original[:1]
+	}
+	return ""
+}
+
+// IncPatch produces the next patch version.
+// If the current version does not have prerelease/metadata information,
+// it unsets metadata and prerelease values, increments patch number.
+// If the current version has any of prerelease or metadata information,
+// it unsets both values and keeps curent patch value
+func (v Version) IncPatch() Version {
+	vNext := v
+	// according to http://semver.org/#spec-item-9
+	// Pre-release versions have a lower precedence than the associated normal version.
+	// according to http://semver.org/#spec-item-10
+	// Build metadata SHOULD be ignored when determining version precedence.
+	if v.pre != "" {
+		vNext.metadata = ""
+		vNext.pre = ""
+	} else {
+		vNext.metadata = ""
+		vNext.pre = ""
+		vNext.patch = v.patch + 1
+	}
+	vNext.original = v.originalVPrefix() + "" + vNext.String()
+	return vNext
+}
+
+// IncMinor produces the next minor version.
+// Sets patch to 0.
+// Increments minor number.
+// Unsets metadata.
+// Unsets prerelease status.
+func (v Version) IncMinor() Version {
+	vNext := v
+	vNext.metadata = ""
+	vNext.pre = ""
+	vNext.patch = 0
+	vNext.minor = v.minor + 1
+	vNext.original = v.originalVPrefix() + "" + vNext.String()
+	return vNext
+}
+
+// IncMajor produces the next major version.
+// Sets patch to 0.
+// Sets minor to 0.
+// Increments major number.
+// Unsets metadata.
+// Unsets prerelease status.
+func (v Version) IncMajor() Version {
+	vNext := v
+	vNext.metadata = ""
+	vNext.pre = ""
+	vNext.patch = 0
+	vNext.minor = 0
+	vNext.major = v.major + 1
+	vNext.original = v.originalVPrefix() + "" + vNext.String()
+	return vNext
+}
+
+// SetPrerelease defines the prerelease value.
+// Value must not include the required 'hypen' prefix.
+func (v Version) SetPrerelease(prerelease string) (Version, error) {
+	vNext := v
+	if len(prerelease) > 0 && !validPrereleaseRegex.MatchString(prerelease) {
+		return vNext, ErrInvalidPrerelease
+	}
+	vNext.pre = prerelease
+	vNext.original = v.originalVPrefix() + "" + vNext.String()
+	return vNext, nil
+}
+
+// SetMetadata defines metadata value.
+// Value must not include the required 'plus' prefix.
+func (v Version) SetMetadata(metadata string) (Version, error) {
+	vNext := v
+	if len(metadata) > 0 && !validPrereleaseRegex.MatchString(metadata) {
+		return vNext, ErrInvalidMetadata
+	}
+	vNext.metadata = metadata
+	vNext.original = v.originalVPrefix() + "" + vNext.String()
+	return vNext, nil
+}
+
+// LessThan tests if one version is less than another one.
+func (v *Version) LessThan(o *Version) bool {
+	return v.Compare(o) < 0
+}
+
+// GreaterThan tests if one version is greater than another one.
+func (v *Version) GreaterThan(o *Version) bool {
+	return v.Compare(o) > 0
+}
+
+// Equal tests if two versions are equal to each other.
+// Note, versions can be equal with different metadata since metadata
+// is not considered part of the comparable version.
+func (v *Version) Equal(o *Version) bool {
+	return v.Compare(o) == 0
+}
+
+// Compare compares this version to another one. It returns -1, 0, or 1 if
+// the version smaller, equal, or larger than the other version.
+//
+// Versions are compared by X.Y.Z. Build metadata is ignored. Prerelease is
+// lower than the version without a prerelease.
+func (v *Version) Compare(o *Version) int {
+	// Compare the major, minor, and patch version for differences. If a
+	// difference is found return the comparison.
+	if d := compareSegment(v.Major(), o.Major()); d != 0 {
+		return d
+	}
+	if d := compareSegment(v.Minor(), o.Minor()); d != 0 {
+		return d
+	}
+	if d := compareSegment(v.Patch(), o.Patch()); d != 0 {
+		return d
+	}
+
+	// At this point the major, minor, and patch versions are the same.
+	ps := v.pre
+	po := o.Prerelease()
+
+	if ps == "" && po == "" {
+		return 0
+	}
+	if ps == "" {
+		return 1
+	}
+	if po == "" {
+		return -1
+	}
+
+	return comparePrerelease(ps, po)
+}
+
+// UnmarshalJSON implements JSON.Unmarshaler interface.
+func (v *Version) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	temp, err := NewVersion(s)
+	if err != nil {
+		return err
+	}
+	v.major = temp.major
+	v.minor = temp.minor
+	v.patch = temp.patch
+	v.pre = temp.pre
+	v.metadata = temp.metadata
+	v.original = temp.original
+	temp = nil
+	return nil
+}
+
+// MarshalJSON implements JSON.Marshaler interface.
+func (v *Version) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.String())
+}
+
+func compareSegment(v, o int64) int {
+	if v < o {
+		return -1
+	}
+	if v > o {
+		return 1
+	}
+
+	return 0
+}
+
+func comparePrerelease(v, o string) int {
+
+	// split the prelease versions by their part. The separator, per the spec,
+	// is a .
+	sparts := strings.Split(v, ".")
+	oparts := strings.Split(o, ".")
+
+	// Find the longer length of the parts to know how many loop iterations to
+	// go through.
+	slen := len(sparts)
+	olen := len(oparts)
+
+	l := slen
+	if olen > slen {
+		l = olen
+	}
+
+	// Iterate over each part of the prereleases to compare the differences.
+	for i := 0; i < l; i++ {
+		// Since the lentgh of the parts can be different we need to create
+		// a placeholder. This is to avoid out of bounds issues.
+		stemp := ""
+		if i < slen {
+			stemp = sparts[i]
+		}
+
+		otemp := ""
+		if i < olen {
+			otemp = oparts[i]
+		}
+
+		d := comparePrePart(stemp, otemp)
+		if d != 0 {
+			return d
+		}
+	}
+
+	// Reaching here means two versions are of equal value but have different
+	// metadata (the part following a +). They are not identical in string form
+	// but the version comparison finds them to be equal.
+	return 0
+}
+
+func comparePrePart(s, o string) int {
+	// Fastpath if they are equal
+	if s == o {
+		return 0
+	}
+
+	// When s or o are empty we can use the other in an attempt to determine
+	// the response.
+	if s == "" {
+		if o != "" {
+			return -1
+		}
+		return 1
+	}
+
+	if o == "" {
+		if s != "" {
+			return 1
+		}
+		return -1
+	}
+
+	// When comparing strings "99" is greater than "103". To handle
+	// cases like this we need to detect numbers and compare them. According
+	// to the semver spec, numbers are always positive. If there is a - at the
+	// start like -99 this is to be evaluated as an alphanum. numbers always
+	// have precedence over alphanum. Parsing as Uints because negative numbers
+	// are ignored.
+
+	oi, n1 := strconv.ParseUint(o, 10, 64)
+	si, n2 := strconv.ParseUint(s, 10, 64)
+
+	// The case where both are strings compare the strings
+	if n1 != nil && n2 != nil {
+		if s > o {
+			return 1
+		}
+		return -1
+	} else if n1 != nil {
+		// o is a string and s is a number
+		return -1
+	} else if n2 != nil {
+		// s is a string and o is a number
+		return 1
+	}
+	// Both are numbers
+	if si > oi {
+		return 1
+	}
+	return -1
+
+}

--- a/vendor/github.com/Masterminds/semver/version_fuzz.go
+++ b/vendor/github.com/Masterminds/semver/version_fuzz.go
@@ -1,0 +1,10 @@
+// +build gofuzz
+
+package semver
+
+func Fuzz(data []byte) int {
+	if _, err := NewVersion(string(data)); err != nil {
+		return 0
+	}
+	return 1
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -54,6 +54,9 @@ github.com/GoogleCloudPlatform/testgrid/pb/custom_evaluator
 github.com/GoogleCloudPlatform/testgrid/pb/state
 github.com/GoogleCloudPlatform/testgrid/pb/test_status
 github.com/GoogleCloudPlatform/testgrid/util/gcs
+# github.com/Masterminds/semver v1.5.0
+## explicit
+github.com/Masterminds/semver
 # github.com/PuerkitoBio/purell v1.1.1
 ## explicit
 github.com/PuerkitoBio/purell


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
`release-handler` is meant to automate tasks related to Gardener releases. 
It identifies four cases based on the change of the `VERSION` file.
- `newRelease`: when the version increases from a dev to a final version like `v1.75.0-dev -> v1.75.0`.
- `nextDevCycle`: when the version increases from a final to a higher dev version like `v1.75.0 -> v1.75.1-dev`
- `prepareNewPatchVersion`: when the version increases from one dev version to another with a higher patch version like `v1.75.0-dev -> v1.75.1-dev`
- `prepareNewMajorMinorVersion`: when the version increases from one dev version to another with a higher major or minor version like `v1.75.0-dev -> v1.76.0-dev` 

In this first version in only acts in the `prepareNewMajorMinorVersion` case and creates new release branches for the lower version.
It will be enabled for `gardener/gardener` repository via this PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
