### PR TITLE
Add PR author to release-notes of cherry-picked PRs

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -251,7 +251,7 @@ func (s *Server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 		"target_branch": targetBranch,
 	})
 	l.Debug("Cherrypick request.")
-	return s.handle(l, ic.Comment.User.Login, &ic.Comment, org, repo, targetBranch, baseBranch, title, body, num)
+	return s.handle(l, pr.User.Login, ic.Comment.User.Login, &ic.Comment, org, repo, targetBranch, baseBranch, title, body, num)
 }
 
 func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent) error {
@@ -373,7 +373,7 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 				"target_branch": targetBranch,
 			})
 			l.Debug("Cherrypick request.")
-			err := s.handle(l, requestor, ic, org, repo, targetBranch, baseBranch, title, body, num)
+			err := s.handle(l, pr.User.Login, requestor, ic, org, repo, targetBranch, baseBranch, title, body, num)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to create cherrypick: %w", err))
 			}
@@ -384,7 +384,7 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 
 var cherryPickBranchFmt = "cherry-pick-%d-to-%s"
 
-func (s *Server) handle(logger *logrus.Entry, requestor string, comment *github.IssueComment, org, repo, targetBranch, baseBranch, title, body string, num int) error {
+func (s *Server) handle(logger *logrus.Entry, author, requestor string, comment *github.IssueComment, org, repo, targetBranch, baseBranch, title, body string, num int) error {
 	var lock *sync.Mutex
 	func() {
 		s.mapLock.Lock()
@@ -503,9 +503,9 @@ func (s *Server) handle(logger *logrus.Entry, requestor string, comment *github.
 	// Open a PR in GitHub.
 	var cherryPickBody string
 	if s.prowAssignments {
-		cherryPickBody = cherrypicker.CreateCherrypickBody(num, requestor, releaseNoteFromParentPR(body))
+		cherryPickBody = cherrypicker.CreateCherrypickBody(num, requestor, releaseNoteFromParentPR(author, org, repo, num, body))
 	} else {
-		cherryPickBody = cherrypicker.CreateCherrypickBody(num, "", releaseNoteFromParentPR(body))
+		cherryPickBody = cherrypicker.CreateCherrypickBody(num, "", releaseNoteFromParentPR(author, org, repo, num, body))
 	}
 	head := fmt.Sprintf("%s:%s", s.botUser.Login, newBranch)
 	createdNum, err := s.ghc.CreatePullRequest(org, repo, title, cherryPickBody, head, targetBranch, true)
@@ -659,10 +659,18 @@ func normalize(input string) string {
 // releaseNoteNoteFromParentPR gets the release note from the
 // parent PR and formats it as per the PR template so that
 // it can be copied to the cherry-pick PR.
-func releaseNoteFromParentPR(body string) string {
+func releaseNoteFromParentPR(author, org, repo string, num int, body string) string {
 	potentialMatch := releaseNoteRe.FindStringSubmatch(body)
 	if potentialMatch == nil {
 		return ""
 	}
-	return fmt.Sprintf("```%s %s\n%s\n```", strings.TrimSpace(potentialMatch[2]), strings.TrimSpace(potentialMatch[3]), strings.TrimSpace(potentialMatch[4]))
+	source := fmt.Sprintf("github.com/%s/%s", org, repo)
+	return fmt.Sprintf("```%s %s %s #%d @%s\n%s\n```",
+		strings.TrimSpace(potentialMatch[2]),
+		strings.TrimSpace(potentialMatch[3]),
+		source,
+		num,
+		author,
+		strings.TrimSpace(potentialMatch[4]),
+	)
 }

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -1102,6 +1102,66 @@ func TestEnsureForkExists(t *testing.T) {
 
 }
 
+func TestReleaseNoteFromParentPR(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "test1",
+			input:    "```feature developer\nUpdate the magic number from 42 to 49\n```",
+			expected: "```feature developer github.com/foo/bar #123 @foo-author\nUpdate the magic number from 42 to 49\n```",
+		},
+		{
+			name:     "test2",
+			input:    "```feature developer github.com/foobar/barfoo #999 @bar-author\nUpdate the magic number from 42 to 49\n```",
+			expected: "```feature developer github.com/foobar/barfoo #999 @bar-author\nUpdate the magic number from 42 to 49\n```",
+		},
+		{
+			name:     "test3",
+			input:    "```feature developer github.com/foobar/barfoo #999\nUpdate the magic number from 42 to 49\n```",
+			expected: "```feature developer github.com/foobar/barfoo #999 @foo-author\nUpdate the magic number from 42 to 49\n```",
+		},
+		{
+			name:     "test4",
+			input:    "```feature developer github.com/foobar/barfoo\nUpdate the magic number from 42 to 49\n```",
+			expected: "```feature developer github.com/foo/bar #123 @foo-author\nUpdate the magic number from 42 to 49\n```",
+		},
+		{
+			name:     "test5",
+			input:    "```feature developer @bar-author\nUpdate the magic number from 42 to 49\n```",
+			expected: "```feature developer github.com/foo/bar #123 @bar-author\nUpdate the magic number from 42 to 49\n```",
+		},
+		{
+			name:     "test6",
+			input:    "```feature developer #999 @bar-author\nUpdate the magic number from 42 to 49\n```",
+			expected: "```feature developer github.com/foo/bar #123 @bar-author\nUpdate the magic number from 42 to 49\n```",
+		},
+		{
+			name:     "test7",
+			input:    "```feature developer github.com/foobar/barfoo @bar-author\nUpdate the magic number from 42 to 49\n```",
+			expected: "```feature developer github.com/foo/bar #123 @bar-author\nUpdate the magic number from 42 to 49\n```",
+		},
+		{
+			name:     "test8",
+			input:    "```feature developer #999\nUpdate the magic number from 42 to 49\n```",
+			expected: "```feature developer github.com/foo/bar #123 @foo-author\nUpdate the magic number from 42 to 49\n```",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := releaseNoteFromParentPR("foo-author", "foo", "bar", 123, tc.input)
+			if result != tc.expected {
+				t.Errorf("Expected: %q\n Got: %q", tc.expected, result)
+			}
+		})
+	}
+}
+
 type threadUnsafeFGHC struct {
 	*fghc
 	orgRepoCountCalled int

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -313,6 +313,7 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 			Base: github.PullRequestBranch{
 				Ref: "master",
 			},
+			User:   github.User{Login: "foo-author"},
 			Merged: true,
 			Title:  "This is a fix for X",
 			Body:   body,
@@ -344,7 +345,7 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 
 	botUser := &github.UserData{Login: "ci-robot", Email: "ci-robot@users.noreply.github.com"}
 	expectedTitle := "[stage] This is a fix for X"
-	expectedBody := fmt.Sprintf("This is an automated cherry-pick of #%d\n\n/assign wiseguy\n\n```feature developer\nUpdate the magic number from 42 to 49\n```", iNumber)
+	expectedBody := fmt.Sprintf("This is an automated cherry-pick of #%d\n\n/assign wiseguy\n\n```feature developer github.com/foo/bar #%d @foo-author\nUpdate the magic number from 42 to 49\n```", iNumber, iNumber)
 	expectedBase := "stage"
 	expectedHead := fmt.Sprintf(botUser.Login+":"+cherryPickBranchFmt, iNumber, expectedBase)
 	expectedLabels := []string{}
@@ -1025,13 +1026,13 @@ func TestHandleLocks(t *testing.T) {
 
 	go func() {
 		defer close(routine1Done)
-		if err := s.handle(l, "", &github.IssueComment{}, "org", "repo", "targetBranch", "baseBranch", "title", "body", 0); err != nil {
+		if err := s.handle(l, "", "", &github.IssueComment{}, "org", "repo", "targetBranch", "baseBranch", "title", "body", 0); err != nil {
 			t.Errorf("routine failed: %v", err)
 		}
 	}()
 	go func() {
 		defer close(routine2Done)
-		if err := s.handle(l, "", &github.IssueComment{}, "org", "repo", "targetBranch", "baseBranch", "title", "body", 0); err != nil {
+		if err := s.handle(l, "", "", &github.IssueComment{}, "org", "repo", "targetBranch", "baseBranch", "title", "body", 0); err != nil {
 			t.Errorf("routine failed: %v", err)
 		}
 	}()

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -1026,13 +1026,13 @@ func TestHandleLocks(t *testing.T) {
 
 	go func() {
 		defer close(routine1Done)
-		if err := s.handle(l, "", "", &github.IssueComment{}, "org", "repo", "targetBranch", "baseBranch", "title", "body", 0); err != nil {
+		if err := s.handle(l, "", "", &github.IssueComment{}, "org", "repo", "targetBranch", "baseBranch", "title", "body", 0, []github.Label{}); err != nil {
 			t.Errorf("routine failed: %v", err)
 		}
 	}()
 	go func() {
 		defer close(routine2Done)
-		if err := s.handle(l, "", "", &github.IssueComment{}, "org", "repo", "targetBranch", "baseBranch", "title", "body", 0); err != nil {
+		if err := s.handle(l, "", "", &github.IssueComment{}, "org", "repo", "targetBranch", "baseBranch", "title", "body", 0, []github.Label{}); err != nil {
 			t.Errorf("routine failed: %v", err)
 		}
 	}()


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Currently the `gardener-ci-robot` appears as author of the PR on cherry-picked PRs.
There is an option to mention the author as label in the release notes. Thus, this PR adds the references to the parent repository, the parent PR and the PR author to the release note string, which should fix this issue.
Additionally, cherry-picker now recognizes release-notes which include these optional release-note labels. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke 
