### PR TITLE
Harmonize `GOPROXY` settings

### DIFF
--- a/config/jobs/ci-infra/build-ci-infra-images.yaml
+++ b/config/jobs/ci-infra/build-ci-infra-images.yaml
@@ -36,7 +36,7 @@ postsubmits:
         - --target=branch-cleaner
         - --add-date-sha-tag=true
         - --add-fixed-tag=latest
-        - --kaniko-arg=--build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
+        - --kaniko-arg=--build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,direct
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted
         # to multiple build pods in parallel.

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -62,7 +62,7 @@ presubmits:
         - --no-push
         - --registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
         - --insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
-        - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
+        - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,direct
         resources:
           requests:
             cpu: 6

--- a/config/jobs/gardener/gardener-build-dev-images.yaml
+++ b/config/jobs/gardener/gardener-build-dev-images.yaml
@@ -27,7 +27,7 @@ postsubmits:
         - --registry=europe-docker.pkg.dev/gardener-project/releases/ci-infra
         - --target=golang-test
         - --context=hack/tools/image
-        - --kaniko-arg=--build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
+        - --kaniko-arg=--build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,direct
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted
         # to multiple build pods in parallel.

--- a/config/jobs/gardener/gardener-test-builds.yaml
+++ b/config/jobs/gardener/gardener-test-builds.yaml
@@ -21,7 +21,7 @@ presubmits:
         - --no-push
         - --registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
         - --insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
-        - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
+        - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,direct
         resources:
           requests:
             cpu: 6

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-87.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-87.yaml
@@ -792,7 +792,7 @@ presubmits:
         - --context=/home/prow/go/src/github.com/gardener/gardener
         - --dockerfile=Dockerfile
         - --no-push
-        - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
+        - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,direct
         - --registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
         - --insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
         command:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-88.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-88.yaml
@@ -792,7 +792,7 @@ presubmits:
         - --context=/home/prow/go/src/github.com/gardener/gardener
         - --dockerfile=Dockerfile
         - --no-push
-        - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
+        - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,direct
         - --registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
         - --insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
         command:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-89.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-89.yaml
@@ -794,7 +794,7 @@ presubmits:
         - --no-push
         - --registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
         - --insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
-        - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
+        - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,direct
         command:
         - /kaniko/executor
         image: gcr.io/kaniko-project/executor:v1.21.0

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-90.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-90.yaml
@@ -794,7 +794,7 @@ presubmits:
         - --no-push
         - --registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
         - --insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
-        - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org
+        - --build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,direct
         command:
         - /kaniko/executor
         image: gcr.io/kaniko-project/executor:v1.21.0

--- a/config/prow/cluster/renovate/helm/values.yaml
+++ b/config/prow/cluster/renovate/helm/values.yaml
@@ -53,3 +53,6 @@ securityContext:
   runAsGroup: 1000
   fsGroup: 1000
   fsGroupChangePolicy: OnRootMismatch
+
+env:
+  GOPROXY: http://athens-proxy.athens.svc.cluster.local,direct

--- a/config/prow/cluster/renovate/renovate_deployment.yaml
+++ b/config/prow/cluster/renovate/renovate_deployment.yaml
@@ -100,6 +100,8 @@ spec:
               env:
                 - name: RENOVATE_CONFIG_FILE
                   value: /usr/src/app/config.json
+                - name: "GOPROXY"
+                  value: "http://athens-proxy.athens.svc.cluster.local,direct"
               envFrom:
                 - secretRef:
                     name: github

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -382,4 +382,4 @@ presets:
 # enable GOPROXY by default and use local athens-proxy as primary choice
 - env:
   - name: GOPROXY
-    value: "http://athens-proxy.athens.svc.cluster.local,https://proxy.golang.org"
+    value: "http://athens-proxy.athens.svc.cluster.local,direct"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR harmonizes `GOPROXY` settings and uses `GOPROXY=http://athens-proxy.athens.svc.cluster.local,direct` everywhere.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
