### PR TITLE
Use Gardener `krte` image with Go 1.21 for e2e tests on master branch of `gardener/gardener`

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-migration-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration-ha-single-zone.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-operator.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20230818-a5fa846-1.21
       command:
       - wrapper.sh
       - bash


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Use Gardener krte image with Go 1.21 for gardener e2e tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @shafeeqes 
