### PR TITLE
Maintain the `redis` image via prow (copy images)

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -70,6 +70,11 @@ images:
   destination: eu.gcr.io/gardener-project/3rd/kindest/local-path-helper
   tags:
   - v20220512-507ff70b
+# gardener/test (Gardener integration tests)
+- source: redis
+  destination: eu.gcr.io/gardener-project/3rd/redis
+  tags:
+  - 5.0.8
 # gardener-extension-networking-calico/charts/images.yaml
 #
 # DO NOT ADD NEW CALICO IMAGES.


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
`eu.gcr.io/gardener-project/3rd/redis:5.0.8` was copied manually with https://github.com/gardener/gardener/pull/6446. Back then we didn't have the functionality in prow to copy images. Hence, let's now benefit from this to make it clear how this redis image was copied.

```
% docker images | grep redis
redis                                                                                5.0.8                                                        975fe4b9f798   3 years ago     98.3MB
eu.gcr.io/gardener-project/3rd/redis                                                 5.0.8                                                        975fe4b9f798   3 years ago     98.3MB
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A