### PR TITLE
Update `gardener` prow jobs to `go@1.22`

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.22
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.22
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.22
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.22
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/gardener/gardener-e2e-kind-migration-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration-ha-single-zone.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.22
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.22
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/gardener/gardener-e2e-kind-operator.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.22
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.22
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240212-9d312fe-1.22
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240212-3dce7f8-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240212-3dce7f8-1.22
         command:
         - make
         args:

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -16,7 +16,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240212-3dce7f8-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240212-3dce7f8-1.22
         command:
         - make
         args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR updates prow jobs for `gardener` to `go@1.22`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke 
It should be merged shortly before https://github.com/gardener/gardener/pull/9138

/hold