### PR TITLE
Decrease volume size of `ghproxy`

### DIFF
--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -24,7 +24,7 @@ spec:
         image: gcr.io/k8s-prow/ghproxy:v20231027-9cda73bb73
         args:
         - --cache-dir=/cache
-        - --cache-sizeGB=99
+        - --cache-sizeGB=9
         - --serve-metrics=true
         ports:
         - name: main
@@ -38,11 +38,3 @@ spec:
       - name: cache
         persistentVolumeClaim:
           claimName: ghproxy
-#      # run on our dedicated node
-#      tolerations:
-#      - key: "dedicated"
-#        operator: "Equal"
-#        value: "ghproxy"
-#        effect: "NoSchedule"
-#      nodeSelector:
-#        dedicated: "ghproxy"

--- a/config/prow/cluster/ghproxy_pvc.yaml
+++ b/config/prow/cluster/ghproxy_pvc.yaml
@@ -10,5 +10,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Gi
+      storage: 10Gi
   storageClassName: gce-ssd


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Decrease volume size of `ghproxy`, because it is way too big. Only 380MB are used.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
