### PR TITLE
Fix target names for `shoot-rsyslog-relp` images

### DIFF
--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-build-images.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-build-images.yaml
@@ -23,8 +23,8 @@ postsubmits:
         - --docker-config-secret=gardener-prow-gcr-docker-config
         - --registry=eu.gcr.io/gardener-project/gardener/extensions
         - --cache-registry=eu.gcr.io/gardener-project/ci-infra/kaniko-cache
-        - --target=gardener-extension-shoot-rsyslog-relp
-        - --target=gardener-extension-shoot-rsyslog-relp-admission
+        - --target=shoot-rsyslog-relp
+        - --target=shoot-rsyslog-relp-admission
         - --add-version-tag=true
         - --add-version-sha-tag=true
         - --add-fixed-tag=latest


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind bug

**What this PR does / why we need it**:
This PR fixes the target names for the `shoot-rsyslog-relp` extension images so that they get created with correct registry names - `eu.gcr.io/gardener-project/gardener/extensions/shoot-rsyslog-relp` and `eu.gcr.io/gardener-project/gardener/extensions/shoot-rsyslog-relp-admission`
I've opened a PR in the extension's repository which changes the targets in its `Dockerfile` accordingly: https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/42

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
