### PR TITLE
Adapt `high-availability` settings for prow cluster workloads

### DIFF
--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -10,7 +10,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
@@ -97,18 +97,16 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 3
           timeoutSeconds: 600
-      affinity: 
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - deck
-              topologyKey: kubernetes.io/hostname
-            weight: 100
+      topologySpreadConstraints: 
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - deck
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
       volumes:
       - name: github-app
         secret:

--- a/config/prow/cluster/deck_service.yaml
+++ b/config/prow/cluster/deck_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.kubernetes.io/topology-aware-hints: "auto"
   labels:
     app: deck
   namespace: prow

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -10,7 +10,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
@@ -83,18 +83,16 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 3
           timeoutSeconds: 600
-      affinity: 
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - hook
-              topologyKey: kubernetes.io/hostname
-            weight: 100
+      topologySpreadConstraints: 
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - hook
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
       volumes:
       - name: github-app
         secret:

--- a/config/prow/cluster/hook_service.yaml
+++ b/config/prow/cluster/hook_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.kubernetes.io/topology-aware-hints: "auto"
   labels:
     app: hook
   namespace: prow

--- a/config/prow/cluster/ingress-nginx/helm/values.yaml
+++ b/config/prow/cluster/ingress-nginx/helm/values.yaml
@@ -1,6 +1,6 @@
 # Check values.yaml of ingress-nginx for help https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
 controller:
-  replicaCount: 2
+  replicaCount: 3
   resources:
     requests:
       cpu: 100m
@@ -17,27 +17,28 @@ controller:
             operator: In
             values:
             - "true"
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: app.kubernetes.io/name
-              operator: In
-              values:
-              - ingress-nginx
-            - key: app.kubernetes.io/instance
-              operator: In
-              values:
-              - ingress-nginx
-            - key: app.kubernetes.io/component
-              operator: In
-              values:
-              - controller
-          topologyKey: kubernetes.io/hostname
+  enableTopologyAwareRouting: true
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+        - ingress-nginx
+      - key: app.kubernetes.io/instance
+        operator: In
+        values:
+        - ingress-nginx
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+        - controller
   updateStrategy:
     rollingUpdate:
+      maxSurge: 0
       maxUnavailable: 1
     type: RollingUpdate
   watchIngressWithoutClass: true
@@ -45,6 +46,13 @@ controller:
     name: nginx
     enabled: true
     default: true
+  service:
+    annotations:
+      service.kubernetes.io/topology-aware-hints: "auto"
+  admissionWebhooks:
+    service:
+      annotations:
+        service.kubernetes.io/topology-aware-hints: "auto"
 defaultBackend:
   affinity:
     nodeAffinity:

--- a/config/prow/cluster/ingress-nginx/ingress-nginx-deployment.yaml
+++ b/config/prow/cluster/ingress-nginx/ingress-nginx-deployment.yaml
@@ -4,10 +4,10 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -26,10 +26,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -42,10 +42,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: default-backend
@@ -58,10 +58,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -75,10 +75,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx
@@ -159,10 +159,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx
@@ -180,10 +180,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -273,10 +273,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -295,11 +295,13 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations: 
+    service.kubernetes.io/topology-aware-hints: auto
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -322,11 +324,12 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    service.kubernetes.io/topology-aware-hints: "auto"
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -358,10 +361,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: default-backend
@@ -385,10 +388,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -400,21 +403,22 @@ spec:
       app.kubernetes.io/name: ingress-nginx
       app.kubernetes.io/instance: ingress-nginx
       app.kubernetes.io/component: controller
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   strategy:
     
     rollingUpdate:
+      maxSurge: 0
       maxUnavailable: 1
     type: RollingUpdate
   minReadySeconds: 0
   template:
     metadata:
       labels:
-        helm.sh/chart: ingress-nginx-4.6.1
+        helm.sh/chart: ingress-nginx-4.7.1
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/version: "1.7.1"
+        app.kubernetes.io/version: "1.8.1"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: controller
@@ -422,7 +426,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
-          image: "registry.k8s.io/ingress-nginx/controller:v1.7.1@sha256:7244b95ea47bddcb8267c1e625fb163fc183ef55448855e3ac52a7b260a60407"
+          image: "registry.k8s.io/ingress-nginx/controller:v1.8.1@sha256:e5c4824e7375fcf2a393e1c03c293b69759af37a9ca6abdb91b13d78a93da8bd"
           imagePullPolicy: IfNotPresent
           lifecycle: 
             preStop:
@@ -441,6 +445,7 @@ spec:
             - --validating-webhook-certificate=/usr/local/certificates/cert
             - --validating-webhook-key=/usr/local/certificates/key
             - --watch-ingress-without-class=true
