### PR TITLE
Prepare switch from GCR to Artifact-Registry

### DIFF
--- a/config/images/README.md
+++ b/config/images/README.md
@@ -11,13 +11,13 @@ The images needed are all listed inside the `images.yaml` with the following sch
 ```yaml
 images:
 - source: kubernetesui/dashboard
-  destination: eu.gcr.io/gardener-project/3rd/kubernetesui/dashboard
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/kubernetesui/dashboard
   tags:
   - v2.2.0
   - v2.4.0
   - v2.5.1
 - source: envoyproxy/envoy-distroless
-  destination: eu.gcr.io/gardener-project/3rd/envoyproxy/envoy-distroless
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/envoyproxy/envoy-distroless
   tags:
   - v1.24.1
 ```
@@ -48,11 +48,11 @@ You can run the `copy-images.sh` script with
 
 You can start the script inside the container from the current directory with
 ```bash
-docker run -v $PWD:/app eu.gcr.io/gardener-project/ci-infra/copy-images:latest /app/copy-images.sh /app/images.yaml
+docker run -v $PWD:/app europe-docker.pkg.dev/gardener-project/releases/ci-infra/copy-images:latest /app/copy-images.sh /app/images.yaml
 ```
 
 **Authentication**  
 In order to authenticate inside the container, mount your `~/.docker/config.json` to `/root/.docker/config.json`.
 ```bash
-docker run -v $PWD:/app -v ~/.docker/config.json:/root/.docker/config.json eu.gcr.io/gardener-project/ci-infra/copy-images:latest /app/copy-images.sh /app/images.yaml
+docker run -v $PWD:/app -v ~/.docker/config.json:/root/.docker/config.json europe-docker.pkg.dev/gardener-project/releases/ci-infra/copy-images:latest /app/copy-images.sh /app/images.yaml
 ```

--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -4,27 +4,27 @@ images:
 # DO NOT ADD NEW GRAFANA IMAGES.
 # With https://github.com/gardener/gardener/pull/7318 grafana is replaced by plutono.
 - source: grafana/grafana
-  destination: eu.gcr.io/gardener-project/3rd/grafana/grafana
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/grafana/grafana
   tags:
   - 7.5.17
 # DO NOT ADD NEW COREDNS IMAGES.
 # With https://github.com/gardener/gardener/pull/8192 a GCR copy image is no longer used for coredns.
 - source: coredns/coredns
-  destination: eu.gcr.io/gardener-project/3rd/coredns/coredns
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/coredns/coredns
   tags:
   - 1.10.0
 - source: kubernetesui/dashboard
-  destination: eu.gcr.io/gardener-project/3rd/kubernetesui/dashboard
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/kubernetesui/dashboard
   tags:
   - v2.2.0
   - v2.4.0
   - v2.5.1
 - source: kubernetesui/metrics-scraper
-  destination: eu.gcr.io/gardener-project/3rd/kubernetesui/metrics-scraper
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/kubernetesui/metrics-scraper
   tags:
   - v1.0.7
 - source: alpine
-  destination: eu.gcr.io/gardener-project/3rd/alpine
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/alpine
   tags:
   - 3.15.4
   - 3.15.8
@@ -32,17 +32,17 @@ images:
 # DO NOT ADD NEW FLUENT/FLUENT-BIT IMAGES.
 # With https://github.com/gardener/gardener/pull/7568 the fluent/fluent-bit image is replaced by kubesphere/fluent-bit.
 - source: fluent/fluent-bit
-  destination: eu.gcr.io/gardener-project/3rd/fluent/fluent-bit
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent/fluent-bit
   tags:
   - 1.9.7
 - source: kubesphere/fluent-bit # A custom Fluent Bit image `kubesphere/fluent-bit` is required to work with FluentBit Operator for dynamic configuration reloading, ref: https://github.com/fluent/fluent-operator#fluent-bit
-  destination: eu.gcr.io/gardener-project/3rd/kubesphere/fluent-bit
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-bit
   tags:
   - v2.0.9
   - v2.0.10
   - v2.1.4
 - source: kubesphere/fluent-operator
-  destination: eu.gcr.io/gardener-project/3rd/kubesphere/fluent-operator
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-operator
   tags:
   - v1.7.0
   - v2.2.0
@@ -50,32 +50,32 @@ images:
 # DO NOT ADD NEW LOKI IMAGES.
 # With https://github.com/gardener/gardener/pull/7318 loki is replaced by vali.
 - source: grafana/loki
-  destination: eu.gcr.io/gardener-project/3rd/grafana/loki
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/grafana/loki
   tags:
   - 2.2.1
 # DO NOT ADD NEW PROMTAIL IMAGES.
 # With https://github.com/gardener/gardener/pull/7318 promtail is replaced by valitail.
 - source: grafana/promtail
