### PR TITLE
Update `krte` image to `debian:bookworm`

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -22,7 +22,7 @@ ARG gardenertoolsimage
 FROM ${gardenertoolsimage} AS gardenertools
 
 # krte
-FROM debian:bullseye AS krte
+FROM debian:bookworm AS krte
 
 # arg that specifies the image name (for debugging)
 ARG IMAGE_ARG
@@ -93,10 +93,11 @@ RUN echo "Installing Packages ..." \
             --usage-reporting=false \
         && gcloud components install kubectl \
     && echo "Installing Docker ..." \
-        && curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - \
-        && add-apt-repository \
-            "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
-            $(lsb_release -cs) stable" \
+        && curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+        && chmod a+r /etc/apt/keyrings/docker.gpg \
+        && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+            "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+            tee /etc/apt/sources.list.d/docker.list > /dev/null \
         && apt-get update \
         && apt-get install -y --no-install-recommends docker-ce docker-buildx-plugin \
         && rm -rf /var/lib/apt/lists/* \

--- a/images/krte/README.md
+++ b/images/krte/README.md
@@ -1,7 +1,7 @@
 # krte image
 
-**Note: This is a fork of [krte from kubernetes/test-infra (commit 1ffa643)](https://github.com/kubernetes/test-infra/tree/1ffa643ca2c0e92824fdb8e706b862466396dae0/images/krte) repository.
-It changes the Go version to Gardener requirements.**
+**Note: This is a fork of [krte from kubernetes/test-infra (commit 8b8d9ff)](https://github.com/kubernetes/test-infra/tree/8b8d9ff4819af95d51b02160a2f99c74459f22d7/images/krte) repository.
+It changes the Go version to Gardener requirements and adds [gardenertools](https://github.com/gardener/gardener/tree/master/hack/tools/image) binaries.**
 
 krte - [KIND](https://sigs.k8s.io/kind) RunTime Environment
 


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR updates `krte` image to `debian:bookworm` similar to how it was done in [kubernetes/test-infra](https://github.com/kubernetes/test-infra/commit/8b8d9ff4819af95d51b02160a2f99c74459f22d7) repository.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
