### PR TITLE
[image-builder] allow additional fields in `variants.yaml`

### DIFF
--- a/prow/cmd/image-builder/buildcontroller.go
+++ b/prow/cmd/image-builder/buildcontroller.go
@@ -517,7 +517,7 @@ func (r *buildReconciler) getVariants() ([]buildVariant, error) {
 		Variants map[string]map[string]string
 	}{}
 
-	if err := yaml.UnmarshalStrict(fileContent, &variants); err != nil {
+	if err := yaml.Unmarshal(fileContent, &variants); err != nil {
 		return nil, fmt.Errorf("failed reading %s", variantsFile)
 	}
 

--- a/prow/cmd/image-builder/buildcontroller_test.go
+++ b/prow/cmd/image-builder/buildcontroller_test.go
@@ -58,7 +58,8 @@ func createTestFileSystem(t *testing.T) fstest.MapFS {
 		ModTime: time.Now(),
 	}
 
-	variantsYaml := `
+	variantsYaml := `apiVersion: variants/v1alpha1
+kind: Variants
 variants:
   v1:
     BUILD_ARG1: v1
@@ -66,7 +67,7 @@ variants:
   v2:
     BUILD_ARG1: v2
     BUILD_ARG2: v2
-  `
+`
 
 	variantsYamlFile := fstest.MapFile{
 		Data:    []byte(variantsYaml),
@@ -94,8 +95,7 @@ func createTestImageBuilderPod(t *testing.T) corev1.Pod {
 	t.Helper()
 	var ibPod corev1.Pod
 
-	unmarshalYAML(t, &ibPod, `
-apiVersion: v1
+	unmarshalYAML(t, &ibPod, `apiVersion: v1
 kind: Pod
 metadata:
   labels:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR allows `image-builder` to parse `variants.yaml` files which contain unused fields. 
It is required to support image updates by `dependabot`  in `ci-infra` repository (https://github.com/gardener/ci-infra/pull/818).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
