### PR TITLE
Enable auto update for `renovate` between 8:30 and 15:30 GMT on every workday

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,6 +52,21 @@
       }
     },
     {
+      "groupName": "Renovate",
+      "matchDatasources": ["docker", "helm"],
+      "matchPackagePatterns": [
+        "^renovate$"
+      ],
+      "addLabels": ["skip-review"],
+      "schedule": ["after 08:30 and before 15:30 every weekday"]
+    },
+    {
+      // k8s.io/test-infra is too noisy because it does not create releases but is referenced by digest
+      "matchDatasources": ["go"],
+      "matchPackagePatterns": ["k8s\\.io\/test-infra"],
+      "extends": ["schedule:monthly"]
+    },
+    {
       // Do not update Kubernetes dependencies except k8s.io/test-infra.
       // The versions of api, apimachiner, client-go and controller-runtime depend on k8s.io/test-infra.
       "matchDatasources": ["go"],
@@ -60,12 +75,6 @@
         "sigs\\.k8s\\.io\/controller-runtime"
       ],
       "enabled": false
-    },
-    {
-      // k8s.io/test-infra is too noisy because it does not create releases but is referenced by digest
-      "matchDatasources": ["go"],
-      "matchPackagePatterns": ["k8s\\.io\/test-infra"],
-      "extends": ["schedule:monthly"]
     },
     {
       // Pin grafana to the latest minor version published with Apache 2.0 license

--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -142,7 +142,7 @@ periodics:
       secret:
         secretName: github-token
 
-- cron: "35 8-12 * * 1-5"
+- cron: "35 8-15 * * 1-5"
   name: ci-prow-autobump-autodeploy
   cluster: gardener-prow-trusted
   decorate: true


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
There are many self updates for `renovate`. Let's merge them automatically on workdays as we do it for `prow` too.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
