### PR TITLE
Use `athens` as `GOPROXY` for image builds in `gardener/gardener` and `gardener/ci-infra`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 # Build container
 # ----------------
 FROM golang:1.21.4 AS builder
+ARG GOPROXY=https://proxy.golang.org,direct
+ENV GOPROXY=$GOPROXY
 LABEL stage=intermediate
 # Copy entire repository to image
 COPY . /code

--- a/config/jobs/ci-infra/build-ci-infra-images.yaml
+++ b/config/jobs/ci-infra/build-ci-infra-images.yaml
@@ -36,6 +36,7 @@ postsubmits:
         - --target=branch-cleaner
         - --add-date-sha-tag=true
         - --add-fixed-tag=latest
+        - --kaniko-arg=--build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted
         # to multiple build pods in parallel.

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -62,6 +62,7 @@ presubmits:
         - --context=/home/prow/go/src/github.com/gardener/ci-infra
         - --dockerfile=Dockerfile
         - --no-push
+        - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
         resources:
           requests:
             cpu: 6

--- a/config/jobs/gardener/gardener-build-dev-images.yaml
+++ b/config/jobs/gardener/gardener-build-dev-images.yaml
@@ -27,6 +27,7 @@ postsubmits:
         - --registry=eu.gcr.io/gardener-project/ci-infra
         - --target=golang-test
         - --context=hack/tools/image
+        - --kaniko-arg=--build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted
         # to multiple build pods in parallel.

--- a/config/jobs/gardener/gardener-test-builds.yaml
+++ b/config/jobs/gardener/gardener-test-builds.yaml
@@ -19,6 +19,7 @@ presubmits:
         - --context=/home/prow/go/src/github.com/gardener/gardener
         - --dockerfile=Dockerfile
         - --no-push
+        - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
         resources:
           requests:
             cpu: 6


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
After PR https://github.com/gardener/gardener/pull/8884 was merged we can now use `athens` as `GOPROXY` for test build and building our test images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke 
