### PR TITLE
Use `config:recommended` instead of `config:best-practices` in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices"
+    "config:recommended"
   ],
   "labels": ["kind/enhancement"],
   "postUpdateOptions": ["gomodTidy"],


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR switches the base of `renovate` config from `config:best-practices` to `config:recommended`.
`config:best-practices` tries to pin dependencies to their digests. This is undesired in our case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
