### PR TITLE
Switch GCR to Artifact-Registry

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -148,6 +148,6 @@ images:
   - 2.8.3
 # gardener-extension-registry-cache/test/e2e
 - source: nginx
-  destination: eu.gcr.io/gardener-project/3rd/nginx
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/nginx
   tags:
   - 1.17.6

--- a/config/jobs/dependency-watchdog/dependency-watchdog-build-dev-images.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-build-dev-images.yaml
@@ -15,14 +15,14 @@ postsubmits:
       serviceAccountName: image-builder
       containers:
       - name: image-builder
-        image: eu.gcr.io/gardener-project/ci-infra/image-builder:v20231219-49e31fd
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/image-builder:v20231219-49e31fd
         command:
         - /image-builder
         args:
         - --log-level=info
         - --docker-config-secret=gardener-prow-gcr-docker-config
-        - --registry=eu.gcr.io/gardener-project/gardener
-        - --cache-registry=eu.gcr.io/gardener-project/ci-infra/kaniko-cache
+        - --registry=europe-docker.pkg.dev/gardener-project/snapshots/gardener
+        - --cache-registry=europe-docker.pkg.dev/gardener-project/releases/ci-infra/kaniko-cache
         - --target=dependency-watchdog
         - --add-version-tag=true
         - --add-version-sha-tag=true

--- a/config/jobs/dependency-watchdog/dependency-watchdog-check-vulnerabilities.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-check-vulnerabilities.yaml
@@ -13,7 +13,7 @@ presubmits:
     spec:
       containers:
       - name: test
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230919-791e3fa-1.19
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20230919-791e3fa-1.19
         command:
         - make
         args:
@@ -36,7 +36,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230919-791e3fa-1.19
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20230919-791e3fa-1.19
       command:
       - make
       args:

--- a/config/jobs/dependency-watchdog/dependency-watchdog-test-builds.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-test-builds.yaml
@@ -34,14 +34,14 @@ presubmits:
       serviceAccountName: image-builder
       containers:
       - name: image-builder
-        image: eu.gcr.io/gardener-project/ci-infra/image-builder:v20231219-49e31fd
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/image-builder:v20231219-49e31fd
         command:
         - /image-builder
         args:
         - --log-level=info
         - --docker-config-secret=gardener-prow-gcr-docker-config
-        - --registry=eu.gcr.io/gardener-project/gardener
-        - --cache-registry=eu.gcr.io/gardener-project/ci-infra/kaniko-cache
+        - --registry=europe-docker.pkg.dev/gardener-project/snapshots/gardener
+        - --cache-registry=europe-docker.pkg.dev/gardener-project/snapshots/ci-infra/kaniko-cache
         - --target=dependency-watchdog
         - --add-version-sha-tag=true
         - --inject-effective-version=true

--- a/config/jobs/dependency-watchdog/dependency-watchdog-unit-tests.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-unit-tests.yaml
@@ -13,7 +13,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230919-791e3fa-1.19
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20230919-791e3fa-1.19
         command:
         - make
         args:
@@ -46,7 +46,7 @@ periodics:
     containers:
     # Run all tests sequentially in one container or as separate prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20230919-791e3fa-1.19
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20230919-791e3fa-1.19
       command:
       - make
       args:

--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for extension-shoot-oidc-service developments in pull requests
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-unit-tests.yaml
+++ b/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-networking-calico developments in pull requests
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-networking-cilium/gardener-extension-networking-cilium-unit-tests.yaml
+++ b/config/jobs/gardener-extension-networking-cilium/gardener-extension-networking-cilium-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-networking-cilium developments in pull requests
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-build-images.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-build-images.yaml
@@ -15,14 +15,14 @@ postsubmits:
       serviceAccountName: image-builder
       containers:
       - name: image-builder
-        image: eu.gcr.io/gardener-project/ci-infra/image-builder:v20231219-49e31fd
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/image-builder:v20231219-49e31fd
         command:
         - /image-builder
         args:
         - --log-level=info
         - --docker-config-secret=gardener-prow-gcr-docker-config
-        - --registry=eu.gcr.io/gardener-project/gardener/extensions
-        - --cache-registry=eu.gcr.io/gardener-project/ci-infra/kaniko-cache
+        - --registry=europe-docker.pkg.dev/gardener-project/snapshots/gardener/extensions
+        - --cache-registry=europe-docker.pkg.dev/gardener-project/snapshots/ci-infra/kaniko-cache
         - --target=registry-cache
         - --target=registry-cache-admission
         - --add-version-tag=true

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-registry-cache developments in pull requests
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-test-builds.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-test-builds.yaml
@@ -30,14 +30,14 @@ presubmits:
       serviceAccountName: image-builder
       containers:
       - name: image-builder
