### PR TITLE
Use Kubernetes yaml style that dependabot is able to identify images in build-variants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ifeq ("$(REGISTRY)", "")
 	@echo "Please set your docker registry in REGISTRY variable or .REGISTRY file first."; false;
 endif
 	@echo "Building docker golang image for tests with version and tag $(GOLANG_TEST_VERSION)"
-	@docker build --build-arg GOLANG_IMAGE=golang:$(GOLANG_TEST_VERSION) -t $(REG_GOLANG_TEST):$(GOLANG_TEST_VERSION) -t $(REG_GOLANG_TEST):latest -f images/golang-test/Dockerfile --target $(IMG_GOLANG_TEST) .
+	@docker build --build-arg image=golang:$(GOLANG_TEST_VERSION) -t $(REG_GOLANG_TEST):$(GOLANG_TEST_VERSION) -t $(REG_GOLANG_TEST):latest -f images/golang-test/Dockerfile --target $(IMG_GOLANG_TEST) .
 	@echo "Building docker images with version and tag $(VERSION)"
 	@docker build -t $(REG_CHERRYPICKER):$(VERSION) -t $(REG_CHERRYPICKER):latest -f Dockerfile --target $(IMG_CHERRYPICKER) .
 	@docker build -t $(REG_CLA_ASSISTANT):$(VERSION) -t $(REG_CLA_ASSISTANT):latest -f Dockerfile --target $(IMG_CLA_ASSISTANT) .

--- a/images/golang-test/Dockerfile
+++ b/images/golang-test/Dockerfile
@@ -1,9 +1,9 @@
 # Image based on golang for gardener unit and integration tests
-ARG GOLANG_IMAGE
+ARG image
 
-FROM ${GOLANG_IMAGE} AS golang-test
+FROM ${image} AS golang-test
 # install gardener unit/integration test related dependencies
-LABEL GOLANG_IMAGE=${GOLANG_IMAGE}
+LABEL BASE_IMAGE=${image}
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \

--- a/images/golang-test/variants.yaml
+++ b/images/golang-test/variants.yaml
@@ -1,7 +1,9 @@
+apiVersion: variants/v1alpha1
+kind: Variants
 variants:
   "1.18":
-    GOLANG_IMAGE: "golang:1.18.10"
+    image: "golang:1.18.10"
   "1.19":
-    GOLANG_IMAGE: "golang:1.19.11"
+    image: "golang:1.19.11"
   "1.20":
-    GOLANG_IMAGE: "golang:1.20.6"
+    image: "golang:1.20.6"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
We have to fake "Kubernetes style" yaml files, that `dependabot` is able to identify images which are not in a `Dockerfile` ([ref](https://github.com/dependabot/dependabot-core/blob/eece01f695b0581ea4293d44cc6907424d52d7a1/docker/lib/dependabot/docker/file_fetcher.rb#L72-L75), [ref](https://github.com/dependabot/dependabot-core/blob/eece01f695b0581ea4293d44cc6907424d52d7a1/docker/lib/dependabot/docker/file_parser.rb#L149), [ref](https://github.com/dependabot/dependabot-core/blob/eece01f695b0581ea4293d44cc6907424d52d7a1/docker/lib/dependabot/docker/file_parser.rb#L35))

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
