### PR TITLE
Update golang-test of `gardener/gardener-extension-shoot-rsyslog-relp` tests to Go 1.21

### DIFF
--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-integration-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-integration-tests.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231012-5bc8827-1.20
+        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231012-5bc8827-1.21
         command:
         - make
         args:
@@ -44,7 +44,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231012-5bc8827-1.20
+      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231012-5bc8827-1.21
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for Gardener extension shoot-rsyslog-relp developments in pull requests
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231012-5bc8827-1.20
+      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231012-5bc8827-1.21
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231012-5bc8827-1.20
+    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231012-5bc8827-1.21
       command:
       - make
       args:


### PR DESCRIPTION
/kind enhancement
Update golang-test of `gardener/gardener-extension-shoot-rsyslog-relp` tests to Go 1.21