-        image: eu.gcr.io/gardener-project/ci-infra/image-builder:v20231219-49e31fd
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/image-builder:v20231219-49e31fd
         command:
         - /image-builder
         args:
         - --log-level=info
         - --docker-config-secret=gardener-prow-gcr-docker-config
-        - --registry=eu.gcr.io/gardener-project/gardener/extensions
-        - --cache-registry=eu.gcr.io/gardener-project/ci-infra/kaniko-cache
+        - --registry=europe-docker.pkg.dev/gardener-project/snapshots/gardener/extensions
+        - --cache-registry=europe-docker.pkg.dev/gardener-project/snapshots/ci-infra/kaniko-cache
         - --target=registry-cache
         - --target=registry-cache-admission
         - --add-version-sha-tag=true

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for Gardener extension registry-cache developments in pull requests
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-shoot-networking-filter developments in pull requests
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-build-images.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-build-images.yaml
@@ -15,14 +15,14 @@ postsubmits:
       serviceAccountName: image-builder
       containers:
       - name: image-builder
-        image: eu.gcr.io/gardener-project/ci-infra/image-builder:v20231219-49e31fd
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/image-builder:v20231219-49e31fd
         command:
         - /image-builder
         args:
         - --log-level=info
         - --docker-config-secret=gardener-prow-gcr-docker-config
-        - --registry=eu.gcr.io/gardener-project/gardener/extensions
-        - --cache-registry=eu.gcr.io/gardener-project/ci-infra/kaniko-cache
+        - --registry=europe-docker.pkg.dev/gardener-project/snapshots/gardener/extensions
+        - --cache-registry=europe-docker.pkg.dev/gardener-project/snapshots/ci-infra/kaniko-cache
         - --target=shoot-rsyslog-relp
         - --target=shoot-rsyslog-relp-admission
         - --add-version-tag=true

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-integration-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-integration-tests.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         command:
         - make
         args:
@@ -44,7 +44,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for Gardener extension shoot-rsyslog-relp developments in pull requests
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       command:
       - make
       args:

--- a/config/jobs/gardener/gardener-apidiff.yaml
+++ b/config/jobs/gardener/gardener-apidiff.yaml
@@ -11,7 +11,7 @@ presubmits:
       containers:
       - name: test
         # don't update go version here until a go-apidiff release is available with new go version support.
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.20
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.20
         command:
         - make
         args:

--- a/config/jobs/gardener/gardener-branch-cleaner.yaml
+++ b/config/jobs/gardener/gardener-branch-cleaner.yaml
@@ -11,7 +11,7 @@ periodics:
       channel: prow-alerts
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/branch-cleaner:v20231219-49e31fd
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/branch-cleaner:v20231219-49e31fd
       command:
       - /branch-cleaner
       args:

--- a/config/jobs/gardener/gardener-build-dev-images.yaml
+++ b/config/jobs/gardener/gardener-build-dev-images.yaml
@@ -18,13 +18,13 @@ postsubmits:
       serviceAccountName: image-builder
       containers:
       - name: image-builder
-        image: eu.gcr.io/gardener-project/ci-infra/image-builder:v20231219-49e31fd
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/image-builder:v20231219-49e31fd
         command:
         - /image-builder
         args:
         - --log-level=info
         - --docker-config-secret=gardener-prow-gcr-docker-config
-        - --registry=eu.gcr.io/gardener-project/ci-infra
+        - --registry=europe-docker.pkg.dev/gardener-project/releases/ci-infra
         - --target=golang-test
         - --context=hack/tools/image
         - --kaniko-arg=--build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-migration-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration-ha-single-zone.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-operator.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         command:
         - make
         args:
@@ -47,7 +47,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       command:
       - make
       args:

--- a/config/jobs/gardener/gardener-release-handler.yaml
+++ b/config/jobs/gardener/gardener-release-handler.yaml
@@ -15,7 +15,7 @@ postsubmits:
     spec:
       containers:
       - name: release-handler
-        image: eu.gcr.io/gardener-project/ci-infra/release-handler:v20231219-49e31fd
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/release-handler:v20231219-49e31fd
         command:
         - /release-handler
         args:

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -16,7 +16,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         command:
         - make
         args:
