### PR TITLE
Include binaries from `gardenertools` image into `golang-test` and `krte` images

### DIFF
--- a/images/golang-test/Dockerfile
+++ b/images/golang-test/Dockerfile
@@ -1,9 +1,17 @@
+# gardenertools image
+ARG gardenertoolsimage
+
+FROM ${gardenertoolsimage} AS gardenertools
+
 # Image based on golang for gardener unit and integration tests
 ARG image
 
 FROM ${image} AS golang-test
 # install gardener unit/integration test related dependencies
 LABEL GOLANG_IMAGE=${image}
+
+COPY --from=gardenertools /gardenertools /gardenertools
+
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \

--- a/images/golang-test/variants.yaml
+++ b/images/golang-test/variants.yaml
@@ -1,9 +1,9 @@
 apiVersion: variants/v1alpha1
 kind: Variants
 variants:
-  "1.19":
-    image: "golang:1.19.13"
   "1.20":
-    image: "golang:1.20.8"
+    image: golang:1.20.8
+    gardenertoolsimage: eu.gcr.io/gardener-project/ci-infra/gardenertools:v20230920-9058cc9-1.20
   "1.21":
-    image: "golang:1.21.1"
+    image: golang:1.21.1
+    gardenertoolsimage: eu.gcr.io/gardener-project/ci-infra/gardenertools:v20230920-9058cc9-1.21

--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -16,6 +16,12 @@
 # NOTE: we attempt to avoid unnecessary tools and image layers while
 # supporting kubernetes builds, kind installation, etc.
 
+# gardenertools image
+ARG gardenertoolsimage
+
+FROM ${gardenertoolsimage} AS gardenertools
+
+# krte
 FROM debian:bullseye AS krte
 
 # arg that specifies the image name (for debugging)
@@ -37,6 +43,7 @@ ENV KRTE_IMAGE=${IMAGE_ARG} \
 
 # copy in image utility scripts
 COPY images/krte/wrapper.sh /usr/local/bin/
+COPY --from=gardenertools /gardenertools /gardenertools
 
 # Install tools needed to:
 # - install docker

--- a/images/krte/variants.yaml
+++ b/images/krte/variants.yaml
@@ -2,6 +2,8 @@ variants:
   "1.20":
     GO_VERSION: 1.20.8
     IMAGE_ARG: eu.gcr.io/gardener-project/ci-infra/krte:1.20
+    gardenertoolsimage: eu.gcr.io/gardener-project/ci-infra/gardenertools:v20230920-9058cc9-1.20
   "1.21":
     GO_VERSION: 1.21.1
     IMAGE_ARG: eu.gcr.io/gardener-project/ci-infra/krte:1.21
+    gardenertoolsimage: eu.gcr.io/gardener-project/ci-infra/gardenertools:v20230920-9058cc9-1.21


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
With this PR the binaries of `gardenertools` image are copied top `/gardenertools` directory of `golang-test` and `krte` images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/hold 
Until https://github.com/gardener/gardener/pull/8509 was merged and image tags of `gardenertools` have been updated
