### PR TITLE
Add `import-tools-bin` make target to tests

### DIFF
--- a/config/jobs/gardener/gardener-apidiff.yaml
+++ b/config/jobs/gardener/gardener-apidiff.yaml
@@ -15,4 +15,5 @@ presubmits:
         command:
         - make
         args:
+        - import-tools-bin
         - check-apidiff

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
@@ -22,7 +22,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-multi-zone-upgrade
+        - make import-tools-bin ci-e2e-kind-ha-multi-zone-upgrade
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -62,7 +62,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-multi-zone-upgrade
+      - make import-tools-bin ci-e2e-kind-ha-multi-zone-upgrade
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -22,7 +22,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-multi-zone
+        - make import-tools-bin ci-e2e-kind-ha-multi-zone
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -62,7 +62,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-multi-zone
+      - make import-tools-bin ci-e2e-kind-ha-multi-zone
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
@@ -22,7 +22,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-single-zone-upgrade
+        - make import-tools-bin ci-e2e-kind-ha-single-zone-upgrade
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -62,7 +62,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-single-zone-upgrade
+      - make import-tools-bin ci-e2e-kind-ha-single-zone-upgrade
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
@@ -22,7 +22,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-single-zone
+        - make import-tools-bin ci-e2e-kind-ha-single-zone
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -62,7 +62,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-single-zone
+      - make import-tools-bin ci-e2e-kind-ha-single-zone
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/gardener/gardener-e2e-kind-migration-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration-ha-single-zone.yaml
@@ -22,7 +22,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-migration-ha-single-zone
+        - make import-tools-bin ci-e2e-kind-migration-ha-single-zone
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -62,7 +62,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-migration-ha-single-zone
+      - make import-tools-bin ci-e2e-kind-migration-ha-single-zone
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -22,7 +22,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-migration
+        - make import-tools-bin ci-e2e-kind-migration
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -62,7 +62,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-migration
+      - make import-tools-bin ci-e2e-kind-migration
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/gardener/gardener-e2e-kind-operator.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator.yaml
@@ -22,7 +22,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-operator
+        - make import-tools-bin ci-e2e-kind-operator
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -62,7 +62,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-operator
+      - make import-tools-bin ci-e2e-kind-operator
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
@@ -22,7 +22,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-upgrade
+        - make import-tools-bin ci-e2e-kind-upgrade
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -62,7 +62,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-upgrade
+      - make import-tools-bin ci-e2e-kind-upgrade
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -22,7 +22,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind
+        - make import-tools-bin ci-e2e-kind
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -62,7 +62,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind
+      - make import-tools-bin ci-e2e-kind
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -19,6 +19,7 @@ presubmits:
         command:
         - make
         args:
+        - import-tools-bin
         - test-integration
         resources:
           limits:
@@ -50,6 +51,7 @@ periodics:
       command:
       - make
       args:
+      - import-tools-bin
       - test-integration
       resources:
         limits:

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -20,6 +20,7 @@ presubmits:
         command:
         - make
         args:
+        - import-tools-bin
         - check-generate
         - check
         - format
@@ -57,6 +58,7 @@ periodics:
       command:
       - make
       args:
+      - import-tools-bin
       - check-generate
       - check
       - format

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-77.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-77.yaml
@@ -25,7 +25,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-multi-zone-upgrade
+      - make import-tools-bin ci-e2e-kind-ha-multi-zone-upgrade
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -65,7 +65,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-multi-zone
+      - make import-tools-bin ci-e2e-kind-ha-multi-zone
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -105,7 +105,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-single-zone-upgrade
+      - make import-tools-bin ci-e2e-kind-ha-single-zone-upgrade
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -145,7 +145,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-single-zone
+      - make import-tools-bin ci-e2e-kind-ha-single-zone
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -185,7 +185,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-migration-ha-single-zone
+      - make import-tools-bin ci-e2e-kind-migration-ha-single-zone
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -225,7 +225,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-migration
+      - make import-tools-bin ci-e2e-kind-migration
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -265,7 +265,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-operator
+      - make import-tools-bin ci-e2e-kind-operator
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -305,7 +305,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-upgrade
+      - make import-tools-bin ci-e2e-kind-upgrade
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -344,7 +344,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind
+      - make import-tools-bin ci-e2e-kind
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -377,6 +377,7 @@ periodics:
   spec:
     containers:
     - args:
+      - import-tools-bin
       - test-integration
       command:
       - make
