### PR TITLE
Remove workaround for wrong scope in `oauth2-proxy`

### DIFF
--- a/config/prow/cluster/oauth2-proxy/helm/values.yaml
+++ b/config/prow/cluster/oauth2-proxy/helm/values.yaml
@@ -6,7 +6,6 @@ extraArgs:
   github-org: gardener
   github-user: timebertt
   email-domain: "*"
-  scope: "user:email"
 
 affinity:
   nodeAffinity:

--- a/config/prow/cluster/oauth2-proxy/oauth2-proxy-deployment.yaml
+++ b/config/prow/cluster/oauth2-proxy/oauth2-proxy-deployment.yaml
@@ -126,7 +126,6 @@ spec:
           - --github-org=gardener
           - --github-user=timebertt
           - --provider=github
-          - --scope=user:email
           - --whitelist-domain=.prow.gardener.cloud
           - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
         env:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
This PR removes a workaround in `oauth2-proxy` for a wrong default scope. This was fixed and now in version `7.6.0` the workaround is broken 😅  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
