### PR TITLE
Fix alertmanager template file location

### DIFF
--- a/config/prow/cluster/monitoring/base-prow/alertmanager/config.yaml
+++ b/config/prow/cluster/monitoring/base-prow/alertmanager/config.yaml
@@ -51,5 +51,5 @@ receivers:
 - name: 'null-receiver'
 
 templates:
-- slack-messages.tmpl
-- cluster-name.tmpl
+- /etc/alertmanager/config/slack-messages.tmpl
+- /etc/alertmanager/config/cluster-name.tmpl

--- a/config/prow/cluster/monitoring/base-prow/kustomization.yaml
+++ b/config/prow/cluster/monitoring/base-prow/kustomization.yaml
@@ -34,6 +34,13 @@ patches:
 - path: prometheusAdapter-deployment.yaml
 - path: prometheusAdapter-service.yaml
 - path: prometheusOperator-deployment.yaml
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: prometheus-operator
+    namespace: monitoring
+  path: prometheusOperator-deployment-patch.yaml
 - patch: |-
     $patch: delete
     apiVersion: v1

--- a/config/prow/cluster/monitoring/base-prow/prometheusOperator-deployment-patch.yaml
+++ b/config/prow/cluster/monitoring/base-prow/prometheusOperator-deployment-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: --config-reloader-cpu-limit=0


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
This PR sets an absolute path for alertmanager template. Alertmanager copies `alertmanager.yaml` to `/etc/alertmanager/config_out/alertmanager.env.yaml` when it is running, so it is not in the same directory as the template files anymore. 

Additionally, it removes CPU limits for config-reloader containers, because they too often create throttling alerts.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
