### PR TITLE
Use dependabot compatible docker image format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 # ----------------
 # Build container
 # ----------------
-ARG GOLANG_VERSION=1.19.11
-
-FROM golang:${GOLANG_VERSION} AS builder
+FROM golang:1.19.11 AS builder
 LABEL stage=intermediate
 # Copy entire repository to image
 COPY . /code

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-REGISTRY          := $(shell cat .REGISTRY 2>/dev/null)
-PUSH_LATEST_TAG   := true
-GOLANG_VERSION    := 1.19.11
-VERSION           := v$(shell date '+%Y%m%d')-$(shell git rev-parse --short HEAD)
+REGISTRY            := $(shell cat .REGISTRY 2>/dev/null)
+PUSH_LATEST_TAG     := true
+GOLANG_TEST_VERSION := 1.20.6
+VERSION             := v$(shell date '+%Y%m%d')-$(shell git rev-parse --short HEAD)
 
 IMG_GOLANG_TEST := golang-test
 REG_GOLANG_TEST := $(REGISTRY)/$(IMG_GOLANG_TEST)
@@ -52,24 +52,24 @@ docker-images:
 ifeq ("$(REGISTRY)", "")
 	@echo "Please set your docker registry in REGISTRY variable or .REGISTRY file first."; false;
 endif
-	@echo "Building docker golang image for tests with version and tag $(GOLANG_VERSION)"
-	@docker build --build-arg GOLANG_VERSION=$(GOLANG_VERSION) -t $(REG_GOLANG_TEST):$(GOLANG_VERSION) -t $(REG_GOLANG_TEST):latest -f images/golang-test/Dockerfile --target $(IMG_GOLANG_TEST) .
+	@echo "Building docker golang image for tests with version and tag $(GOLANG_TEST_VERSION)"
+	@docker build --build-arg GOLANG_IMAGE=golang:$(GOLANG_TEST_VERSION) -t $(REG_GOLANG_TEST):$(GOLANG_TEST_VERSION) -t $(REG_GOLANG_TEST):latest -f images/golang-test/Dockerfile --target $(IMG_GOLANG_TEST) .
 	@echo "Building docker images with version and tag $(VERSION)"
-	@docker build --build-arg GOLANG_VERSION=$(GOLANG_VERSION) -t $(REG_CHERRYPICKER):$(VERSION) -t $(REG_CHERRYPICKER):latest -f Dockerfile --target $(IMG_CHERRYPICKER) .
-	@docker build --build-arg GOLANG_VERSION=$(GOLANG_VERSION) -t $(REG_CLA_ASSISTANT):$(VERSION) -t $(REG_CLA_ASSISTANT):latest -f Dockerfile --target $(IMG_CLA_ASSISTANT) .
-	@docker build --build-arg GOLANG_VERSION=$(GOLANG_VERSION) -t $(REG_IMAGE_BUILDER):$(VERSION) -t $(REG_IMAGE_BUILDER):latest -f Dockerfile --target $(IMG_IMAGE_BUILDER) .
-	@docker build --build-arg GOLANG_VERSION=$(GOLANG_VERSION) -t $(REG_JOB_FORKER):$(VERSION) -t $(REG_JOB_FORKER):latest -f Dockerfile --target $(IMG_JOB_FORKER) .
-	@docker build --build-arg GOLANG_VERSION=$(GOLANG_VERSION) -t $(REG_MILESTONE_ACTIVATOR):$(VERSION) -t $(REG_MILESTONE_ACTIVATOR):latest -f Dockerfile --target $(IMG_MILESTONE_ACTIVATOR) .
-	@docker build --build-arg GOLANG_VERSION=$(GOLANG_VERSION) -t $(REG_RELEASE_HANDLER):$(VERSION) -t $(REG_RELEASE_HANDLER):latest -f Dockerfile --target $(IMG_RELEASE_HANDLER) .
-	@docker build --build-arg GOLANG_VERSION=$(GOLANG_VERSION) -t $(REG_BRANCH_CLEANER):$(VERSION) -t $(REG_BRANCH_CLEANER):latest -f Dockerfile --target $(IMG_BRANCH_CLEANER) .
+	@docker build -t $(REG_CHERRYPICKER):$(VERSION) -t $(REG_CHERRYPICKER):latest -f Dockerfile --target $(IMG_CHERRYPICKER) .
+	@docker build -t $(REG_CLA_ASSISTANT):$(VERSION) -t $(REG_CLA_ASSISTANT):latest -f Dockerfile --target $(IMG_CLA_ASSISTANT) .
+	@docker build -t $(REG_IMAGE_BUILDER):$(VERSION) -t $(REG_IMAGE_BUILDER):latest -f Dockerfile --target $(IMG_IMAGE_BUILDER) .
+	@docker build -t $(REG_JOB_FORKER):$(VERSION) -t $(REG_JOB_FORKER):latest -f Dockerfile --target $(IMG_JOB_FORKER) .
+	@docker build -t $(REG_MILESTONE_ACTIVATOR):$(VERSION) -t $(REG_MILESTONE_ACTIVATOR):latest -f Dockerfile --target $(IMG_MILESTONE_ACTIVATOR) .
+	@docker build -t $(REG_RELEASE_HANDLER):$(VERSION) -t $(REG_RELEASE_HANDLER):latest -f Dockerfile --target $(IMG_RELEASE_HANDLER) .
+	@docker build -t $(REG_BRANCH_CLEANER):$(VERSION) -t $(REG_BRANCH_CLEANER):latest -f Dockerfile --target $(IMG_BRANCH_CLEANER) .
 
 .PHONY: docker-push
 docker-push:
 ifeq ("$(REGISTRY)", "")
 	@echo "Please set your docker registry in REGISTRY variable or .REGISTRY file first."; false;
 endif
