### PR TITLE
Never initialize `logrus.StandardLogger().Formatter` in `main()` functions

### DIFF
--- a/prow/cmd/branch-cleaner/main.go
+++ b/prow/cmd/branch-cleaner/main.go
@@ -83,7 +83,7 @@ func gatherOptions() options {
 func main() {
 	logrusutil.Init(&logrusutil.DefaultFieldsFormatter{
 		PrintLineNumber:  true,
-		WrappedFormatter: &logrus.TextFormatter{},
+		WrappedFormatter: logrus.StandardLogger().Formatter,
 	})
 
 	o := gatherOptions()

--- a/prow/cmd/image-builder/main.go
+++ b/prow/cmd/image-builder/main.go
@@ -179,7 +179,7 @@ func getPodNamespace() (string, error) {
 func main() {
 	logrusutil.Init(&logrusutil.DefaultFieldsFormatter{
 		PrintLineNumber:  true,
-		WrappedFormatter: &logrus.TextFormatter{},
+		WrappedFormatter: logrus.StandardLogger().Formatter,
 	})
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/job-forker/main.go
+++ b/prow/cmd/job-forker/main.go
@@ -108,7 +108,7 @@ func gatherOptions() options {
 func main() {
 	logrusutil.Init(&logrusutil.DefaultFieldsFormatter{
 		PrintLineNumber:  true,
-		WrappedFormatter: &logrus.TextFormatter{},
+		WrappedFormatter: logrus.StandardLogger().Formatter,
 	})
 
 	o := gatherOptions()

--- a/prow/cmd/milestone-activator/main.go
+++ b/prow/cmd/milestone-activator/main.go
@@ -114,7 +114,7 @@ func gatherOptions() options {
 func main() {
 	logrusutil.Init(&logrusutil.DefaultFieldsFormatter{
 		PrintLineNumber:  true,
-		WrappedFormatter: &logrus.TextFormatter{},
+		WrappedFormatter: logrus.StandardLogger().Formatter,
 	})
 
 	o := gatherOptions()

--- a/prow/external-plugins/cherrypicker/main.go
+++ b/prow/external-plugins/cherrypicker/main.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-
 	"k8s.io/test-infra/pkg/flagutil"
 	"k8s.io/test-infra/prow/config/secret"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
@@ -86,7 +85,10 @@ func gatherOptions() options {
 }
 
 func main() {
-	logrusutil.ComponentInit()
+	logrusutil.Init(&logrusutil.DefaultFieldsFormatter{
+		PrintLineNumber:  true,
+		WrappedFormatter: logrus.StandardLogger().Formatter,
+	})
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)

--- a/prow/external-plugins/cla-assistant/main.go
+++ b/prow/external-plugins/cla-assistant/main.go
@@ -77,7 +77,10 @@ func gatherOptions() options {
 }
 
 func main() {
-	logrusutil.ComponentInit()
+	logrusutil.Init(&logrusutil.DefaultFieldsFormatter{
+		PrintLineNumber:  true,
+		WrappedFormatter: logrus.StandardLogger().Formatter,
+	})
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {
 		logrus.Fatalf("Invalid options: %v", err)


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Initializing `logrus.StandardLogger().Formatter` can be dangerous in case [prow secret agent ](https://github.com/kubernetes/test-infra/blob/master/prow/config/secret/agent.go) is used, because this may overwrite [the censoring logger](https://github.com/kubernetes/test-infra/blob/ce9ca273df909cf5c3acbbd4e3958f406951e691/prow/config/secret/agent.go#L39) which is setup in its `init()` function. This may result in secrets like tokens being logged.

Thus, this PR removes all initializations `logrus.StandardLogger().Formatter` in `main()` functions regardless prow secret manager is used or not.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
