### PR TITLE
Fix path of `wrapper.sh` in `krte` Dockerfile

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -36,7 +36,7 @@ ENV KRTE_IMAGE=${IMAGE_ARG} \
     CONTAINER=docker
 
 # copy in image utility scripts
-COPY wrapper.sh /usr/local/bin/
+COPY images/krte/wrapper.sh /usr/local/bin/
 
 # Install tools needed to:
 # - install docker


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
#848 includes a wrong path to `wrapper.sh` so the build fails [log](https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-ci-infra-build-krte-image/1692493835889807360).
This PR corrects the path.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @shafeeqes 
