### PR TITLE
Update `golang-test` images

### DIFF
--- a/images/golang-test/variants.yaml
+++ b/images/golang-test/variants.yaml
@@ -1,9 +1,9 @@
 apiVersion: variants/v1alpha1
 kind: Variants
 variants:
-  "1.18":
-    image: "golang:1.18.10"
   "1.19":
-    image: "golang:1.19.11"
+    image: "golang:1.19.12"
   "1.20":
-    image: "golang:1.20.6"
+    image: "golang:1.20.7"
+  "1.21":
+    image: "golang:1.21.0"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
An image for the freshly [released Go 1.21.0](https://tip.golang.org/doc/go1.21) was added.
Go 1.18 is out of maintenance, so its image was removed.

Patch level updates for Go 1.19 & 1.20 because apparently `dependabot` cannot handle the same image in different versions in the same file 😞 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
