### PR TITLE
Reduce user's permissions in branch-protection rules

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -137,7 +137,7 @@ branch-protection:
           required_status_checks:
             contexts:
             - license/cla
-          restrictions: # prevent everyone except gardener-prow from pushing/merging
+          restrictions: # prevent everyone except gardener-prow from pushing/merging (except admins and gardener-prow)
             apps:
             - gardener-prow
             users: []
@@ -151,14 +151,13 @@ branch-protection:
           required_status_checks:
             contexts:
             - license/cla
-          restrictions: # prevent everyone from pushing/merging (except admins and gardener-prow)
+          restrictions: # prevent everyone from pushing/merging (except admins, gardener-prow and ci robots)
             apps:
             - gardener-prow
             users: []
             teams:
             - ci # allow CI users (e.g. concourse) to push (e.g. release commits)
-          enforce_admins: false # protections don't apply to admins
-          allow_deletions: true # allow maintainers to delete outdated release branches
+          enforce_admins: true # protections apply to admins as well
         gardener-extension-registry-cache:
           protect: true
           include:
@@ -166,13 +165,13 @@ branch-protection:
           required_status_checks:
             contexts:
             - license/cla
-          restrictions: # prevent everyone from pushing/merging (except admins and gardener-prow)
+          restrictions: # prevent everyone from pushing/merging (except admins, gardener-prow and ci robots)
             apps:
             - gardener-prow
             users: []
             teams:
             - ci # allow CI users (e.g. concourse) to push (e.g. release commits)
-          enforce_admins: false # protections don't apply to admins
+          enforce_admins: true # protections apply to admins as well
         dependency-watchdog:
           protect: true
           include:
@@ -180,14 +179,13 @@ branch-protection:
           required_status_checks:
             contexts:
               - license/cla
-          restrictions: # prevent everyone from pushing/merging (except admins and gardener-prow)
+          restrictions: # prevent everyone from pushing/merging (except admins, gardener-prow and ci robots)
             apps:
               - gardener-prow
             users: []
             teams:
               - ci # allow CI users (e.g. concourse) to push (e.g. release commits)
-          enforce_admins: false # protections don't apply to admins
-          allow_deletions: true # allow maintainers to delete outdated release branches
+          enforce_admins: true # protections apply to admins as well
 
 tide:
   sync_period: 1m


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
We could reduce the permissions of users in the branch-protection rules, because some settings do not have a use case (anymore):
- Remove `allow_deletions`: outdated gardener/gardener branches are deleted by prow now. Other repos don't have the use case, that people with write access only delete branches. Admins and maintainers of a repo will be still able to delete branches.
- Set `enforce_admins` to `true`: Merging PRs with failing required tests is foreseen in the PR review process for Gardener repos. Repository admins and maintainers should follow this process too.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
