### PR TITLE
Update Go for ci-infra tests to 1.21

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -319,7 +319,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230919-791e3fa-1.19
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230919-791e3fa-1.21
       command:
       - make
       args:

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -33,7 +33,7 @@ presubmits:
       description: Runs go tests for prow developments in ci-infra 
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230919-791e3fa-1.19
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230919-791e3fa-1.21
         command:
         - make
         args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR updates Go version of ci-infra tests 1.21. It is required to make the tests of PR https://github.com/gardener/ci-infra/pull/930 work.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
