### PR TITLE
Copy registry:3.0.0-alpha.1

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -170,6 +170,7 @@ images:
   - 2.8.1
   - 2.8.2
   - 2.8.3
+  - 3.0.0-alpha.1
 # gardener-extension-registry-cache/test/e2e
 - source: nginx
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/nginx


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
We decided to evaluate the upgrade of the registry image to `registry:3.0.0-alpha.1`. Yes, it is an alpha image but it would unblock us with 2 tasks:
- the monitoring task: `3.0.0-alpha.1` exposes metrics of the proxy in prometheus native format
- configurable TTL: currently one of the limitations of the proxy is that the images TTL is hard-coded to 7 days. This means that a blob lives 7 days in the cache and after that it is always deleted. This reduces the effectiveness of the proxy. Bigger TTL values can make the proxy more effective. We want to expose the TTL field in the registry API.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/3

**Special notes for your reviewer**:
N/A