### PR TITLE
Update registry-cache unit tests job to go@1.20

### DIFF
--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for Gardener extension registry-cache developments in pull requests
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230712-f2fc43c-1.19
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230712-f2fc43c-1.20
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230712-f2fc43c-1.19
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230712-f2fc43c-1.20
       command:
       - make
       args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Related PR on registry-cache side - ref https://github.com/gardener/gardener-extension-registry-cache/pull/26.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A