### PR TITLE
Add `images/krte/wrapper.sh` as exception to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,13 +4,11 @@
 **
 # -----------------------------------------------------------------------
 
-
 # ALLOW:
-
-!Dockerfile   # Dockerfile might be needed for pushing containers to registry later
-
 !go.mod
 !go.sum
 !vendor/**
 
 !prow/**
+
+!images/krte/wrapper.sh


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
`wrapper.sh` could not be copied because it it not an exception in `.dockerignore`.

Additionally, the `Dockerfile` was removed because it is not needed anywhere in a docker container. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @shafeeqes 
