### PR TITLE
Deploy and enable `athens` as `GOPROXY` on trusted and build clusters

### DIFF
--- a/config/prow/cluster/athens/athens-proxy.yaml
+++ b/config/prow/cluster/athens/athens-proxy.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: athens-proxy
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1

--- a/config/prow/cluster/athens/athens_deployment.yaml
+++ b/config/prow/cluster/athens/athens_deployment.yaml
@@ -1,0 +1,223 @@
+---
+# Source: athens-proxy/templates/service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: athens-proxy
+  labels:
+    
+    app: athens-proxy
+    chart: athens-proxy-0.8.0
+    release: "athens"
+    heritage: "Helm"
+    app.kubernetes.io/name: athens-proxy
+    helm.sh/chart: athens-proxy-0.8.0
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "athens"
+    app.kubernetes.io/version: "v0.12.1"
+---
+# Source: athens-proxy/templates/secret.yaml
+kind: Secret
+apiVersion: v1
+metadata:
+  name: athens-proxy-secret
+  labels:
+    
+    app: athens-proxy
+    chart: athens-proxy-0.8.0
+    release: "athens"
+    heritage: "Helm"
+    app.kubernetes.io/name: athens-proxy
+    helm.sh/chart: athens-proxy-0.8.0
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "athens"
+    app.kubernetes.io/version: "v0.12.1"
+type: Opaque
+data:
+---
+# Source: athens-proxy/templates/storage-pvc.yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: athens-proxy-storage
+  labels:
+    
+    app: athens-proxy-storage
+    chart: athens-proxy-0.8.0
+    release: "athens"
+    heritage: "Helm"
+    app.kubernetes.io/name: athens-proxy-storage
+    helm.sh/chart: athens-proxy-0.8.0
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "athens"
+    app.kubernetes.io/version: "v0.12.1"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "20Gi"
+  storageClassName: "gce-ssd"
+---
+# Source: athens-proxy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: athens-proxy
+  labels:
+    
+    app: athens-proxy
+    chart: athens-proxy-0.8.0
+    release: "athens"
+    heritage: "Helm"
+    app.kubernetes.io/name: athens-proxy
+    helm.sh/chart: athens-proxy-0.8.0
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "athens"
+    app.kubernetes.io/version: "v0.12.1"
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: 3000
+    protocol: TCP
+  selector:
+    app: athens-proxy
+    release: "athens"
+---
+# Source: athens-proxy/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: athens-proxy
+  labels:
+    
+    app: athens-proxy
+    chart: athens-proxy-0.8.0
+    release: "athens"
+    heritage: "Helm"
+    app.kubernetes.io/name: athens-proxy
+    helm.sh/chart: athens-proxy-0.8.0
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "athens"
+    app.kubernetes.io/version: "v0.12.1"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: athens-proxy
+      release: "athens"
+  template:
+    metadata:
+      labels:
+        
+        app: athens-proxy
+        chart: athens-proxy-0.8.0
+        release: "athens"
+        heritage: "Helm"
+        app.kubernetes.io/name: athens-proxy
+        helm.sh/chart: athens-proxy-0.8.0
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "athens"
+        app.kubernetes.io/version: "v0.12.1"
+      annotations:
+        checksum/upstream: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/ssh-config: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/ssh-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      serviceAccount: athens-proxy
+      containers:
+      - name: athens-proxy
+        image: "docker.io/gomods/athens:v0.12.1"
+        imagePullPolicy: "IfNotPresent"
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: "/healthz"
+            port: 3000
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: "/readyz"
+            port: 3000
+        env:
+        - name: ATHENS_GOGET_WORKERS
+          value: "5"
+        - name: ATHENS_GO_BINARY_ENV_VARS
+          value: GOPROXY=https://proxy.golang.org,direct
+        - name: ATHENS_STORAGE_TYPE
+          value: "disk"
+        - name: ATHENS_DISK_STORAGE_ROOT
+          value: "/var/lib/athens"
+        ports:
+        - containerPort: 3000
+        volumeMounts:
+        - name: storage-volume
+          mountPath: "/var/lib/athens"
+        resources:
+          requests:
+            cpu: 2
+            memory: 512Mi
+      volumes:
+      - name: storage-volume
+        persistentVolumeClaim:
+          claimName: athens-proxy-storage
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: worker.gardener.cloud/system-components
+                operator: In
+                values:
+                - "true"
+---
+# Source: athens-proxy/templates/service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    
+    app: athens-proxy
+    chart: athens-proxy-0.8.0
+    release: "athens"
+    heritage: "Helm"
+    app.kubernetes.io/name: athens-proxy
+    helm.sh/chart: athens-proxy-0.8.0
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "athens"
+    app.kubernetes.io/version: "v0.12.1"
+    prometheus: default
+  name: athens-proxy
+  namespace: monitoring
+spec:
+  endpoints:
+  - path: /metrics
+    port: http
+  namespaceSelector:
+    matchNames:
+    - athens
+  selector:
+    matchLabels:
+      app: athens-proxy
+      release: "athens"
+---
+# Source: athens-proxy/templates/test/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "athens-proxy-test-connection"
+  labels:
+    app: athens-proxy
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['athens-proxy:80']
+  restartPolicy: Never

