### PR TITLE
Allow admins to bypass branch-protection rules for concourse managed repositories

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -157,7 +157,7 @@ branch-protection:
             users: []
             teams:
             - ci # allow CI users (e.g. concourse) to push (e.g. release commits)
-          enforce_admins: true # protections apply to admins as well
+          enforce_admins: false # protections don't apply to admins
         gardener-extension-registry-cache:
           protect: true
           include:
@@ -171,7 +171,7 @@ branch-protection:
             users: []
             teams:
             - ci # allow CI users (e.g. concourse) to push (e.g. release commits)
-          enforce_admins: true # protections apply to admins as well
+          enforce_admins: false # protections don't apply to admins
         dependency-watchdog:
           protect: true
           include:
@@ -185,7 +185,7 @@ branch-protection:
             users: []
             teams:
               - ci # allow CI users (e.g. concourse) to push (e.g. release commits)
-          enforce_admins: true # protections apply to admins as well
+          enforce_admins: false # protections don't apply to admins
 
 tide:
   sync_period: 1m


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind regression

**What this PR does / why we need it**:
Settings from #872 are too restrictive and do not allow concourse to push release commits anymore. This PR fixes that.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ 