@@ -53,7 +53,7 @@ periodics:
     containers:
     # Run all tests sequentially in one container or as separate prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       command:
       - make
       args:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-84.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-84.yaml
@@ -31,7 +31,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -71,7 +71,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -111,7 +111,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -151,7 +151,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -191,7 +191,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -231,7 +231,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -271,7 +271,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -311,7 +311,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -350,7 +350,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -381,7 +381,7 @@ periodics:
       - test-integration
       command:
       - make
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       name: test-integration
       resources:
         limits:
@@ -416,7 +416,7 @@ periodics:
       - test-prometheus
       command:
       - make
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       name: ""
       resources:
         limits:
@@ -455,7 +455,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -491,7 +491,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -527,7 +527,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -563,7 +563,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -599,7 +599,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -635,7 +635,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -671,7 +671,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -707,7 +707,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -742,7 +742,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -769,7 +769,7 @@ presubmits:
         - test-integration
         command:
         - make
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         name: test-integration
         resources:
           limits:
@@ -823,7 +823,7 @@ presubmits:
         - test-prometheus
         command:
         - make
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         name: ""
         resources:
           limits:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-85.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-85.yaml
@@ -31,7 +31,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -71,7 +71,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -111,7 +111,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -151,7 +151,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -191,7 +191,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -231,7 +231,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -271,7 +271,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -311,7 +311,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -350,7 +350,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -381,7 +381,7 @@ periodics:
       - test-integration
       command:
       - make
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       name: test-integration
       resources:
         limits:
@@ -416,7 +416,7 @@ periodics:
       - test-prometheus
       command:
       - make
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       name: ""
       resources:
         limits:
@@ -455,7 +455,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -491,7 +491,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -527,7 +527,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -563,7 +563,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -599,7 +599,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -635,7 +635,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -671,7 +671,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -707,7 +707,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -742,7 +742,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -769,7 +769,7 @@ presubmits:
         - test-integration
         command:
         - make
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         name: test-integration
         resources:
           limits:
@@ -823,7 +823,7 @@ presubmits:
         - test-prometheus
         command:
         - make
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         name: ""
         resources:
           limits:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-86.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-86.yaml
@@ -31,7 +31,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -71,7 +71,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -111,7 +111,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -151,7 +151,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -191,7 +191,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -231,7 +231,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -271,7 +271,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -311,7 +311,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -350,7 +350,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
       name: ""
       resources:
         requests:
@@ -381,7 +381,7 @@ periodics:
       - test-integration
       command:
       - make
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       name: test-integration
       resources:
         limits:
@@ -416,7 +416,7 @@ periodics:
       - test-prometheus
       command:
       - make
-      image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
       name: ""
       resources:
         limits:
@@ -455,7 +455,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -491,7 +491,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -527,7 +527,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -563,7 +563,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -599,7 +599,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -635,7 +635,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -671,7 +671,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -707,7 +707,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -742,7 +742,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: eu.gcr.io/gardener-project/ci-infra/krte:v20231219-49e31fd-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20231219-49e31fd-1.21
         name: ""
         resources:
           requests:
@@ -769,7 +769,7 @@ presubmits:
         - test-integration
         command:
         - make
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         name: test-integration
         resources:
           limits:
@@ -824,7 +824,7 @@ presubmits:
         - test-prometheus
         command:
         - make
-        image: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21
         name: ""
         resources:
           limits:

--- a/images/krte/variants.yaml
+++ b/images/krte/variants.yaml
@@ -1,7 +1,7 @@
 variants:
   "1.20":
-    IMAGE_ARG: eu.gcr.io/gardener-project/ci-infra/krte:1.20
-    golangtestimage: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.20
+    IMAGE_ARG: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:1.20
+    golangtestimage: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.20
   "1.21":
-    IMAGE_ARG: eu.gcr.io/gardener-project/ci-infra/krte:1.21
-    golangtestimage: eu.gcr.io/gardener-project/ci-infra/golang-test:v20231219-92940f4-1.21
+    IMAGE_ARG: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:1.21
+    golangtestimage: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20231219-92940f4-1.21


### PR DESCRIPTION
/kind technical-debt


**Special notes for your reviewer**

As discussed with @oliver-goetz : 

switch to `releases` registry (policy: keep all images "forever"):
- `image: eu.gcr.io/gardener-project/ci-infra/*`
- `--registry=eu.gcr.io/gardener-project/ci-infra`
- krte

Switch other occurrences to `snapshots` registry (policy: automatically purge any image after 30d).