### PR TITLE
Update Go toolchain to `1.22.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/ci-infra
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
`ci-infra` are already built with Go 1.22.0. This PR updates the toolchain to the same version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
