### PR TITLE
Enable autobumping `gcsweb` again

### DIFF
--- a/config/prow/cluster/gcsweb_deployment.yaml
+++ b/config/prow/cluster/gcsweb_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: gcsweb
-          image: gcr.io/k8s-prow/gcsweb@sha256:d236a4b6a627569a6946800359506ec9393fd254278519d39b73891103cfcf32
+          image: gcr.io/k8s-prow/gcsweb:v20240109-ae9036acf5
           args:
             - -upgrade-proxied-http-to-https
             # buckets owned by gardener


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Now that the upstream bug was fixed with PR https://github.com/kubernetes/test-infra/pull/31364, we can enable autombump for `gcsweb` again.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timebertt 
