### PR TITLE
Remove Go 1.20 version of `krte` image

### DIFF
--- a/images/krte/variants.yaml
+++ b/images/krte/variants.yaml
@@ -1,7 +1,4 @@
 variants:
-  "1.20":
-    IMAGE_ARG: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:1.20
-    golangtestimage: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240216-792399a-1.20
   "1.21":
     IMAGE_ARG: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:1.21
     golangtestimage: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240219-eda15ab-1.21


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
Go 1.20 is deprecated, so we can remove the corresponding version of `krte` image too.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
