### PR TITLE
Added new prow job with feature gate turned off to run etcd-druid e2e tests with etcd-custom-image.

### DIFF
--- a/config/jobs/etcd-druid/druid-e2e-kind-nondistroless-etcd.yaml
+++ b/config/jobs/etcd-druid/druid-e2e-kind-nondistroless-etcd.yaml
@@ -13,7 +13,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-kind-volume-mounts: "true"
       annotations:
-        description: Runs KIND cluster based e2e tests for etcd druid developments in pull requests with activated alpha features
+        description: Runs KIND cluster based e2e tests for etcd druid developments in pull requests with etcd-custom-image(nondistroless-etcd).
       spec:
         containers:
           - image: gcr.io/k8s-staging-test-infra/krte:v20231208-8b9fd88e88-master
@@ -48,7 +48,7 @@ periodics:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     annotations:
-      description: Runs KIND cluster based e2e tests for etcd druid developments periodically with activated alpha features
+      description: Runs KIND cluster based e2e tests for etcd druid developments periodically with etcd-custom-image(nondistroless-etcd).
       testgrid-dashboards: gardener-etcd-druid
       testgrid-days-of-results: "60"
     spec:

--- a/config/jobs/etcd-druid/druid-e2e-kind-nondistroless-etcd.yaml
+++ b/config/jobs/etcd-druid/druid-e2e-kind-nondistroless-etcd.yaml
@@ -1,6 +1,6 @@
 presubmits:
   gardener/etcd-druid:
-    - name: pull-etcd-druid-e2e-kind-alpha-features
+    - name: pull-etcd-druid-e2e-kind-nondistroless-etcd
       cluster: gardener-prow-build
       always_run: true
       skip_branches:
@@ -31,9 +31,9 @@ presubmits:
                 memory: 8Gi
             env:
             - name: USE_ETCD_DRUID_FEATURE_GATES
-              value: "true"
+              value: "false"
 periodics:
-  - name: ci-etcd-druid-e2e-kind-alpha-features
+  - name: ci-etcd-druid-e2e-kind-nondistroless-etcd
     cluster: gardener-prow-build
     interval: 4h
     extra_refs:
@@ -68,4 +68,4 @@ periodics:
               memory: 8Gi
           env:
           - name: USE_ETCD_DRUID_FEATURE_GATES
-            value: "true"
+            value: "false"


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:
The `UseEtcdWrapper` feature in etcd-druid is transitioning from alpha to beta stage, and will be set as the default option in etcd-druid. Hence, `etcd-wrapper` will be used to run druid end-to-end (e2e) tests in pipeline.

However, we will continue to support etcd-custom-image(nondistroless-etcd). Therefore, the druid pipeline still requires to run druid e2e tests with etcd-custom-image.



**Which issue(s) this PR fixes**:
Fixes # https://github.com/gardener/etcd-druid/issues/743

**Special notes for your reviewer**:
cc @aaronfern @shreyas-s-rao 
