### PR TITLE
Fix `gcsweb` health and readiness endpoints and ports

### DIFF
--- a/config/prow/cluster/gcsweb_deployment.yaml
+++ b/config/prow/cluster/gcsweb_deployment.yaml
@@ -42,14 +42,14 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8080
+              port: 8081
             initialDelaySeconds: 3
             timeoutSeconds: 2
             failureThreshold: 2
           readinessProbe:
             httpGet:
-              path: /healthz
-              port: 8080
+              path: /healthz/ready
+              port: 8081
             initialDelaySeconds: 3
             timeoutSeconds: 2
             failureThreshold: 2


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The new version of `gcsweb` introduced in PR #828 uses different health and readiness endpoints and ports.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