+            - --enable-topology-aware-routing=true
           securityContext: 
             capabilities:
               drop:
@@ -512,25 +517,24 @@ spec:
                 operator: In
                 values:
                 - "true"
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - ingress-nginx
-                - key: app.kubernetes.io/instance
-                  operator: In
-                  values:
-                  - ingress-nginx
-                - key: app.kubernetes.io/component
-                  operator: In
-                  values:
-                  - controller
-              topologyKey: kubernetes.io/hostname
-            weight: 100
+      topologySpreadConstraints: 
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - ingress-nginx
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+              - ingress-nginx
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - controller
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 300
       volumes:
@@ -543,10 +547,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: default-backend
@@ -632,10 +636,10 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -653,10 +657,10 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -694,10 +698,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -711,10 +715,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -736,10 +740,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -762,10 +766,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -788,10 +792,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -814,10 +818,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -826,17 +830,17 @@ spec:
     metadata:
       name: ingress-nginx-admission-create
       labels:
-        helm.sh/chart: ingress-nginx-4.6.1
+        helm.sh/chart: ingress-nginx-4.7.1
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/version: "1.7.1"
+        app.kubernetes.io/version: "1.8.1"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
     spec:
       containers:
         - name: create
-          image: "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794@sha256:01d181618f270f2a96c04006f33b2699ad3ccb02da48d0f89b22abce084b292f"
+          image: "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20230407@sha256:543c40fd093964bc9ab509d3e791f9989963021f1e9e4c9c7b6700b02bfb227b"
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -869,10 +873,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: ingress-nginx-4.6.1
+    helm.sh/chart: ingress-nginx-4.7.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.7.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -881,17 +885,17 @@ spec:
     metadata:
       name: ingress-nginx-admission-patch
       labels:
-        helm.sh/chart: ingress-nginx-4.6.1
+        helm.sh/chart: ingress-nginx-4.7.1
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/version: "1.7.1"
+        app.kubernetes.io/version: "1.8.1"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
     spec:
       containers:
         - name: patch
-          image: "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794@sha256:01d181618f270f2a96c04006f33b2699ad3ccb02da48d0f89b22abce084b292f"
+          image: "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20230407@sha256:543c40fd093964bc9ab509d3e791f9989963021f1e9e4c9c7b6700b02bfb227b"
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/config/prow/cluster/monitoring/base-prow/alertmanager-alertmanager.yaml
+++ b/config/prow/cluster/monitoring/base-prow/alertmanager-alertmanager.yaml
@@ -32,30 +32,29 @@ spec:
             operator: In
             values:
             - "true"
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: app.kubernetes.io/instance
-              operator: In
-              values:
-              - main
-            - key: app.kubernetes.io/managed-by
-              operator: In
-              values:
-              - prometheus-operator
-            - key: app.kubernetes.io/component
-              operator: In
-              values:
-              - alert-router
-            - key: app.kubernetes.io/name
-              operator: In
-              values:
-              - alertmanager
-            - key: app.kubernetes.io/part-of
-              operator: In
-              values:
-              - kube-prometheus
-          topologyKey: kubernetes.io/hostname
-        weight: 100
+  topologySpreadConstraints: 
+    - labelSelector:
+        matchExpressions:
+        - key: app.kubernetes.io/instance
+          operator: In
+          values:
+          - main
+        - key: app.kubernetes.io/managed-by
+          operator: In
+          values:
+          - prometheus-operator
+        - key: app.kubernetes.io/component
+          operator: In
+          values:
+          - alert-router
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+          - alertmanager
+        - key: app.kubernetes.io/part-of
+          operator: In
+          values:
+          - kube-prometheus
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule

--- a/config/prow/cluster/monitoring/base-prow/alertmanager-service.yaml
+++ b/config/prow/cluster/monitoring/base-prow/alertmanager-service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.kubernetes.io/topology-aware-hints: "auto"
+  name: alertmanager-main
+  namespace: monitoring

--- a/config/prow/cluster/monitoring/base-prow/kustomization.yaml
+++ b/config/prow/cluster/monitoring/base-prow/kustomization.yaml
@@ -18,13 +18,16 @@ patchesStrategicMerge:
 - delete-grafana-dashboardDefinitions.yaml
 - delete-prometheusAdapter-apiService.yaml
 - alertmanager-alertmanager.yaml
+- alertmanager-service.yaml
 - blackboxExporter-deployment.yaml
 - grafana-deployment.yaml
 - grafana-networkPolicy.yaml
 - kubeStateMetrics-deployment.yaml
 - nodeExporter-daemonset.yaml
