### PR TITLE
Set fixed debian version in test images

### DIFF
--- a/images/golang-test/variants.yaml
+++ b/images/golang-test/variants.yaml
@@ -1,9 +1,12 @@
 apiVersion: variants/v1alpha1
 kind: Variants
+# Debian versions of golang images must be in sync with these images to avoid problems with different `glibc` versions:
+# - https://github.com/gardener/ci-infra/blob/master/images/krte/Dockerfile
+# - https://github.com/gardener/gardener/blob/master/hack/tools/image/variants.yaml
 variants:
   "1.20":
-    image: golang:1.20.8
+    image: golang:1.20.8-bookworm
     gardenertoolsimage: eu.gcr.io/gardener-project/ci-infra/gardenertools:v20230922-cbcbf87-1.20
   "1.21":
-    image: golang:1.21.1
+    image: golang:1.21.1-bookworm
     gardenertoolsimage: eu.gcr.io/gardener-project/ci-infra/gardenertools:v20230922-cbcbf87-1.21

--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -22,6 +22,9 @@ ARG gardenertoolsimage
 FROM ${gardenertoolsimage} AS gardenertools
 
 # krte
+# Debian versions of krte image must be in sync with these images to avoid problems with different `glibc` versions:
+# - https://github.com/gardener/ci-infra/blob/master/images/golang-test/variants.yaml
+# - https://github.com/gardener/gardener/blob/master/hack/tools/image/variants.yaml
 FROM debian:bookworm AS krte
 
 # arg that specifies the image name (for debugging)


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR sets the `debian` version of test images explicitly to `bookworm` that we don't run into `glibc` issues in case the default base image of `golang` changes.
There is a related PR in gardener repo: https://github.com/gardener/gardener/pull/8542

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
