### PR TITLE
Reduce retention days and increase memory request for prometheus on build cluster

### DIFF
--- a/config/prow/cluster/monitoring/build-cluster/prometheus.yaml
+++ b/config/prow/cluster/monitoring/build-cluster/prometheus.yaml
@@ -12,5 +12,5 @@ spec:
       periodSeconds: 15
   resources:
     requests:
-      memory: 14Gi
-  retention: 30d
+      memory: 28Gi
+  retention: 14d


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Prometheus on build cluster in not running stable, so this PR reduces retention days and increases memory requests to improve the situation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