@@ -407,6 +408,7 @@ periodics:
   spec:
     containers:
     - args:
+      - import-tools-bin
       - check-generate
       - check
       - format
@@ -496,7 +498,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-multi-zone-upgrade
+        - make import-tools-bin ci-e2e-kind-ha-multi-zone-upgrade
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -532,7 +534,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-multi-zone
+        - make import-tools-bin ci-e2e-kind-ha-multi-zone
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -568,7 +570,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-single-zone-upgrade
+        - make import-tools-bin ci-e2e-kind-ha-single-zone-upgrade
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -604,7 +606,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-single-zone
+        - make import-tools-bin ci-e2e-kind-ha-single-zone
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -640,7 +642,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-migration-ha-single-zone
+        - make import-tools-bin ci-e2e-kind-migration-ha-single-zone
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -676,7 +678,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-migration
+        - make import-tools-bin ci-e2e-kind-migration
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -712,7 +714,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-operator
+        - make import-tools-bin ci-e2e-kind-operator
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -748,7 +750,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-upgrade
+        - make import-tools-bin ci-e2e-kind-upgrade
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -783,7 +785,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind
+        - make import-tools-bin ci-e2e-kind
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -812,6 +814,7 @@ presubmits:
     spec:
       containers:
       - args:
+        - import-tools-bin
         - test-integration
         command:
         - make
@@ -904,6 +907,7 @@ presubmits:
     spec:
       containers:
       - args:
+        - import-tools-bin
         - check-generate
         - check
         - format

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-77.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-77.yaml
@@ -31,7 +31,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+      image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
       name: ""
       resources:
         requests:
@@ -71,7 +71,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+      image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
       name: ""
       resources:
         requests:
@@ -111,7 +111,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+      image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
       name: ""
       resources:
         requests:
@@ -151,7 +151,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+      image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
       name: ""
       resources:
         requests:
@@ -191,7 +191,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+      image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
       name: ""
       resources:
         requests:
@@ -231,7 +231,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+      image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
       name: ""
       resources:
         requests:
@@ -271,7 +271,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+      image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
       name: ""
       resources:
         requests:
@@ -311,7 +311,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+      image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
       name: ""
       resources:
         requests:
@@ -350,7 +350,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+      image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
       name: ""
       resources:
         requests:
@@ -504,7 +504,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+        image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
         name: ""
         resources:
           requests:
@@ -540,7 +540,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+        image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
         name: ""
         resources:
           requests:
@@ -576,7 +576,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+        image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
         name: ""
         resources:
           requests:
@@ -612,7 +612,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+        image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
         name: ""
         resources:
           requests:
@@ -648,7 +648,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+        image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
         name: ""
         resources:
           requests:
@@ -684,7 +684,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+        image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
         name: ""
         resources:
           requests:
@@ -720,7 +720,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+        image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
         name: ""
         resources:
           requests:
@@ -756,7 +756,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+        image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
         name: ""
         resources:
           requests:
@@ -791,7 +791,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: gcr.io/k8s-staging-test-infra/krte:v20230908-f87868ed63-master
+        image: eu.gcr.io/gardener-project/ci-infra/krte:v20230919-791e3fa-1.20
         name: ""
         resources:
           requests:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-78.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-78.yaml
@@ -25,7 +25,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-multi-zone-upgrade
+      - make import-tools-bin ci-e2e-kind-ha-multi-zone-upgrade
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -65,7 +65,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-multi-zone
+      - make import-tools-bin ci-e2e-kind-ha-multi-zone
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -105,7 +105,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-single-zone-upgrade
+      - make import-tools-bin ci-e2e-kind-ha-single-zone-upgrade
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -145,7 +145,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-single-zone
+      - make import-tools-bin ci-e2e-kind-ha-single-zone
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -185,7 +185,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-migration-ha-single-zone
+      - make import-tools-bin ci-e2e-kind-migration-ha-single-zone
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -225,7 +225,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-migration
+      - make import-tools-bin ci-e2e-kind-migration
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -265,7 +265,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-operator
+      - make import-tools-bin ci-e2e-kind-operator
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -305,7 +305,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-upgrade
+      - make import-tools-bin ci-e2e-kind-upgrade
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -344,7 +344,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind
+      - make import-tools-bin ci-e2e-kind
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -377,6 +377,7 @@ periodics:
   spec:
     containers:
     - args:
+      - import-tools-bin
       - test-integration
       command:
       - make
@@ -407,6 +408,7 @@ periodics:
   spec:
     containers:
     - args:
