### PR TITLE
Update golang-test of `gardener/gardener-extension-shoot-networking-filter` tests to Go 1.21

### DIFF
--- a/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-shoot-networking-filter developments in pull requests
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230925-2cf45e8-1.20
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230925-2cf45e8-1.21
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230925-2cf45e8-1.20
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230925-2cf45e8-1.21
       command:
       - make
       args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
This PR updates Go version of golang-test images for gardener-extension-shoot-networking-filter tests to Go 1.21 that we can update the version there.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
