### PR TITLE
Disable major and minor version updates for `golang-test` images by `dependabot`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,6 @@ updates:
   directory: /images/golang-test
   schedule:
     interval: daily
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-# Create PRs for golang and alpine version updates
+# Create update PRs for ci-infra and golang-test images
 - package-ecosystem: docker
   directory: /
   schedule:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
We would like to support more than one minor version for the `golang-test` images, so major and minor updates are disabled here.
Additionally, `dependabot` did not notice that it was activated in PR https://github.com/gardener/ci-infra/pull/813. Hopefully it does when `dependabot.yaml` is changed again.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/hold
Merge after PRs #818 & #819
