### PR TITLE
Update golang-test of `gardener/dependency-watchdog` to Go 1.21

### DIFF
--- a/config/jobs/dependency-watchdog/dependency-watchdog-check-vulnerabilities.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-check-vulnerabilities.yaml
@@ -13,7 +13,7 @@ presubmits:
     spec:
       containers:
       - name: test
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20230919-791e3fa-1.19
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20230919-791e3fa-1.21
         command:
         - make
         args:
@@ -36,7 +36,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20230919-791e3fa-1.19
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20230919-791e3fa-1.21
       command:
       - make
       args:

--- a/config/jobs/dependency-watchdog/dependency-watchdog-unit-tests.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-unit-tests.yaml
@@ -13,7 +13,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20230919-791e3fa-1.19
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20230919-791e3fa-1.21
         command:
         - make
         args:
@@ -46,7 +46,7 @@ periodics:
     containers:
     # Run all tests sequentially in one container or as separate prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20230919-791e3fa-1.19
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20230919-791e3fa-1.21
       command:
       - make
       args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Update golang-test of gardener/dependency-watchdog tests to Go 1.21

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
