### PR TITLE
Fix grafana ingress `nginx.ingress.kubernetes.io/auth-signin` annotations

### DIFF
--- a/config/prow/cluster/monitoring/build-cluster/grafana-ingress.yaml
+++ b/config/prow/cluster/monitoring/build-cluster/grafana-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     dns.gardener.cloud/class: garden
     dns.gardener.cloud/dnsnames: monitoring-build.prow.gardener.cloud
     nginx.ingress.kubernetes.io/auth-url: https://oauth2.prow.gardener.cloud/oauth2/auth
-    nginx.ingress.kubernetes.io/auth-signin: https://oauth2.prow.gardener.cloud/oauth2/start?rd=https%3A//monitoring-build.prow.gardener.cloud
+    nginx.ingress.kubernetes.io/auth-signin: https://oauth2.prow.gardener.cloud/oauth2/start?rd=https://monitoring-build.prow.gardener.cloud
 spec:
   rules:
   - host: monitoring-build.prow.gardener.cloud

--- a/config/prow/cluster/monitoring/trusted-cluster/grafana-ingress.yaml
+++ b/config/prow/cluster/monitoring/trusted-cluster/grafana-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     dns.gardener.cloud/class: garden
     dns.gardener.cloud/dnsnames: monitoring.prow.gardener.cloud
     nginx.ingress.kubernetes.io/auth-url: https://oauth2.prow.gardener.cloud/oauth2/auth
-    nginx.ingress.kubernetes.io/auth-signin: https://oauth2.prow.gardener.cloud/oauth2/start?rd=https%3A//monitoring.prow.gardener.cloud
+    nginx.ingress.kubernetes.io/auth-signin: https://oauth2.prow.gardener.cloud/oauth2/start?rd=https://monitoring.prow.gardener.cloud
 spec:
   rules:
   - host: monitoring.prow.gardener.cloud


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Since validation of nginx annotations was enabled in #980, the login to grafana does not work anymore. This PR fixes the `nginx.ingress.kubernetes.io/auth-signin` annotations of grafana ingresses.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timebertt 
