### PR TITLE
Update shoot-rsyslog-relp jobs to go@1.22

### DIFF
--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for Gardener extension shoot-rsyslog-relp developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240229-6c791a2-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240229-6c791a2-1.22
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240229-6c791a2-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240229-6c791a2-1.22
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-integration-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-integration-tests.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240228-64b5a86-1.21
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240228-64b5a86-1.22
         command:
         - make
         args:
@@ -44,7 +44,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240228-64b5a86-1.21
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240228-64b5a86-1.22
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for Gardener extension shoot-rsyslog-relp developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240228-64b5a86-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240228-64b5a86-1.22
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240228-64b5a86-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240228-64b5a86-1.22
       command:
       - make
       args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Related PR on shoot-rsyslog-relp side - ref https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/73

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
