### PR TITLE
`branch-cleaner` removes branch protection rules of branches it plans to delete

### DIFF
--- a/prow/cmd/branch-cleaner/README.md
+++ b/prow/cmd/branch-cleaner/README.md
@@ -2,6 +2,8 @@
 ## Functionality
 The `branch-cleaner` scans GitHub repositories for branches of a specific pattern and deletes them.
 
-When the `--keep-branches=N` is set, it keeps the last `N` matching branches sorted in alphabetical order. 
-When `--ignore-open-prs=false` it checks the branches for open PRs before deletion. If there are any, the branch won't be deleted. 
-When `--release-branch-mode=true` it checks release branch names for semver versions and searches for an existing Github release tag (`v{major}.{minor}.0`) for this version. Release branches which do not have a version yet are neither counted nor considered for deletion, because they are not released yet. If the branch names to not include a semver version `branch-cleaner` fails in this mode.
+You have to specify at the the `--repository` and `--branch-pattern` CLI parameters to run `branch-cleaner`. `repository` is set in the format `{org}/{repo}`, `branch-pattern` is the regexp pattern of the branches which should be cleaned.
+
+When the `--keep-branches=N` is set, it keeps the last `N` matching branches sorted in alphabetical order.  
+When `--ignore-open-prs=false` it checks the branches for open PRs before deletion. If there are any, the branch won't be deleted.  
+When `--release-branch-mode=true` it checks release branch names for semver versions and searches for an existing Github release tag (`v{major}.{minor}.0`) for this version. Release branches which do not have a version yet are neither counted nor considered for deletion, because they are not released yet. If matching branch names do not include a semver version `branch-cleaner` fails in this mode. Additionally, this mode deletes `branch-protection` rules for deleted branches if they exist.


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
After permissions in branch protection rules have been reduced in https://github.com/gardener/ci-infra/pull/872, `branch-cleaner` is no longer able to clean up old release branches ([ref](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-branch-cleaner/1706428598539259904)).
Additionally, there are orphaned branch-protection rules of release branches which have been deleted in the past.
Thus, rather then reverting the change this PR enables `branch-protector` to delete branch protection rules for release branches it deletes. This removes one task for the the release responsible.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke 
