### PR TITLE
Reduce the memory resource requests for the gardener/gardener builds

### DIFF
--- a/config/jobs/gardener/gardener-build-dev-images.yaml
+++ b/config/jobs/gardener/gardener-build-dev-images.yaml
@@ -43,7 +43,7 @@ postsubmits:
         resources:
           requests:
             cpu: 6
-            memory: 9Gi
+            memory: 7Gi
       # Node selector is copied to build pods
       nodeSelector:
         dedicated: high-cpu

--- a/config/jobs/gardener/gardener-test-builds.yaml
+++ b/config/jobs/gardener/gardener-test-builds.yaml
@@ -22,7 +22,7 @@ presubmits:
         resources:
           requests:
             cpu: 6
-            memory: 9Gi
+            memory: 7Gi
   - name: pull-gardener-publish-test-images
     cluster: gardener-prow-trusted
     skip_branches:
@@ -62,7 +62,7 @@ presubmits:
         resources:
           requests:
             cpu: 6
-            memory: 9Gi
+            memory: 7Gi
       # Node selector is copied to build pods
       nodeSelector:
         dedicated: high-cpu


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Similar to https://github.com/gardener/ci-infra/pull/795

For the testing I used the following base Pod yaml:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: kaniko
spec:
  containers:
  - name: kaniko
    image: gcr.io/kaniko-project/executor:v1.9.2
    command:
    - /kaniko/executor
    args:
    - --context=git://github.com/gardener/gardener
    - --dockerfile=Dockerfile
    - --git=branch=master
    - --no-push
    resources:
      requests:
        cpu: 6
  restartPolicy: Never
```

And I was experimenting with different memory requests/limits. A summary of my testing:
```
---
Memory: 2Gi limit
OOMKilled
---
Memory: 3Gi limit
OOMKilled
---
Memory: 2Gi requests, 4Gi limit
Highest values: 9009m, 3760Mi
Time: 371s
---
Memory: 2Gi requests, 4Gi limit
Highest values: 9418m, 3701Mi
Time: 362s
---
Memory: 9Gi requests, no limit
Highest values: 9583m, 6563Mi
Time: 295s
---
Memory: 4Gi requests, no limit
Highest values: 9749m, 6545Mi
Time: 294s
---
Memory: no requests, no limit
Highest values: 10279m, 6422Mi
Time: 287s
---
Memory: 7Gi requests, 7Gi limit
Highest values: 9400m, 6372Mi
Time: 298s
---
Memory: 7Gi requests, no limit
Highest values: 5722Mi
Time: 290s
---
Memory: 7Gi requests, no limit
Highest values: 9297m, 6545Mi
Time: 315s
---
Memory: no requests, no limit
Highest values: 9813m, 6414Mi
Time: 287s
---
Memory: 7Gi requests, no limit
Highest values: 9389m, 6391Mi
Time: 283s
---
Memory: 7Gi requests, 7Gi limit
Highest values: 10456m, 6499Mi
Time: 295s
---
Memory: 7Gi requests, 7Gi limit
Highest values: 9214m, 6364Mi
Time: 316s
---
Memory: 4Gi requests, 4Gi limit
Highest values: 9501m, 3485Mi
Time: 363s
```

As the memory usage varies around 6.5Gi when there is no memory limit set, I decided to decrease the memory requests from 9Gi to 7Gi. Also with 7Gi memory limit, I didn't observe OOM kills.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A