### PR TITLE
[cherry-picker] Support copying multiple release-notes to cherry-picked PR

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -689,9 +689,6 @@ func releaseNoteFromParentPR(prAuthor, org, repo string, num int, body string) s
 	var output string
 	potentialMatches := releaseNoteRe.FindAllStringSubmatch(body, -1)
 	for i, potentialMatch := range potentialMatches {
-		if potentialMatch == nil {
-			return ""
-		}
 		source := strings.TrimSpace(potentialMatch[4])
 		ref := strings.TrimSpace(potentialMatch[5])
 		if source == "" || ref == "" {

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -686,26 +686,33 @@ func normalize(input string) string {
 // parent PR and formats it as per the PR template so that
 // it can be copied to the cherry-pick PR.
 func releaseNoteFromParentPR(prAuthor, org, repo string, num int, body string) string {
-	potentialMatch := releaseNoteRe.FindStringSubmatch(body)
-	if potentialMatch == nil {
-		return ""
+	var output string
+	potentialMatches := releaseNoteRe.FindAllStringSubmatch(body, -1)
+	for i, potentialMatch := range potentialMatches {
+		if potentialMatch == nil {
+			return ""
+		}
+		source := strings.TrimSpace(potentialMatch[4])
+		ref := strings.TrimSpace(potentialMatch[5])
+		if source == "" || ref == "" {
+			source = fmt.Sprintf("github.com/%s/%s", org, repo)
+			ref = fmt.Sprintf("#%d", num)
+		}
+		author := strings.TrimSpace(potentialMatch[6])
+		if author == "" {
+			author = fmt.Sprintf("@%s", prAuthor)
+		}
+		output += fmt.Sprintf("```%s %s %s %s %s\n%s\n```",
+			strings.TrimSpace(potentialMatch[2]),
+			strings.TrimSpace(potentialMatch[3]),
+			source,
+			ref,
+			author,
+			strings.TrimSpace(potentialMatch[7]),
+		)
+		if i+1 < len(potentialMatches) {
+			output += "\n"
+		}
 	}
-	source := strings.TrimSpace(potentialMatch[4])
-	ref := strings.TrimSpace(potentialMatch[5])
-	if source == "" || ref == "" {
-		source = fmt.Sprintf("github.com/%s/%s", org, repo)
-		ref = fmt.Sprintf("#%d", num)
-	}
-	author := strings.TrimSpace(potentialMatch[6])
-	if author == "" {
-		author = fmt.Sprintf("@%s", prAuthor)
-	}
-	return fmt.Sprintf("```%s %s %s %s %s\n%s\n```",
-		strings.TrimSpace(potentialMatch[2]),
-		strings.TrimSpace(potentialMatch[3]),
-		source,
-		ref,
-		author,
-		strings.TrimSpace(potentialMatch[7]),
-	)
+	return output
 }

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -1172,6 +1172,16 @@ func TestReleaseNoteFromParentPR(t *testing.T) {
 			input:    "```feature developer #999\nUpdate the magic number from 42 to 49\n```",
 			expected: "```feature developer github.com/foo/bar #123 @foo-author\nUpdate the magic number from 42 to 49\n```",
 		},
+		{
+			name:     "test9",
+			input:    "```feature developer\nUpdate the magic number from 42 to 49\n```\n\n```feature operator\nUpdate another magic number\n```",
+			expected: "```feature developer github.com/foo/bar #123 @foo-author\nUpdate the magic number from 42 to 49\n```\n```feature operator github.com/foo/bar #123 @foo-author\nUpdate another magic number\n```",
+		},
+		{
+			name:     "test10",
+			input:    "foobar",
+			expected: "",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -1174,7 +1174,7 @@ func TestReleaseNoteFromParentPR(t *testing.T) {
 		},
 		{
 			name:     "test9",
-			input:    "```feature developer\nUpdate the magic number from 42 to 49\n```\n\n```feature operator\nUpdate another magic number\n```",
+			input:    "```feature developer\nUpdate the magic number from 42 to 49\n```\n```feature operator\nUpdate another magic number\n```",
 			expected: "```feature developer github.com/foo/bar #123 @foo-author\nUpdate the magic number from 42 to 49\n```\n```feature operator github.com/foo/bar #123 @foo-author\nUpdate another magic number\n```",
 		},
 		{


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Cherry-picker did not support copying multiple release notes section into the cherry-picked PR, but copied the first one only. This PR adds support to copy multiple release-notes to the cherry-picked PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
