### PR TITLE
Add job to build `shoot-rsyslog-relp` images on head updates

### DIFF
--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-build-images.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-build-images.yaml
@@ -1,0 +1,48 @@
+postsubmits:
+  gardener/gardener-extension-shoot-rsyslog-relp:
+  - name: post-gardener-extension-shoot-rsyslog-relp-build-images
+    cluster: gardener-prow-trusted
+    skip_if_only_changed: '^VERSION$'
+    branches:
+    - ^main$
+    annotations:
+      description: Gardener extension shoot-rsyslog-relp image build on main branch
+      testgrid-dashboards: gardener-extension-shoot-rsyslog-relp
+      testgrid-days-of-results: "60"
+    decorate: true
+    max_concurrency: 1
+    spec:
+      serviceAccountName: image-builder
+      containers:
+      - name: image-builder
+        image: eu.gcr.io/gardener-project/ci-infra/image-builder:v20231201-441840e
+        command:
+        - /image-builder
+        args:
+        - --log-level=info
+        - --docker-config-secret=gardener-prow-gcr-docker-config
+        - --registry=eu.gcr.io/gardener-project/gardener/extensions
+        - --cache-registry=eu.gcr.io/gardener-project/ci-infra/kaniko-cache
+        - --target=gardener-extension-shoot-rsyslog-relp
+        - --target=gardener-extension-shoot-rsyslog-relp-admission
+        - --add-version-tag=true
+        - --add-version-sha-tag=true
+        - --add-fixed-tag=latest
+        # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
+        # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted
+        # to multiple build pods in parallel.
+        # For a proper scheduling the combined resource requests of all build pods are assigned to this pod, even though it does not
+        # use them. The resource requests of build pods themselves are "0"
+        resources:
+          requests:
+            cpu: 6
+            memory: 2Gi
+      # Node selector is copied to build pods
+      nodeSelector:
+        dedicated: high-cpu
+      # Tolerations are copied to build pods
+      tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "high-cpu"
+        effect: "NoSchedule"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds a job config to run image builds on head updates of the `main` branch for the [`shoot-rsyslog-relp`](https://github.com/gardener/gardener-extension-shoot-rsyslog-relp) extension.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I will shortly open a PR which removes builds done by concourse for head-updates from that repository's `pipeline_definitions` - concourse will only be used for release builds.