-  destination: eu.gcr.io/gardener-project/3rd/grafana/promtail
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/grafana/promtail
   tags:
   - 2.2.1
 - source: envoyproxy/envoy-distroless
-  destination: eu.gcr.io/gardener-project/3rd/envoyproxy/envoy-distroless
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/envoyproxy/envoy-distroless
   tags:
   - v1.24.1
   - v1.26.4
 # gardener/pkg/provider-local/images.yaml
 - source: kindest/local-path-provisioner
-  destination: eu.gcr.io/gardener-project/3rd/kindest/local-path-provisioner
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/kindest/local-path-provisioner
   tags:
   - v0.0.22-kind.0
 - source: kindest/local-path-helper
-  destination: eu.gcr.io/gardener-project/3rd/kindest/local-path-helper
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/kindest/local-path-helper
   tags:
   - v20220512-507ff70b
 # gardener/test (Gardener integration tests)
 - source: redis
-  destination: eu.gcr.io/gardener-project/3rd/redis
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/redis
   tags:
   - 5.0.8
 # gardener-extension-networking-calico/charts/images.yaml
@@ -83,43 +83,43 @@ images:
 # DO NOT ADD NEW CALICO IMAGES.
 # With https://github.com/gardener/gardener-extension-networking-calico/pull/275 GCR copy images are no longer used for the calico images.
 - source: calico/node
-  destination: eu.gcr.io/gardener-project/3rd/calico/node
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/calico/node
   tags:
   - v3.25.1
   - v3.25.0
   - v3.22.2
 - source: calico/cni
-  destination: eu.gcr.io/gardener-project/3rd/calico/cni
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/calico/cni
   tags:
   - v3.25.1
   - v3.25.0
   - v3.22.2
 - source: calico/typha
-  destination: eu.gcr.io/gardener-project/3rd/calico/typha
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/calico/typha
   tags:
   - v3.25.1
   - v3.25.0
   - v3.22.2
 - source: calico/kube-controllers
-  destination: eu.gcr.io/gardener-project/3rd/calico/kube-controllers
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/calico/kube-controllers
   tags:
   - v3.25.1
   - v3.25.0
   - v3.22.2
 - source: calico/pod2daemon-flexvol
-  destination: eu.gcr.io/gardener-project/3rd/calico/pod2daemon-flexvol
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/calico/pod2daemon-flexvol
   tags:
   - v3.22.2
 # gardener-extension-provider-equinix-metal/charts/images.yaml
 - source: equinix/cloud-provider-equinix-metal
-  destination: eu.gcr.io/gardener-project/3rd/equinix/cloud-provider-equinix-metal
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/equinix/cloud-provider-equinix-metal
   tags:
   - v3.5.0
   - v3.6.0
   - v3.6.1
   - v3.6.2
 - source: packethost/metabot
-  destination: eu.gcr.io/gardener-project/3rd/packethost/metabot
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/packethost/metabot
   tags:
   - v1.0.0
 # gardener-extension-provider-openstack/charts/images.yaml
@@ -127,13 +127,13 @@ images:
 # DO NOT ADD NEW OPENSTACK IMAGES.
 # With https://github.com/gardener/gardener-extension-provider-openstack/pull/593 GCR copy images are no longer used for the openstack-cloud-controller-manager and cinder-csi-plugin images.
 - source: k8scloudprovider/openstack-cloud-controller-manager
-  destination: eu.gcr.io/gardener-project/3rd/k8scloudprovider/openstack-cloud-controller-manager
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/k8scloudprovider/openstack-cloud-controller-manager
   tags:
   - v1.21.0
   - v1.22.2
   - v1.23.4
 - source: k8scloudprovider/cinder-csi-plugin
-  destination: eu.gcr.io/gardener-project/3rd/k8scloudprovider/cinder-csi-plugin
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/k8scloudprovider/cinder-csi-plugin
   tags:
   - v1.20.3
   - v1.21.0
@@ -141,7 +141,7 @@ images:
   - v1.23.4
 # gardener-extension-registry-cache/charts/images.yaml
 - source: registry
-  destination: eu.gcr.io/gardener-project/3rd/registry
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/registry
   tags:
   - 2.8.1
   - 2.8.2

--- a/config/jobs/ci-infra/build-ci-infra-images.yaml
+++ b/config/jobs/ci-infra/build-ci-infra-images.yaml
@@ -19,14 +19,14 @@ postsubmits:
       serviceAccountName: image-builder
       containers:
       - name: image-builder
-        image: eu.gcr.io/gardener-project/ci-infra/image-builder:v20231219-49e31fd
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/image-builder:v20231219-49e31fd
         command:
         - /image-builder
         args:
         - --log-level=info
         - --docker-config-secret=gardener-prow-gcr-docker-config
