### PR TITLE
Update `golang-test` of `gardener/gardener` tests to `Go 1.21`

### DIFF
--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230810-2a54385-1.20
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230810-2a54385-1.21
         command:
         - make
         args:
@@ -46,7 +46,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230810-2a54385-1.20
+      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230810-2a54385-1.21
       command:
       - make
       args:

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -16,7 +16,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230810-2a54385-1.20
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230810-2a54385-1.21
         command:
         - make
         args:
@@ -53,7 +53,7 @@ periodics:
     containers:
     # Run all tests sequentially in one container or as separate prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230810-2a54385-1.20
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230810-2a54385-1.21
       command:
       - make
       args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR updates Go version of `golang-test` images for `gardener/gardener` tests to `Go 1.21` that we can update the version there.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please merge shortly before merging https://github.com/gardener/gardener/pull/8333
