### PR TITLE
Add e2e tests for registry-cache pull requests

### DIFF
--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
@@ -1,0 +1,73 @@
+presubmits:
+  gardener/gardener-extension-registry-cache:
+  - name: pull-gardener-extension-registry-cache-e2e-kind
+    cluster: gardener-prow-build
+    always_run: true
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for gardener-extension-registry-cache developments in pull requests
+    spec:
+      containers:
+      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-878cbf0-1.21
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - make ci-e2e-kind
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 6
+            memory: 18Gi
+        env:
+        - name: SKAFFOLD_UPDATE_CHECK
+          value: "false"
+        - name: SKAFFOLD_INTERACTIVE
+          value: "false"
+periodics:
+- name: ci-gardener-extension-registry-cache-e2e-kind
+  cluster: gardener-prow-build
+  interval: 24h
+  extra_refs:
+  - org: gardener
+    repo: gardener-extension-registry-cache
+    base_ref: main
+  decorate: true
+  decoration_config:
+    timeout: 60m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs end-to-end tests for gardener-extension-registry-cache developments periodically
+    testgrid-dashboards: gardener-extension-registry-cache
+    testgrid-days-of-results: "60"
+  spec:
+    containers:
+    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-878cbf0-1.21
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 6
+          memory: 18Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"


### PR DESCRIPTION
/kind enhancement

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
This PR adds a presubmit job that runs e2e tests for the registry-cache extension. 

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
~~Draft until https://github.com/gardener/gardener-extension-registry-cache/pull/30 is merged.~~