### PR TITLE
Replace upstream `krte` images with gardener images

### DIFF
--- a/config/jobs/dependency-watchdog/dependency-watchdog-e2e-kind.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-e2e-kind.yaml
@@ -16,7 +16,7 @@ presubmits:
         description: Runs KIND cluster based e2e tests for dependency watchdog developments in pull requests
       spec:
         containers:
-          - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
             command:
               - wrapper.sh
               - bash
@@ -50,7 +50,7 @@ periodics:
       testgrid-days-of-results: "60"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
           command:
             - wrapper.sh
             - bash

--- a/config/jobs/etcd-druid/druid-e2e-kind-nondistroless-etcd.yaml
+++ b/config/jobs/etcd-druid/druid-e2e-kind-nondistroless-etcd.yaml
@@ -16,7 +16,7 @@ presubmits:
         description: Runs KIND cluster based e2e tests for etcd druid developments in pull requests with etcd-custom-image(nondistroless-etcd).
       spec:
         containers:
-          - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
             command:
             - wrapper.sh
             - bash
@@ -53,7 +53,7 @@ periodics:
       testgrid-days-of-results: "60"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
           command:
           - wrapper.sh
           - bash

--- a/config/jobs/etcd-druid/druid-e2e-kind.yaml
+++ b/config/jobs/etcd-druid/druid-e2e-kind.yaml
@@ -16,7 +16,7 @@ presubmits:
         description: Runs KIND cluster based e2e tests for etcd druid developments in pull requests
       spec:
         containers:
-          - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
             command:
             - wrapper.sh
             - bash
@@ -50,7 +50,7 @@ periodics:
       testgrid-days-of-results: "60"
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
           command:
           - wrapper.sh
           - bash

--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-oidc-service developments in pull requests
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-networking-calico developments in pull requests
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-networking-cilium/gardener-extension-networking-cilium-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-networking-cilium/gardener-extension-networking-cilium-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-networking-cilium developments in pull requests
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-networking-filter developments in pull requests
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for Gardener extension shoot-rsyslog-relp developments in pull requests
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/landscaper/landscaper-e2e-kind.yaml
+++ b/config/jobs/landscaper/landscaper-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for landscaper developments in pull requests
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/krte:v20240130-9db6d59ca0-master
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240129-6ed9d9f-1.21
         command:
         - wrapper.sh
         - bash


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Apparently, the upstream `krte` image is facing the same docker-ce 25.0.0 related issue now we fixed with https://github.com/gardener/ci-infra/pull/1108 ([ref](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener-extension-shoot-oidc-service/149/pull-extension-shoot-oidc-service-e2e-kind/1752607938695925760#1:build-log.txt%3A14-16)).
Thus, this PR switches those images to the Gardener ones.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