-	@if ! docker images $(REG_GOLANG_TEST) | awk '{ print $$2 }' | grep -q -F $(GOLANG_VERSION); then echo "$(REG_GOLANG_TEST) version $(GOLANG_VERSION) is not yet built. Please run 'make docker-images'"; false; fi
-	@docker push $(REG_GOLANG_TEST):$(GOLANG_VERSION)
+	@if ! docker images $(REG_GOLANG_TEST) | awk '{ print $$2 }' | grep -q -F $(GOLANG_TEST_VERSION); then echo "$(REG_GOLANG_TEST) version $(GOLANG_TEST_VERSION) is not yet built. Please run 'make docker-images'"; false; fi
+	@docker push $(REG_GOLANG_TEST):$(GOLANG_TEST_VERSION)
 	@if ! docker images $(REG_CHERRYPICKER) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(REG_CHERRYPICKER) version $(VERSION) is not yet built. Please run 'make docker-images'"; false; fi
 	@if ! docker images $(REG_CLA_ASSISTANT) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(REG_CLA_ASSISTANT) version $(VERSION) is not yet built. Please run 'make docker-images'"; false; fi
 	@if ! docker images $(REG_IMAGE_BUILDER) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(REG_IMAGE_BUILDER) version $(VERSION) is not yet built. Please run 'make docker-images'"; false; fi

--- a/images/golang-test/Dockerfile
+++ b/images/golang-test/Dockerfile
@@ -1,9 +1,9 @@
 # Image based on golang for gardener unit and integration tests
-ARG GOLANG_VERSION
+ARG GOLANG_IMAGE
 
-FROM golang:${GOLANG_VERSION}-bullseye AS golang-test
+FROM ${GOLANG_IMAGE} AS golang-test
 # install gardener unit/integration test related dependencies
-LABEL GOLANG_VERSION=${GOLANG_VERSION}
+LABEL GOLANG_IMAGE=${GOLANG_IMAGE}
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \

--- a/images/golang-test/variants.yaml
+++ b/images/golang-test/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   "1.18":
-    GOLANG_VERSION: "1.18.10"
+    GOLANG_IMAGE: "golang:1.18.10"
   "1.19":
-    GOLANG_VERSION: "1.19.11"
+    GOLANG_IMAGE: "golang:1.19.11"
   "1.20":
-    GOLANG_VERSION: "1.20.6"
+    GOLANG_IMAGE: "golang:1.20.6"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The format used in `ci-infra` to specify docker images is most likely not compatible to `dependabot` introduced in https://github.com/gardener/ci-infra/pull/813 yet, because the images are concatenated using different `args`.
This PR removes this concatenation that `dependabot` is (hopefully) able to identify the docker images correctly.

Additionally, it uses `golang:${VERSION}` images instead of `golang:${VERSION}-bullseye` images as base for our test-image, because we use these kinds of base images for building gardener images too.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ 
