### PR TITLE
Update registry-cache jobs to go@1.22

### DIFF
--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-registry-cache developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.22
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.22
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for Gardener extension registry-cache developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240212-3dce7f8-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240212-3dce7f8-1.22
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240212-3dce7f8-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240212-3dce7f8-1.22
       command:
       - make
       args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Related PR on registry-cache side - ref https://github.com/gardener/gardener-extension-registry-cache/pull/139.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A