### PR TITLE
Build an `krte` image which uses `Go 1.22`

### DIFF
--- a/images/krte/variants.yaml
+++ b/images/krte/variants.yaml
@@ -5,3 +5,6 @@ variants:
   "1.21":
     IMAGE_ARG: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:1.21
     golangtestimage: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240208-8bd73f5-1.21
+  "1.22":
+    IMAGE_ARG: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:1.22
+    golangtestimage: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240208-8bd73f5-1.22


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
With this PR we build a version of `krte` image which uses `Go 1.22`, so that we can validate Gardener with Go 1.22.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke 
