### PR TITLE
Add missing docker package to renovate auto-update package-rule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,10 +52,11 @@
       }
     },
     {
-      "groupName": "Renovate",
+      "groupName": "auto-update: renovate",
       "matchDatasources": ["docker", "helm"],
       "matchPackagePatterns": [
-        "^renovate$"
+        "^renovate$",
+        "^ghcr\\.io\/renovatebot\/renovate$"
       ],
       "addLabels": ["skip-review"],
       "schedule": ["after 08:30 and before 15:30 every weekday"]


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The docker package for renovate is `ghcr.io/renovatebot/renovate`, so the PRs for renovate test jobs are not labeled with `skip-review` yet.
This PR adds the package name.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
