### PR TITLE
Added new prow job to run e2e tests of etcd-druid with feature gates turned on

### DIFF
--- a/config/jobs/etcd-druid/druid-e2e-kind-alpha-features-true.yaml
+++ b/config/jobs/etcd-druid/druid-e2e-kind-alpha-features-true.yaml
@@ -1,0 +1,71 @@
+presubmits:
+  gardener/etcd-druid:
+    - name: pull-etcd-druid-e2e-kind-alpha-features-true
+      cluster: gardener-prow-build
+      always_run: true
+      skip_branches:
+        - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+      decorate: true
+      decoration_config:
+        timeout: 60m
+        grace_period: 15m
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+      annotations:
+        description: Runs KIND cluster based e2e tests for etcd druid developments in pull requests
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/krte:v20230719-72ce785784-master
+            command:
+            - wrapper.sh
+            - bash
+            - -c
+            - make ci-e2e-kind
+            # we need privileged mode in order to do docker in docker
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 6
+                memory: 8Gi
+            env:
+            - name: USE_ETCD_DRUID_FEATURE_GATES
+              value: "true"
+periodics:
+  - name: ci-etcd-druid-e2e-kind-alpha-features-true
+    cluster: gardener-prow-build
+    interval: 4h
+    extra_refs:
+      - org: gardener
+        repo: etcd-druid
+        base_ref: master
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs KIND cluster based e2e tests for etcd druid developments periodically
+      testgrid-dashboards: gardener-etcd-druid
+      testgrid-days-of-results: "60"
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/krte:v20230719-72ce785784-master
+          command:
+          - wrapper.sh
+          - bash
+          - -c
+          - make ci-e2e-kind
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 6
+              memory: 8Gi
+          env:
+          - name: USE_ETCD_DRUID_FEATURE_GATES
+            value: "true"

--- a/config/jobs/etcd-druid/druid-e2e-kind-alpha-features.yaml
+++ b/config/jobs/etcd-druid/druid-e2e-kind-alpha-features.yaml
@@ -1,6 +1,6 @@
 presubmits:
   gardener/etcd-druid:
-    - name: pull-etcd-druid-e2e-kind-alpha-features-true
+    - name: pull-etcd-druid-e2e-kind-alpha-features
       cluster: gardener-prow-build
       always_run: true
       skip_branches:
@@ -13,7 +13,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-kind-volume-mounts: "true"
       annotations:
-        description: Runs KIND cluster based e2e tests for etcd druid developments in pull requests
+        description: Runs KIND cluster based e2e tests for etcd druid developments in pull requests with activated alpha features
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/krte:v20230719-72ce785784-master
@@ -33,7 +33,7 @@ presubmits:
             - name: USE_ETCD_DRUID_FEATURE_GATES
               value: "true"
 periodics:
-  - name: ci-etcd-druid-e2e-kind-alpha-features-true
+  - name: ci-etcd-druid-e2e-kind-alpha-features
     cluster: gardener-prow-build
     interval: 4h
     extra_refs:
@@ -48,7 +48,7 @@ periodics:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     annotations:
-      description: Runs KIND cluster based e2e tests for etcd druid developments periodically
+      description: Runs KIND cluster based e2e tests for etcd druid developments periodically with activated alpha features
       testgrid-dashboards: gardener-etcd-druid
       testgrid-days-of-results: "60"
     spec:


### PR DESCRIPTION

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
This PR introduces a new prow job `pull-etcd-druid-e2e-kind-alpha-features-true` that runs `etcd-druid` e2e tests with all feature gates turned on

**Which issue(s) this PR fixes**:
Fixes partially gardener/etcd-druid#643

**Special notes for your reviewer**:

