### PR TITLE
Bump up fluent-bit container image to v2.2.2

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -42,6 +42,7 @@ images:
   - v2.0.10
   - v2.1.4
   - v2.2.0
+  - v2.2.2
 - source: kubesphere/fluent-operator
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-operator
   tags:


### PR DESCRIPTION
/kind enhancement

This PR brings the latest container images fluent-bit (v2.2.2)
Currently used fluent-bits (v2.2.0) are to be upgraded to v2.2.0 due to public security vulnerabilities reported in the older version.
