### PR TITLE
Use `--force-conflicts` parameter in `deploy.sh` 

### DIFF
--- a/config/prow/deploy.sh
+++ b/config/prow/deploy.sh
@@ -23,19 +23,19 @@ set -o pipefail
 # See https://misc.flogisoft.com/bash/tip_colors_and_formatting
 
 color-green() { # Green
-  echo -e "\x1B[1;32m${@}\x1B[0m"
+  echo -e "\x1B[1;32m${*}\x1B[0m"
 }
 
 color-step() { # Yellow
-  echo -e "\x1B[1;33m${@}\x1B[0m"
+  echo -e "\x1B[1;33m${*}\x1B[0m"
 }
 
 color-context() { # Bold blue
-  echo -e "\x1B[1;34m${@}\x1B[0m"
+  echo -e "\x1B[1;34m${*}\x1B[0m"
 }
 
 color-missing() { # Yellow
-  echo -e "\x1B[1;33m${@}\x1B[0m"
+  echo -e "\x1B[1;33m${*}\x1B[0m"
 }
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
@@ -67,43 +67,43 @@ export KUBECONFIG="$temp_kubeconfig"
 echo -n "$(color-step "Ensuring contexts exist"):"
 ensure-context gardener-prow-trusted
 ensure-context gardener-prow-build
-echo " $(color-green done)"
+echo " $(color-green "done")"
 
 echo "$(color-step "Deploying prow components to gardener-prow-trusted cluster...")"
 kubectl config use-context gardener-prow-trusted
 kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster"
-echo "$(color-green done)"
+echo "$(color-green "done")"
 
 echo "$(color-step "Deploying prow components to gardener-prow-build cluster...")"
 kubectl config use-context gardener-prow-build
 kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/base"
-echo "$(color-green done)"
+echo "$(color-green "done")"
 
 echo "$(color-step "Deploying ingress-nginx components to gardener-prow-trusted cluster...")"
 kubectl config use-context gardener-prow-trusted
 kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/ingress-nginx"
 kubectl wait --for=condition=available deployment -l app.kubernetes.io/component=controller -n ingress-nginx --timeout 2m
-echo "$(color-green done)"
+echo "$(color-green "done")"
 
 echo "$(color-step "Deploying oauth2-proxy components to gardener-prow-trusted cluster...")"
 kubectl config use-context gardener-prow-trusted
 kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/oauth2-proxy"
-echo "$(color-green done)"
+echo "$(color-green "done")"
 
 echo "$(color-step "Deploying monitoring components to gardener-prow-trusted cluster...")"
 kubectl config use-context gardener-prow-trusted
 kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/monitoring/trusted-cluster"
-echo "$(color-green done)"
+echo "$(color-green "done")"
 
 echo "$(color-step "Deploying ingress-nginx components to gardener-prow-build cluster...")"
 kubectl config use-context gardener-prow-build
 kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/ingress-nginx"
 kubectl wait --for=condition=available deployment -l app.kubernetes.io/component=controller -n ingress-nginx --timeout 2m
-echo "$(color-green done)"
+echo "$(color-green "done")"
 
 echo "$(color-step "Deploying monitoring components to gardener-prow-build cluster...")"
 kubectl config use-context gardener-prow-build
 kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/monitoring/build-cluster"
-echo "$(color-green done)"
+echo "$(color-green "done")"
 
-echo "$(color-green SUCCESS)"
+echo "$(color-green "SUCCESS")"

--- a/config/prow/deploy.sh
+++ b/config/prow/deploy.sh
@@ -71,39 +71,39 @@ echo " $(color-green done)"
 
 echo "$(color-step "Deploying prow components to gardener-prow-trusted cluster...")"
 kubectl config use-context gardener-prow-trusted
-kubectl apply --server-side=true -k "$SCRIPT_DIR/cluster"
+kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster"
 echo "$(color-green done)"
 
 echo "$(color-step "Deploying prow components to gardener-prow-build cluster...")"
 kubectl config use-context gardener-prow-build
-kubectl apply --server-side=true -k "$SCRIPT_DIR/cluster/base"
+kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/base"
 echo "$(color-green done)"
 
 echo "$(color-step "Deploying ingress-nginx components to gardener-prow-trusted cluster...")"
 kubectl config use-context gardener-prow-trusted
-kubectl apply --server-side=true -k "$SCRIPT_DIR/cluster/ingress-nginx"
+kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/ingress-nginx"
 kubectl wait --for=condition=available deployment -l app.kubernetes.io/component=controller -n ingress-nginx --timeout 2m
 echo "$(color-green done)"
 
 echo "$(color-step "Deploying oauth2-proxy components to gardener-prow-trusted cluster...")"
 kubectl config use-context gardener-prow-trusted
-kubectl apply --server-side=true -k "$SCRIPT_DIR/cluster/oauth2-proxy"
+kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/oauth2-proxy"
 echo "$(color-green done)"
 
 echo "$(color-step "Deploying monitoring components to gardener-prow-trusted cluster...")"
 kubectl config use-context gardener-prow-trusted
-kubectl apply --server-side=true -k "$SCRIPT_DIR/cluster/monitoring/trusted-cluster"
+kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/monitoring/trusted-cluster"
 echo "$(color-green done)"
 
 echo "$(color-step "Deploying ingress-nginx components to gardener-prow-build cluster...")"
 kubectl config use-context gardener-prow-build
-kubectl apply --server-side=true -k "$SCRIPT_DIR/cluster/ingress-nginx"
+kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/ingress-nginx"
 kubectl wait --for=condition=available deployment -l app.kubernetes.io/component=controller -n ingress-nginx --timeout 2m
 echo "$(color-green done)"
 
 echo "$(color-step "Deploying monitoring components to gardener-prow-build cluster...")"
 kubectl config use-context gardener-prow-build
-kubectl apply --server-side=true -k "$SCRIPT_DIR/cluster/monitoring/build-cluster"
+kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/monitoring/build-cluster"
 echo "$(color-green done)"
 
 echo "$(color-green SUCCESS)"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds the `--force-conflicts` parameter to `kubectl` commands in `deploy.sh`. This avoids failing deploy jobs caused by manual changes in the clusters ([example](https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-ci-infra-deploy-prow/1688831651737505792)).
Additionally, it fixes some findings by `ShellCheck`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
