### PR TITLE
Add e2e test job for gardener-extension-shoot-rsyslog-relp repo

### DIFF
--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-e2e-kind.yaml
@@ -1,0 +1,73 @@
+presubmits:
+  gardener/gardener-extension-shoot-rsyslog-relp:
+  - name: pull-gardener-extension-shoot-rsyslog-relp-e2e-kind
+    cluster: gardener-prow-build
+    always_run: true
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for Gardener extension shoot-rsyslog-relp developments in pull requests
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - make ci-e2e-kind
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 6
+            memory: 18Gi
+        env:
+        - name: SKAFFOLD_UPDATE_CHECK
+          value: "false"
+        - name: SKAFFOLD_INTERACTIVE
+          value: "false"
+periodics:
+- name: ci-gardener-extension-shoot-rsyslog-relp-e2e-kind
+  cluster: gardener-prow-build
+  interval: 24h
+  extra_refs:
+  - org: gardener
+    repo: gardener-extension-shoot-rsyslog-relp
+    base_ref: main
+  decorate: true
+  decoration_config:
+    timeout: 60m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs end-to-end tests for Gardener extension shoot-rsyslog-relp developments periodically
+    testgrid-dashboards: gardener-extension-shoot-rsyslog-relp
+    testgrid-days-of-results: "60"
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/krte:v20230810-706aedbe3b-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 6
+          memory: 18Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Adds a job to run e2e tests for the https://github.com/gardener/gardener-extension-shoot-rsyslog-relp repo

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/issues/2

**Special notes for your reviewer**:
ref: https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/7