### PR TITLE
Change domain of `gcsweb` to `gcsweb.prow.gardener.cloud`

### DIFF
--- a/config/prow/cluster/gcsweb_ingress.yaml
+++ b/config/prow/cluster/gcsweb_ingress.yaml
@@ -9,10 +9,10 @@ metadata:
     cert.gardener.cloud/issuer: ci-issuer
     cert.gardener.cloud/purpose: managed
     dns.gardener.cloud/class: garden
-    dns.gardener.cloud/dnsnames: gcsweb.gardener.cloud
+    dns.gardener.cloud/dnsnames: gcsweb.prow.gardener.cloud
 spec:
   rules:
-  - host: gcsweb.gardener.cloud
+  - host: gcsweb.prow.gardener.cloud
     http:
       paths:
       - path: /
@@ -24,5 +24,5 @@ spec:
               number: 80
   tls:
   - hosts:
-    - gcsweb.gardener.cloud
+    - gcsweb.prow.gardener.cloud
     secretName: gcsweb-ingress-tls

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -48,7 +48,7 @@ sinker:
 deck:
   spyglass:
     size_limit: 100000000 # 100MB
-    gcs_browser_prefix: https://gcsweb.gardener.cloud/gcs/
+    gcs_browser_prefix: https://gcsweb.prow.gardener.cloud/gcs/
     testgrid_config: gs://gardener-prow/testgrid/config
     testgrid_root: https://testgrid.k8s.io/
     lenses:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
We recently changed the DNS configuration of our prow cluster. As a consequence we can use `prow.gardener.cloud` + subdomains only. Thus, `gcsweb` has to move from `gcsweb.gardener.cloud` to `gcsweb.prow.gardener.cloud`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timebertt 
