### PR TITLE
Bump up container images: fluent-bit to v2.2.0 and fluent-operator to…

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -41,12 +41,14 @@ images:
   - v2.0.9
   - v2.0.10
   - v2.1.4
+  - v2.2.0
 - source: kubesphere/fluent-operator
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-operator
   tags:
   - v1.7.0
   - v2.2.0
   - v2.3.0
+  - v2.7.0
 # DO NOT ADD NEW LOKI IMAGES.
 # With https://github.com/gardener/gardener/pull/7318 loki is replaced by vali.
 - source: grafana/loki


### PR DESCRIPTION
/kind enhancement

This PR brings the latest container images of fluent-operator (v2.7.0) and fluent-bit (v2.2.0)
Currently used fluent-bits (v2.1.4) are to be upgraded to v2.2.0 due to public security vulnerabilities reported in the older version. 
