### PR TITLE
Enable dependabot to create update PRs for docker images

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+# Create PRs for golang and alpine version updates
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily
+- package-ecosystem: docker
+  directory: /images/golang-test
+  schedule:
+    interval: daily


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR enables `dependabot` to create update PRs for Golang and Alpine docker images similar to how it is done in other gardener repositories ([ref](https://github.com/gardener/gardener-extension-os-gardenlinux/blob/020f32da8659e91bf5877fde7cd26e0259537cd5/.github/dependabot.yaml#L11-L15)).
According to the latest update PRs ([ref](https://github.com/gardener/ci-infra/pull/779), [ref](https://github.com/gardener/ci-infra/pull/780)), there are images in `Dockerfile` and in `images/golang-test` folder. I'm not quite sure if dependabot manages to update the later folder, but let's see 😄 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR changes a file in `.github` directory. It cannot be merged by `Tide` but needs to be merged manually.
