### PR TITLE
Fix `ulimit` error in `krte` image when starting docker service with docker-ce 25.0.0

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -89,6 +89,7 @@ RUN echo "Installing Packages ..." \
         && apt-get install -y --no-install-recommends docker-ce docker-buildx-plugin \
         && rm -rf /var/lib/apt/lists/* \
         && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
+        && sed -i 's/ulimit -Hn/# ulimit -Hn/g' /etc/init.d/docker \
     && echo "Ensuring Legacy Iptables ..." \
         && update-alternatives --set iptables /usr/sbin/iptables-legacy \
         && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy

--- a/images/krte/wrapper.sh
+++ b/images/krte/wrapper.sh
@@ -32,7 +32,7 @@ set -o nounset
 
 >&2 echo "wrapper.sh] [INFO] Wrapping Test Command: \`$*\`"
 >&2 echo "wrapper.sh] [INFO] Running in: ${KRTE_IMAGE}"
->&2 echo "wrapper.sh] [INFO] See: https://github.com/kubernetes/test-infra/blob/master/images/krte/wrapper.sh"
+>&2 echo "wrapper.sh] [INFO] See: https://github.com/gardener/ci-infra/blob/master/images/krte/wrapper.sh"
 printf '%0.s=' {1..80} >&2; echo >&2
 >&2 echo "wrapper.sh] [SETUP] Performing pre-test setup ..."
 


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Starting docker in `krte` image fails with docker-ce 25.0.0 with an ulimit error ([ref](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/9048/pull-gardener-e2e-kind-upgrade/1749725781455540224)).
This PR applies removes the `ulimit` command from `/etc/init.d/docker` as suggested [here](https://github.com/docker/cli/issues/4807#issuecomment-1903950217).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
