### PR TITLE
Validate `renovate` config in PRs in `gardener/gardener`

### DIFF
--- a/config/jobs/gardener/gardener-check-renovate-config.yaml
+++ b/config/jobs/gardener/gardener-check-renovate-config.yaml
@@ -1,0 +1,14 @@
+presubmits:
+  gardener/gardener:
+  - name: pull-gardener-check-renovate-config
+    cluster: gardener-prow-build
+    always_run: true
+    annotations:
+      description: Validates renovate config on pull requests to master branch
+    decorate: true
+    spec:
+      containers:
+      - name: renovate
+        image: ghcr.io/renovatebot/renovate:37.203.3
+        command:
+        - renovate-config-validator


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Before we introduce `renovate` in `gardener/gardener` (see https://github.com/gardener/gardener/pull/9197), we should introduce a prow jobs which validates the configuration.
This is done in this PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
