### PR TITLE
Enable dependabot for automatically updating `k8s.io/test-infra` dependency

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,3 +18,11 @@ updates:
   ignore:
     - dependency-name: "*"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
+# Create PRs for k8s.io/test-infra dependency updates
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 5
+  allow:
+  - dependency-name: "k8s.io/test-infra"

--- a/.github/workflows/vendor_k8s_test_infra.yaml
+++ b/.github/workflows/vendor_k8s_test_infra.yaml
@@ -1,0 +1,31 @@
+name: Vendor k8s.io/test-infra
+on:
+  push:
+    branches:
+    - dependabot/go_modules/k8s.io/test-infra/**
+permissions: write-all
+jobs:
+  run:
+    name: Run make revendor
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: go.mod
+
+    - name: Make revendor
+      run: make revendor
+    - name: Commit changes
+      run: |
+        # Exit early if there is nothing to commit. This can happen if someone pushes to the dependabot's PR (for example has to adapt to a breaking change).
+        if [[ -z $(git status --porcelain) ]]; then
+          echo "Nothing to commit, working tree clean. Exiting..."
+          exit 0
+        fi
+        
+        git config user.name gardener-ci-robot
+        git config user.email gardener.ci.robot@gmail.com
+        git add .
+        git commit -m "[dependabot skip] make revendor"
+        git push origin


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Let's keep our dependencies up-to-date with upstream prow repository github.com/kubernetes/test-infra.
This PR enables dependabot automatically updating `k8s.io/test-infra` dependency similiar to how it is done in [other repositories for github.com/gardener/gardener](https://github.com/gardener/gardener-extension-registry-cache/pull/28).
There are many configuration related changes in upstream repository, so we don't update on a daily but on a weekly basis only.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
PR must be merged manually. Tide cannot do it, because it changes a github workflow.
