### PR TITLE
Use registry-cache when running build verify prow jobs

### DIFF
--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -53,13 +53,15 @@ presubmits:
     spec:
       containers:
       - name: kaniko
-        image: gcr.io/kaniko-project/executor:v1.16.0
+        image: gcr.io/kaniko-project/executor:v1.20.1
         command:
         - /kaniko/executor
         args:
         - --context=/home/prow/go/src/github.com/gardener/ci-infra
         - --dockerfile=Dockerfile
         - --no-push
+        - --registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
+        - --insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
         - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
         resources:
           requests:

--- a/config/jobs/dependency-watchdog/dependency-watchdog-test-builds.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-test-builds.yaml
@@ -11,13 +11,15 @@ presubmits:
     spec:
       containers:
       - name: kaniko
-        image: gcr.io/kaniko-project/executor:v1.16.0
+        image: gcr.io/kaniko-project/executor:v1.20.1
         command:
         - /kaniko/executor
         args:
         - --context=/home/prow/go/src/github.com/gardener/dependency-watchdog
         - --dockerfile=Dockerfile
         - --no-push
+        - --registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
+        - --insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
         resources:
           requests:
             cpu: 6

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-test-builds.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-test-builds.yaml
@@ -9,13 +9,15 @@ presubmits:
     spec:
       containers:
       - name: kaniko
-        image: gcr.io/kaniko-project/executor:v1.16.0
+        image: gcr.io/kaniko-project/executor:v1.20.1
         command:
         - /kaniko/executor
         args:
         - --context=/home/prow/go/src/github.com/gardener/gardener-extension-registry-cache
         - --dockerfile=Dockerfile
         - --no-push
+        - --registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
+        - --insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
         resources:
           requests:
             cpu: 6

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-test-builds.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-test-builds.yaml
@@ -9,13 +9,15 @@ presubmits:
     spec:
       containers:
       - name: kaniko
-        image: gcr.io/kaniko-project/executor:v1.16.0
+        image: gcr.io/kaniko-project/executor:v1.20.1
         command:
         - /kaniko/executor
         args:
         - --context=/home/prow/go/src/github.com/gardener/gardener-extension-shoot-rsyslog-relp
         - --dockerfile=Dockerfile
         - --no-push
+        - --registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
+        - --insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
         resources:
           requests:
             cpu: 6

--- a/config/jobs/gardener/gardener-test-builds.yaml
+++ b/config/jobs/gardener/gardener-test-builds.yaml
@@ -12,13 +12,15 @@ presubmits:
     spec:
       containers:
       - name: kaniko
-        image: gcr.io/kaniko-project/executor:v1.16.0
+        image: gcr.io/kaniko-project/executor:v1.20.1
         command:
         - /kaniko/executor
         args:
         - --context=/home/prow/go/src/github.com/gardener/gardener
         - --dockerfile=Dockerfile
         - --no-push
+        - --registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
+        - --insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
         - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
         resources:
           requests:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-86.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-86.yaml
@@ -793,9 +793,11 @@ presubmits:
         - --dockerfile=Dockerfile
         - --no-push
         - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
+        - --registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
+        - --insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
         command:
         - /kaniko/executor
-        image: gcr.io/kaniko-project/executor:v1.16.0
+        image: gcr.io/kaniko-project/executor:v1.20.1
         name: kaniko
         resources:
           requests:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-87.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-87.yaml
@@ -793,9 +793,11 @@ presubmits:
         - --dockerfile=Dockerfile
         - --no-push
         - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
+        - --registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
+        - --insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
         command:
         - /kaniko/executor
-        image: gcr.io/kaniko-project/executor:v1.16.0
+        image: gcr.io/kaniko-project/executor:v1.20.1
         name: kaniko
         resources:
           requests:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-88.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-88.yaml
@@ -793,9 +793,11 @@ presubmits:
         - --dockerfile=Dockerfile
         - --no-push
         - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
+        - --registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
+        - --insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
         command:
         - /kaniko/executor
-        image: gcr.io/kaniko-project/executor:v1.16.0
+        image: gcr.io/kaniko-project/executor:v1.20.1
         name: kaniko
         resources:
           requests:

--- a/prow/cmd/image-builder/main.go
+++ b/prow/cmd/image-builder/main.go
@@ -110,7 +110,7 @@ func gatherOptions() options {
 	fs.StringVar(&o.buildVariant, "build-variant", "", "variant of a context which should be built. Builds all variants if empty")
 	fs.StringVar(&o.registry, "registry", "", "container registry where build artifacts are being pushed")
 	fs.StringVar(&o.cacheRegistry, "cache-registry", "", "container registry where cache artifacts are being pushed. Cache is disabled for empty value")
-	fs.StringVar(&o.kanikoImage, "kaniko-image", "gcr.io/kaniko-project/executor:v1.16.0", "kaniko image for kaniko build")
+	fs.StringVar(&o.kanikoImage, "kaniko-image", "gcr.io/kaniko-project/executor:v1.20.1", "kaniko image for kaniko build")
 	fs.BoolVar(&o.addVersionTag, "add-version-tag", false, "Add label from VERSION file of git root directory to image tags")
 	fs.BoolVar(&o.addVersionSHATag, "add-version-sha-tag", false, "Add label from VERSION file of git root directory plus SHA from git HEAD to image tags")
 	fs.BoolVar(&o.addDateSHATag, "add-date-sha-tag", false, "Using vYYYYMMDD-<rev short> scheme which is compatible to autobumper")


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR enables registry-cache for build verify prow jobs. At the moment kaniko is supporting a mirror for docker.io only.
Alongside, it updates kaniko to the latest version ([v1.20.1](https://github.com/GoogleContainerTools/kaniko/releases/tag/v1.20.1)).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