--- a/config/prow/cluster/athens/athens_namespace.yaml
+++ b/config/prow/cluster/athens/athens_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: athens

--- a/config/prow/cluster/athens/athens_prometheus_rbac.yaml
+++ b/config/prow/cluster/athens/athens_prometheus_rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: athens
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: athens
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: monitoring

--- a/config/prow/cluster/athens/helm/README.md
+++ b/config/prow/cluster/athens/helm/README.md
@@ -1,0 +1,4 @@
+`../athens_deployment.yaml` was generated from helm chart **gomods/athens-proxy**.
+
+
+`generate-athens-deployments.sh` is templating and overwriting this configuration based on the latest version of the helm chart.

--- a/config/prow/cluster/athens/helm/generate-athens-deployments.sh
+++ b/config/prow/cluster/athens/helm/generate-athens-deployments.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script templates the athens helm chart for gardener-ci prow cluster
+# and replaces the old content of /config/prow/cluster/athens/athens_deployment.yaml with the freshly templated version
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+if ! which helm &>/dev/null; then
+  echo "helm not found, please install it"
+  exit 1
+fi
+
+echo "Adding & updating athens helm repository"
+helm repo add gomods https://gomods.github.io/athens-charts
+helm repo update
+
+echo "Templating athens"
+helm template -n athens athens gomods/athens-proxy -f $SCRIPT_DIR/values.yaml > $SCRIPT_DIR/../athens_deployment.yaml
+
+echo "Done"

--- a/config/prow/cluster/athens/helm/values.yaml
+++ b/config/prow/cluster/athens/helm/values.yaml
@@ -1,0 +1,42 @@
+fullnameOverride: athens-proxy
+
+replicaCount: 1
+
+ingress:
+  enabled: false
+
+storage:
+  type: disk
+  disk:
+    storageRoot: "/var/lib/athens"
+    persistence:
+      enabled: true
+      accessMode: ReadWriteOnce
+      size: 20Gi
+      storageClass: gce-ssd
+
+configEnvVars:
+- name: ATHENS_GO_BINARY_ENV_VARS
+  value: GOPROXY=https://proxy.golang.org,direct
+
+goGetWorkers: 5
+
+metrics:
+  serviceMonitor:
+    enabled: true
+    namespace: monitoring
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: worker.gardener.cloud/system-components
+              operator: In
+              values:
+                - "true"
+
+resources:
+  requests:
+    cpu: 2
+    memory: 512Mi

--- a/config/prow/cluster/athens/kustomization.yaml
+++ b/config/prow/cluster/athens/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: athens
+
+resources:
+- athens_namespace.yaml
+- athens_deployment.yaml
+- athens_prometheus_rbac.yaml
+
+patches:
+  - path: athens-proxy.yaml
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: athens-proxy-test-connection
+
+transformers:
+    - |-
+        apiVersion: builtin
+        kind: PatchTransformer
+        metadata:
+          name: fix-servicemonitor-namespace
+        patch: '[{"op": "replace", "path": "/metadata/namespace", "value": "monitoring"}]'
+        target:
+          group: monitoring.coreos.com
+          kind: ServiceMonitor

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -347,7 +347,7 @@ presets:
       hostPath:
         path: /sys/fs/cgroup
         type: Directory
-# enable GOPROXY by default
+# enable GOPROXY by default and use local athens-proxy as primary choice
 - env:
   - name: GOPROXY
-    value: "https://proxy.golang.org"
+    value: "http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org"

--- a/config/prow/deploy.sh
+++ b/config/prow/deploy.sh
@@ -106,4 +106,14 @@ kubectl config use-context gardener-prow-build
 kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/monitoring/build-cluster"
 echo "$(color-green "done")"
 
+echo "$(color-step "Deploying athens components to gardener-prow-trusted cluster...")"
+kubectl config use-context gardener-prow-trusted
+kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/athens"
+echo "$(color-green "done")"
+
+echo "$(color-step "Deploying athens components to gardener-prow-build cluster...")"
+kubectl config use-context gardener-prow-build
+kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/athens"
+echo "$(color-green "done")"
+
 echo "$(color-green "SUCCESS")"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR deploys and enables [athens](https://github.com/gomods/athens) as `GOPROXY` on trusted and build clusters.
The primary intention of this change is reducing networking traffic for our tests.
https://proxy.golang.org is configured as backup `GOPROXY` in case `athens` is unavailable.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
