### PR TITLE
Add `verify` make target and use it `presubmit` and `periodic` jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,14 +106,9 @@ check: $(GOIMPORTS) $(GOLANGCI_LINT)
 
 .PHONY: revendor
 revendor:
+	@echo "> Revendor"
 	@GO111MODULE=on go mod tidy
 	@GO111MODULE=on go mod vendor
-
-.PHONY: verify-vendor
-verify-vendor: revendor
-	@if !(git diff --quiet HEAD -- go.sum go.mod vendor); then \
-		echo "go module files or vendor folder are out of date, please run 'make revendor'"; exit 1; \
-	fi
 
 .PHONY: test
 test:
@@ -122,3 +117,13 @@ test:
 .PHONY: test-cov
 test-cov:
 	@./hack/test-cover.sh ./prow/...
+
+.PHONY: verify
+verify: check test verify-vendor
+
+.PHONY: verify-vendor
+verify-vendor: revendor
+	@echo "> Verify vendor"
+	@if !(git diff --quiet HEAD -- go.sum go.mod vendor); then \
+		echo "go module files or vendor folder are out of date, please run 'make revendor'"; exit 1; \
+	fi

--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -323,9 +323,7 @@ periodics:
       command:
       - make
       args:
-      - check
-      - test
-      - verify-vendor
+      - verify
       resources:
         limits:
           memory: 4Gi

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -37,9 +37,7 @@ presubmits:
         command:
         - make
         args:
-        - check
-        - test
-        - verify-vendor
+        - verify
         resources:
           limits:
             memory: 4Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds a `verify` make target and uses it presubmit and periodic jobs.
The change makes it easier to remove `vendoring` from `ci-infra` repository in a follow-up PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