+      - import-tools-bin
       - check-generate
       - check
       - format
@@ -496,7 +498,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-multi-zone-upgrade
+        - make import-tools-bin ci-e2e-kind-ha-multi-zone-upgrade
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -532,7 +534,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-multi-zone
+        - make import-tools-bin ci-e2e-kind-ha-multi-zone
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -568,7 +570,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-single-zone-upgrade
+        - make import-tools-bin ci-e2e-kind-ha-single-zone-upgrade
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -604,7 +606,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-single-zone
+        - make import-tools-bin ci-e2e-kind-ha-single-zone
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -640,7 +642,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-migration-ha-single-zone
+        - make import-tools-bin ci-e2e-kind-migration-ha-single-zone
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -676,7 +678,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-migration
+        - make import-tools-bin ci-e2e-kind-migration
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -712,7 +714,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-operator
+        - make import-tools-bin ci-e2e-kind-operator
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -748,7 +750,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-upgrade
+        - make import-tools-bin ci-e2e-kind-upgrade
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -783,7 +785,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind
+        - make import-tools-bin ci-e2e-kind
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -812,6 +814,7 @@ presubmits:
     spec:
       containers:
       - args:
+        - import-tools-bin
         - test-integration
         command:
         - make
@@ -904,6 +907,7 @@ presubmits:
     spec:
       containers:
       - args:
+        - import-tools-bin
         - check-generate
         - check
         - format

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-79.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-79.yaml
@@ -25,7 +25,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-multi-zone-upgrade
+      - make import-tools-bin ci-e2e-kind-ha-multi-zone-upgrade
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -65,7 +65,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-multi-zone
+      - make import-tools-bin ci-e2e-kind-ha-multi-zone
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -105,7 +105,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-single-zone-upgrade
+      - make import-tools-bin ci-e2e-kind-ha-single-zone-upgrade
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -145,7 +145,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-ha-single-zone
+      - make import-tools-bin ci-e2e-kind-ha-single-zone
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -185,7 +185,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-migration-ha-single-zone
+      - make import-tools-bin ci-e2e-kind-migration-ha-single-zone
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -225,7 +225,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-migration
+      - make import-tools-bin ci-e2e-kind-migration
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -265,7 +265,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-operator
+      - make import-tools-bin ci-e2e-kind-operator
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -305,7 +305,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind-upgrade
+      - make import-tools-bin ci-e2e-kind-upgrade
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -344,7 +344,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - make ci-e2e-kind
+      - make import-tools-bin ci-e2e-kind
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"
@@ -377,6 +377,7 @@ periodics:
   spec:
     containers:
     - args:
+      - import-tools-bin
       - test-integration
       command:
       - make
@@ -407,6 +408,7 @@ periodics:
   spec:
     containers:
     - args:
+      - import-tools-bin
       - check-generate
       - check
       - format
@@ -496,7 +498,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-multi-zone-upgrade
+        - make import-tools-bin ci-e2e-kind-ha-multi-zone-upgrade
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -532,7 +534,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-multi-zone
+        - make import-tools-bin ci-e2e-kind-ha-multi-zone
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -568,7 +570,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-single-zone-upgrade
+        - make import-tools-bin ci-e2e-kind-ha-single-zone-upgrade
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -604,7 +606,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-ha-single-zone
+        - make import-tools-bin ci-e2e-kind-ha-single-zone
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -640,7 +642,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-migration-ha-single-zone
+        - make import-tools-bin ci-e2e-kind-migration-ha-single-zone
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -676,7 +678,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-migration
+        - make import-tools-bin ci-e2e-kind-migration
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -712,7 +714,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-operator
+        - make import-tools-bin ci-e2e-kind-operator
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -748,7 +750,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind-upgrade
+        - make import-tools-bin ci-e2e-kind-upgrade
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -783,7 +785,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - make ci-e2e-kind
+        - make import-tools-bin ci-e2e-kind
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -812,6 +814,7 @@ presubmits:
     spec:
       containers:
       - args:
+        - import-tools-bin
         - test-integration
         command:
         - make
@@ -904,6 +907,7 @@ presubmits:
     spec:
       containers:
       - args:
+        - import-tools-bin
         - check-generate
         - check
         - format


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds `import-tools-bin` make target to all tests, that they could import the binaries from `gardenertools` image before running the tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/hold
Until https://github.com/gardener/gardener/pull/8509 was merged and cherry-picked to the release branches.