+- prometheus-service.yaml
 - prometheus.yaml
 - prometheusAdapter-deployment.yaml
+- prometheusAdapter-service.yaml
 - prometheusOperator-deployment.yaml
 
 secretGenerator:

--- a/config/prow/cluster/monitoring/base-prow/prometheus-service.yaml
+++ b/config/prow/cluster/monitoring/base-prow/prometheus-service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.kubernetes.io/topology-aware-hints: "auto"
+  name: prometheus-k8s
+  namespace: monitoring

--- a/config/prow/cluster/monitoring/base-prow/prometheus.yaml
+++ b/config/prow/cluster/monitoring/base-prow/prometheus.yaml
@@ -30,30 +30,29 @@ spec:
             operator: In
             values:
             - "true" 
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: app.kubernetes.io/instance
-              operator: In
-              values:
-              - k8s
-            - key: app.kubernetes.io/managed-by
-              operator: In
-              values:
-              - prometheus-operator
-            - key: app.kubernetes.io/component
-              operator: In
-              values:
-              - prometheus
-            - key: app.kubernetes.io/name
-              operator: In
-              values:
-              - prometheus
-            - key: app.kubernetes.io/part-of
-              operator: In
-              values:
-              - kube-prometheus
-          topologyKey: kubernetes.io/hostname
-        weight: 100
+  topologySpreadConstraints: 
+    - labelSelector:
+        matchExpressions:
+        - key: app.kubernetes.io/instance
+          operator: In
+          values:
+          - k8s
+        - key: app.kubernetes.io/managed-by
+          operator: In
+          values:
+          - prometheus-operator
+        - key: app.kubernetes.io/component
+          operator: In
+          values:
+          - prometheus
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+          - prometheus
+        - key: app.kubernetes.io/part-of
+          operator: In
+          values:
+          - kube-prometheus
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule

--- a/config/prow/cluster/monitoring/base-prow/prometheusAdapter-deployment.yaml
+++ b/config/prow/cluster/monitoring/base-prow/prometheusAdapter-deployment.yaml
@@ -15,22 +15,21 @@ spec:
                 operator: In
                 values:
                 - "true"
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/component
-                  operator: In
-                  values:
-                  - metrics-adapter
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - prometheus-adapter
-                - key: app.kubernetes.io/part-of
-                  operator: In
-                  values:
-                  - kube-prometheus
-              topologyKey: kubernetes.io/hostname
-            weight: 100
+      topologySpreadConstraints: 
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - metrics-adapter
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - prometheus-adapter
+            - key: app.kubernetes.io/part-of
+              operator: In
+              values:
+              - kube-prometheus
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule

--- a/config/prow/cluster/monitoring/base-prow/prometheusAdapter-service.yaml
+++ b/config/prow/cluster/monitoring/base-prow/prometheusAdapter-service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.kubernetes.io/topology-aware-hints: "auto"
+  name: prometheus-adapter
+  namespace: monitoring

--- a/config/prow/cluster/oauth2-proxy/helm/values.yaml
+++ b/config/prow/cluster/oauth2-proxy/helm/values.yaml
@@ -17,25 +17,29 @@ affinity:
           operator: In
           values:
           - "true"
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-    - weight: 100
-      podAffinityTerm:
-        labelSelector:
-          matchExpressions:
-          - key: app.kubernetes.io/name
-            operator: In
-            values:
-            - ingress-nginx
-          - key: app.kubernetes.io/instance
-            operator: In
-            values:
-            - ingress-nginx
-          - key: app.kubernetes.io/component
-            operator: In
-            values:
-            - controller
-        topologyKey: kubernetes.io/hostname
+
+topologySpreadConstraints:
+- maxSkew: 1
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: DoNotSchedule
+  labelSelector:
+    matchExpressions:
+    - key: app.kubernetes.io/name
+      operator: In
+      values:
+      - oauth2-proxy
+    - key: app.kubernetes.io/instance
+      operator: In
+      values:
+      - oauth2-proxy
+    - key: app.kubernetes.io/component
+      operator: In
+      values:
+      - authentication-proxy
+
+service:
+  annotations:
+    service.kubernetes.io/topology-aware-hints: "auto"
 
 config:
   existingSecret: oauth2-proxy
@@ -65,4 +69,4 @@ resources:
     cpu: 100m
     memory: 300Mi
 
-replicaCount: 2
+replicaCount: 3

--- a/config/prow/cluster/oauth2-proxy/kustomization.yaml
+++ b/config/prow/cluster/oauth2-proxy/kustomization.yaml
@@ -18,3 +18,6 @@ configMapGenerator:
       app.kubernetes.io/version: "7.4.0"
   files:
   - config/oauth2_proxy.cfg
