### PR TITLE
Revert version of `gcsweb`

### DIFF
--- a/config/prow/cluster/gcsweb_deployment.yaml
+++ b/config/prow/cluster/gcsweb_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: gcsweb
-          image: gcr.io/k8s-prow/gcsweb:v20231127-6bd5ce71de
+          image: gcr.io/k8s-prow/gcsweb:v20231121-4e39ac27ea
           args:
             - -upgrade-proxied-http-to-https
             # buckets owned by gardener


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
This PR reverts the version of `gcsweb` to `gcr.io/k8s-prow/gcsweb:v20231121-4e39ac27ea`.
The current version introduced 
 breaks our setup because of an upstream regression introduced in https://github.com/kubernetes/test-infra/pull/31241.
With this change `gcsweb` is not accessible anymore but shows the following error message.
```
Error: error while processing object: googleapi: Error 403: Insufficient Permission, insufficientPermissions
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timebertt 
