### PR TITLE
Reduce the memory resource requests for the registry-cache builds

### DIFF
--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-build-images.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-build-images.yaml
@@ -36,7 +36,7 @@ postsubmits:
         resources:
           requests:
             cpu: 6
-            memory: 9Gi
+            memory: 2Gi
       # Node selector is copied to build pods
       nodeSelector:
         dedicated: high-cpu

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-test-builds.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-test-builds.yaml
@@ -19,4 +19,4 @@ presubmits:
         resources:
           requests:
             cpu: 6
-            memory: 9Gi
+            memory: 2Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR reduces the memory resource requests for the registry-cache builds. Rough observations from my testing (described below) - during the image build in kaniko, the container memory usage varies between `1Gi` to `2Gi` while the CPU usage varies between `6` and `9.5`. I set container's memory limit to `2Gi` and I didn't observe OOM kills.

---

For the testing, I use the following Pod spec:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: kaniko
spec:
  containers:
  - name: kaniko
    image: gcr.io/kaniko-project/executor:v1.9.2
    command:
    - /kaniko/executor
    args:
    - --context=git://github.com/gardener/gardener-extension-registry-cache
    - --dockerfile=Dockerfile
    - --git=branch=main
    - --no-push
  restartPolicy: Never
```

I was watching the resource usage with `kubectl top po`
```
watch "kubectl top po kaniko >> result.txt"
```

First I tried to use prometheus, but the interval between the data points there was 1min which was not giving the most correct data points. The Pod itself lives between 1min and 2min and prometheus was not always catching and showing the usage peaks.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/3

**Special notes for your reviewer**:
I believe we can apply the same change for builds jobs of projects like dependency-watchdog and shoot-oidc-service. But I will leave this for a dedicated PR after this PR.