### PR TITLE
Use FQDN for `ghproxy` endpoint in prow jobs

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -64,7 +64,7 @@ periodics:
       - --confirm
       - --enable-apps-restrictions=true
       - --job-config-path=config/jobs
-      - --github-endpoint=http://ghproxy.prow.svc
+      - --github-endpoint=http://ghproxy.prow.svc.cluster.local
       - --github-endpoint=https://api.github.com
       - --github-token-path=/etc/github/token
       volumeMounts:
@@ -93,7 +93,7 @@ periodics:
       - /job-forker
       args:
       - --github-token-path=/etc/github-token/token
-      - --github-endpoint=http://ghproxy
+      - --github-endpoint=http://ghproxy.prow.svc.cluster.local
       - --github-endpoint=https://api.github.com
       - --dry-run=false
       - --job-directory=config/jobs/gardener
@@ -128,7 +128,7 @@ periodics:
       - /milestone-activator
       args:
       - --github-token-path=/etc/github-token/token
-      - --github-endpoint=http://ghproxy
+      - --github-endpoint=http://ghproxy.prow.svc.cluster.local
       - --github-endpoint=https://api.github.com
       - --dry-run=false
       - --milestone-repository=gardener/gardener


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Use FQDN for `ghproxy` endpoint in prow jobs because prow job pods run in `test-pods` namespace.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
