### PR TITLE
Update to Go 1.19.11 and 1.20.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ----------------
 # Build container
 # ----------------
-ARG GOLANG_VERSION=1.19.10
+ARG GOLANG_VERSION=1.19.11
 
 FROM golang:${GOLANG_VERSION} AS builder
 LABEL stage=intermediate

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 REGISTRY          := $(shell cat .REGISTRY 2>/dev/null)
 PUSH_LATEST_TAG   := true
-GOLANG_VERSION    := 1.19.10
+GOLANG_VERSION    := 1.19.11
 VERSION           := v$(shell date '+%Y%m%d')-$(shell git rev-parse --short HEAD)
 
 IMG_GOLANG_TEST := golang-test

--- a/images/golang-test/variants.yaml
+++ b/images/golang-test/variants.yaml
@@ -2,6 +2,6 @@ variants:
   "1.18":
     GOLANG_VERSION: "1.18.10"
   "1.19":
-    GOLANG_VERSION: "1.19.10"
+    GOLANG_VERSION: "1.19.11"
   "1.20":
-    GOLANG_VERSION: "1.20.5"
+    GOLANG_VERSION: "1.20.6"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Go 1.19.11 ([ref](https://go.dev/doc/devel/release#go1.19.11)) and 1.20.6 ([ref](https://go.dev/doc/devel/release#go1.20.6)) are released.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