-        - --registry=eu.gcr.io/gardener-project/ci-infra
-        - --cache-registry=eu.gcr.io/gardener-project/ci-infra/kaniko-cache
+        - --registry=europe-docker.pkg.dev/gardener-project/releases/ci-infra
+        - --cache-registry=europe-docker.pkg.dev/gardener-project/snapshots/ci-infra/kaniko-cache
         - --target=cherrypicker
         - --target=cla-assistant
         - --target=image-builder

--- a/config/jobs/ci-infra/build-job-images.yaml
+++ b/config/jobs/ci-infra/build-job-images.yaml
@@ -18,13 +18,13 @@ postsubmits:
       serviceAccountName: image-builder
       containers:
       - name: image-builder
-        image: eu.gcr.io/gardener-project/ci-infra/image-builder:v20231219-49e31fd
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/image-builder:v20231219-49e31fd
         command:
         - /image-builder
         args:
         - --log-level=info
         - --docker-config-secret=gardener-prow-gcr-docker-config
-        - --registry=eu.gcr.io/gardener-project/ci-infra
+        - --registry=europe-docker.pkg.dev/gardener-project/releases/ci-infra
         - --target=copy-images
         - --dockerfile=images/copy-images/Dockerfile
         - --add-date-sha-tag=true
@@ -65,13 +65,13 @@ postsubmits:
       serviceAccountName: image-builder
       containers:
       - name: image-builder
-        image: eu.gcr.io/gardener-project/ci-infra/image-builder:v20231219-49e31fd
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/image-builder:v20231219-49e31fd
         command:
         - /image-builder
         args:
         - --log-level=info
         - --docker-config-secret=gardener-prow-gcr-docker-config
-        - --registry=eu.gcr.io/gardener-project/ci-infra
+        - --registry=europe-docker.pkg.dev/gardener-project/releases/ci-infra
         - --target=krte
         - --context=images/krte
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule

--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -88,7 +88,7 @@ periodics:
       channel: prow-alerts
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/job-forker:v20231219-49e31fd
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/job-forker:v20231219-49e31fd
       command:
       - /job-forker
       args:
@@ -319,7 +319,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       command:
       - make
       args:
@@ -344,7 +344,7 @@ periodics:
       channel: prow-alerts
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/branch-cleaner:v20231219-49e31fd
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/branch-cleaner:v20231219-49e31fd
       command:
       - /branch-cleaner
       args:

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -33,7 +33,7 @@ presubmits:
       description: Runs go tests for prow developments in ci-infra 
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         command:
         - make
         args:

--- a/config/jobs/ci-infra/copy-images.yaml
+++ b/config/jobs/ci-infra/copy-images.yaml
@@ -17,7 +17,7 @@ postsubmits:
     spec:
       containers:
       - name: copy-images
-        image: eu.gcr.io/gardener-project/ci-infra/copy-images:v20231208-f745421
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/copy-images:v20231208-f745421
         command:
         - ./config/images/copy-images.sh
         args:

--- a/config/prow/autobump-config/prow-component-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-component-autobump-config.yaml
@@ -24,7 +24,7 @@ prefixes:
     summarise: true
     consistentImages: true
   - name: "Prow - ci-infra"
-    prefix: "eu.gcr.io/gardener-project/ci-infra/"
+    prefix: "europe-docker.pkg.dev/gardener-project/releases/ci-infra/"
     refConfigFile: "config/prow/cluster/cla_assistant_deployment.yaml"
     repo: "https://github.com/gardener/ci-infra"
     summarise: true

--- a/config/prow/cluster/cherrypicker_deployment.yaml
+++ b/config/prow/cluster/cherrypicker_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: eu.gcr.io/gardener-project/ci-infra/cherrypicker:v20231219-49e31fd
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/cherrypicker:v20231219-49e31fd
         imagePullPolicy: Always
         args:
         - --github-token-path=/etc/github/token

--- a/config/prow/cluster/cla_assistant_deployment.yaml
+++ b/config/prow/cluster/cla_assistant_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cla-assistant
-        image: eu.gcr.io/gardener-project/ci-infra/cla-assistant:v20231219-49e31fd
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/cla-assistant:v20231219-49e31fd
         imagePullPolicy: Always
         args:
         - --dry-run=false


### PR DESCRIPTION
/kind technical-debt

**What this PR does / why we need it**

Prepare switching of Gardener-Pipelines to publish images from GCR to Artifact-Registry (motivated by [deprecation of GCR](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr)).

- configure 3rd-party images to be published to AR instead of GCR
- configure images used by/for prow to be published to AR instead of GCR

**Special notes for your reviewer**

