### PR TITLE
More `high-availability` settings for prow cluster workloads

### DIFF
--- a/config/prow/cluster/gcsweb_deployment.yaml
+++ b/config/prow/cluster/gcsweb_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: gcsweb
-          image: k8s.gcr.io/gcsweb:v1.1.0
+          image: gcr.io/k8s-prow/gcsweb:v20230808-2811823aac
           args:
             - -upgrade-proxied-http-to-https
             # buckets owned by gardener

--- a/config/prow/cluster/gcsweb_deployment.yaml
+++ b/config/prow/cluster/gcsweb_deployment.yaml
@@ -12,7 +12,7 @@ spec:
       app: gcsweb
   strategy:
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: 0
       maxUnavailable: 1
     type: RollingUpdate
   template:
@@ -53,15 +53,13 @@ spec:
             initialDelaySeconds: 3
             timeoutSeconds: 2
             failureThreshold: 2
-      affinity: 
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - gcsweb
-              topologyKey: kubernetes.io/hostname
-            weight: 100
+      topologySpreadConstraints: 
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - gcsweb
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule

--- a/config/prow/cluster/gcsweb_service.yaml
+++ b/config/prow/cluster/gcsweb_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.kubernetes.io/topology-aware-hints: "auto"
   name: gcsweb
   namespace: gcsweb
   labels:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
PR #823 forgot to add the HA configuration to `gcsweb` component. This is done in this PR.
Additionally, it updates the image source to a more recent one where images are auto-updated the same way as the other prow images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
