### PR TITLE
Add tests for gardener-extension-shoot-networking-filter.

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -23,7 +23,7 @@ periodics:
       args:
       - --config=config/prow/labels.yaml
       - --confirm=true
-      - --only=gardener/ci-infra,gardener/gardener,gardener/gardener-extension-registry-cache,gardener/gardener-extension-shoot-oidc-service,gardener/dependency-watchdog,gardener/etcd-druid,gardener/gardener-extension-networking-cilium,gardener/gardener-extension-networking-calico,gardener/gardener-extension-shoot-rsyslog-relp
+      - --only=gardener/ci-infra,gardener/gardener,gardener/gardener-extension-registry-cache,gardener/gardener-extension-shoot-oidc-service,gardener/dependency-watchdog,gardener/etcd-druid,gardener/gardener-extension-networking-cilium,gardener/gardener-extension-networking-calico,gardener/gardener-extension-shoot-networking-filter,gardener/gardener-extension-shoot-rsyslog-relp
       - --endpoint=http://ghproxy.prow.svc
       - --endpoint=https://api.github.com
       # TODO: switch to GitHub App Auth, once it's implemented in label_sync

--- a/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-kind.yaml
@@ -1,0 +1,91 @@
+presubmits:
+  gardener/gardener-extension-shoot-networking-filter:
+  - name: pull-extension-shoot-networking-filter-e2e-kind
+    cluster: gardener-prow-build
+    always_run: true
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for gardener-extension-shoot-networking-filter developments in pull requests
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - |
+          set -o nounset
+          set -o pipefail
+          set -o errexit
+
+          # https://github.com/kubernetes/test-infra/issues/23741
+          iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
+          # run test
+          make test-e2e-local
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 6
+            memory: 18Gi
+        env:
+        - name: SKAFFOLD_UPDATE_CHECK
+          value: "false"
+        - name: SKAFFOLD_INTERACTIVE
+          value: "false"
+periodics:
+- name: ci-extension-shoot-networking-filter-e2e-kind
+  cluster: gardener-prow-build
+  interval: 24h
+  extra_refs:
+  - org: gardener
+    repo: gardener-extension-shoot-networking-filter
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 60m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs end-to-end tests for gardener-extension-shoot-networking-filter developments periodically
+    testgrid-dashboards: gardener-extension-shoot-networking-filter
+    testgrid-days-of-results: "60"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - |
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+
+        # https://github.com/kubernetes/test-infra/issues/23741
+        iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
+        # run test
+        make test-e2e-local
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 6
+          memory: 18Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"

--- a/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-unit-tests.yaml
@@ -1,0 +1,53 @@
+presubmits:
+  gardener/gardener-extension-shoot-networking-filter:
+  - name: pull-extension-shoot-networking-filter
+    cluster: gardener-prow-build
+    always_run: true
+    decorate: true
+    decoration_config:
+      timeout: 30m
+      grace_period: 10m
+    annotations:
+      description: Runs unit tests for gardener-extension-shoot-networking-filter developments in pull requests
+    spec:
+      containers:
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230810-2a54385-1.20
+        command:
+        - make
+        args:
+        - verify-extended
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: 2
+            memory: 1Gi
+periodics:
+- name: ci-extension-shoot-networking-filter
+  cluster: gardener-prow-build
+  interval: 4h
+  extra_refs:
+  - org: gardener
+    repo: gardener-extension-shoot-networking-filter
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 30m
+    grace_period: 10m
+  annotations:
+    description: Periodically runs unit tests for gardener-extension-shoot-networking-filter master branch
+    testgrid-dashboards: gardener-extension-shoot-networking-filter
+    testgrid-days-of-results: "60"
+  spec:
+    containers:
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230810-2a54385-1.20
+      command:
+      - make
+      args:
+      - verify-extended
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: 2
+          memory: 1Gi

--- a/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-unit-tests.yaml
@@ -1,6 +1,6 @@
 presubmits:
   gardener/gardener-extension-shoot-networking-filter:
-  - name: pull-extension-shoot-networking-filter
+  - name: pull-extension-shoot-networking-filter-unit
     cluster: gardener-prow-build
     always_run: true
     decorate: true
@@ -23,7 +23,7 @@ presubmits:
             cpu: 2
             memory: 1Gi
 periodics:
-- name: ci-extension-shoot-networking-filter
+- name: ci-extension-shoot-networking-filter-unit
   cluster: gardener-prow-build
   interval: 4h
   extra_refs:

--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -3316,6 +3316,20 @@ repos:
         target: prs
         prowPlugin: trigger
         addedBy: prow
+  gardener/gardener-extension-shoot-networking-filter:
+    labels:
+      - color: b60205
+        description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
+        name: needs-ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow
+      - color: 15dd18
+        description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
+        name: ok-to-test
+        target: prs
+        prowPlugin: trigger
+        addedBy: prow
   gardener/gardener-extension-shoot-rsyslog-relp:
     labels:
       - color: b60205

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -307,6 +307,11 @@ plugins:
     - override
     - skip
     - trigger
+  gardener/gardener-extension-shoot-networking-filter:
+    plugins:
+    - override
+    - skip
+    - trigger
   gardener/gardener-extension-shoot-rsyslog-relp:
     plugins:
     - override

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -9,6 +9,7 @@ dashboard_groups:
     - gardener-etcd-druid
     - gardener-extension-networking-cilium
     - gardener-extension-networking-calico
+    - gardener-extension-shoot-networking-filter
     - gardener-extension-shoot-rsyslog-relp
 
 dashboards:
@@ -20,4 +21,5 @@ dashboards:
 - name: gardener-etcd-druid
 - name: gardener-extension-networking-cilium
 - name: gardener-extension-networking-calico
+- name: gardener-extension-shoot-networking-filter
 - name: gardener-extension-shoot-rsyslog-relp


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
As a broken networking filter could possibly remain unnoticed for a long time, it's important to test it on a regular basis.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
