### PR TITLE
Copy nginx:1.17.6 - used for registry-cache e2e tests

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -146,3 +146,8 @@ images:
   - 2.8.1
   - 2.8.2
   - 2.8.3
+# gardener-extension-registry-cache/test/e2e
+- source: nginx
+  destination: eu.gcr.io/gardener-project/3rd/nginx
+  tags:
+  - 1.17.6


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
In the registry-cache e2e tests we use nginx image from eu.gcr.io for the Shoot system components e2e tests. We have images in the Shoot system components such as apiserver-proxy which images come from eu.gcr.io

https://github.com/gardener/gardener-extension-registry-cache/blob/53e0ff524197779efa5d252ca8819a5b110d82a5/test/common/common.go#L49-L50

https://github.com/gardener/gardener-extension-registry-cache/blob/90dfa7829651c766a3ee7a4d2bde3b5a1a835b97/test/e2e/create_enabled_delete_shoot_system_components_test.go#L57-L58

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A