### PR TITLE
Adds external plugins for shoot-rsyslog-relp extension

### DIFF
--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -3344,6 +3344,27 @@ repos:
         target: prs
         prowPlugin: trigger
         addedBy: prow
+      - color: e11d21
+        description: Indicates the PR's author has not signed the cla-assistant.io CLA.
+        name: 'cla: no'
+        target: prs
+        prowPlugin: cla-assistant
+        isExternalPlugin: true
+        addedBy: prow
+      - color: bfe5bf
+        description: Indicates the PR's author has signed the cla-assistant.io CLA.
+        name: 'cla: yes'
+        target: prs
+        prowPlugin: cla-assistant
+        isExternalPlugin: true
+        addedBy: prow
+      - color: e11d21
+        description: Indicates a PR cannot be merged because it has merge conflicts with HEAD.
+        name: needs-rebase
+        target: prs
+        prowPlugin: needs-rebase
+        isExternalPlugin: true
+        addedBy: prow
   gardener/landscaper:
     labels:
       - color: b60205

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -384,3 +384,18 @@ external_plugins:
       events:
         - issue_comment
         - pull_request
+  gardener/gardener-extension-shoot-rsyslog-relp:
+  - name: cla-assistant
+    events:
+      - issue_comment
+      - pull_request_review
+      - pull_request_review_comment
+      - status
+  - name: needs-rebase
+    events:
+      - issue_comment
+      - pull_request
+  - name: cherrypicker
+    events:
+    - issue_comment
+    - pull_request


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds the `cla-assistant`, `needs-rebase` and `cherrypicker` external plugins for the https://github.com/gardener/gardener-extension-shoot-rsyslog-relp extension repository

The label added from `cla-assistant` is currently not used in the repo. However, in the future it will most likely be used

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