+
+patchesStrategicMerge:
+- patch-oauth2-proxy-deployment.yaml

--- a/config/prow/cluster/oauth2-proxy/oauth2-proxy-deployment.yaml
+++ b/config/prow/cluster/oauth2-proxy/oauth2-proxy-deployment.yaml
@@ -5,7 +5,7 @@ kind: PodDisruptionBudget
 metadata:
   labels:
     app: oauth2-proxy    
-    helm.sh/chart: oauth2-proxy-6.12.0
+    helm.sh/chart: oauth2-proxy-6.16.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
@@ -27,7 +27,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: oauth2-proxy    
-    helm.sh/chart: oauth2-proxy-6.12.0
+    helm.sh/chart: oauth2-proxy-6.16.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
@@ -44,7 +44,7 @@ kind: Service
 metadata:
   labels:
     app: oauth2-proxy    
-    helm.sh/chart: oauth2-proxy-6.12.0
+    helm.sh/chart: oauth2-proxy-6.16.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
@@ -53,6 +53,8 @@ metadata:
     app.kubernetes.io/version: "7.4.0"
   name: oauth2-proxy
   namespace: oauth2-proxy
+  annotations:
+    service.kubernetes.io/topology-aware-hints: auto
 spec:
   type: ClusterIP
   ports:
@@ -76,7 +78,7 @@ kind: Deployment
 metadata:
   labels:
     app: oauth2-proxy    
-    helm.sh/chart: oauth2-proxy-6.12.0
+    helm.sh/chart: oauth2-proxy-6.16.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy
@@ -86,7 +88,7 @@ metadata:
   name: oauth2-proxy
   namespace: oauth2-proxy
 spec:
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:      
@@ -102,7 +104,7 @@ spec:
         checksum/redis-secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
       labels:
         app: oauth2-proxy        
-        helm.sh/chart: oauth2-proxy-6.12.0
+        helm.sh/chart: oauth2-proxy-6.16.1
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: authentication-proxy
         app.kubernetes.io/part-of: oauth2-proxy
@@ -178,6 +180,17 @@ spec:
         - mountPath: /etc/oauth2_proxy/oauth2_proxy.cfg
           name: configmain
           subPath: oauth2_proxy.cfg
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 2000
+          runAsNonRoot: true
+          runAsUser: 2000
+          seccompProfile:
+            type: RuntimeDefault
       volumes:
       - configMap:
           defaultMode: 420
@@ -192,27 +205,26 @@ spec:
                 operator: In
                 values:
                 - "true"
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - ingress-nginx
-                - key: app.kubernetes.io/instance
-                  operator: In
-                  values:
-                  - ingress-nginx
-                - key: app.kubernetes.io/component
-                  operator: In
-                  values:
-                  - controller
-              topologyKey: kubernetes.io/hostname
-            weight: 100
       tolerations:
         []
+      topologySpreadConstraints:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - oauth2-proxy
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+              - oauth2-proxy
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - authentication-proxy
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
 ---
 # Source: oauth2-proxy/templates/ingress.yaml
 apiVersion: networking.k8s.io/v1
@@ -220,7 +232,7 @@ kind: Ingress
 metadata:
   labels:
     app: oauth2-proxy    
-    helm.sh/chart: oauth2-proxy-6.12.0
+    helm.sh/chart: oauth2-proxy-6.16.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: authentication-proxy
     app.kubernetes.io/part-of: oauth2-proxy

--- a/config/prow/cluster/oauth2-proxy/patch-oauth2-proxy-deployment.yaml
+++ b/config/prow/cluster/oauth2-proxy/patch-oauth2-proxy-deployment.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oauth2-proxy
+  namespace: oauth2-proxy
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Our prow clusters are multi zonal clusters for a while now. 
Thus, this PR adapts high-availability settings of the prow cluster workloads. These are the new settings:
- all `Deployments`/`Statefulsets` with more than one replica are using `topologySpreadConstraints` with `topologyKey=topology.kubernetes.io/zone`now
- `Services` pointing to these apps are annotated with `service.kubernetes.io/topology-aware-hints: "auto"`
- `replicaCount` of `ingress-nginx` is increased to 3. Most HTTP traffic goes to `deck` and `hook` which are using three replicas too. The nodes for system-components have enough memory and CPU, so we could save a bit of cross-zonal traffic.

Additionally, `ingress-nginx` and `oauth2-proxy` are updated to their latest versions and a copy&paste error in `matchExpressions` of `oauth2-proxy` was fixed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
