### PR TITLE
Set `retentionSize` to 90GB for prometheus instances

### DIFF
--- a/config/prow/cluster/monitoring/base-prow/prometheus.yaml
+++ b/config/prow/cluster/monitoring/base-prow/prometheus.yaml
@@ -4,6 +4,7 @@ metadata:
   name: k8s
   namespace: monitoring
 spec:
+  retentionSize: 90GB
   storage:
     volumeClaimTemplate:
       metadata:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
We were facing an issue that the PV of a prometheus was full.
This PR sets the [retentionSize](https://github.com/gardener/ci-infra/blob/2ddec27c6f54e47093fede284b773f6caceea9f3/config/prow/cluster/monitoring/base/setup/0prometheusCustomResourceDefinition.yaml#L5466-L5469) for our prometheus instances to 90GB in order to avoid this issue in the future. The PV has 100GB of size, so setting the parameter to 90GB leaves 10 GB for the WAL file.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov 
