### PR TITLE
Remove `check-docforge`

### DIFF
--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -26,7 +26,6 @@ presubmits:
         - format
         - test
         - test-prometheus
-        - check-docforge
         resources:
           limits:
             memory: 16Gi
@@ -64,7 +63,6 @@ periodics:
       - format
       - test
       - test-prometheus
-      - check-docforge
       resources:
         limits:
           memory: 16Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind cleanup

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
Removes `check-docforge` from unit tests
Part of https://github.com/gardener/gardener/pull/8692

**Special notes for your reviewer**:
