### PR TITLE
Update AWS ebs-csi-driver image in copy-list

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -141,6 +141,7 @@ images:
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/ebs-csi-driver/volume-modifier-for-k8s
   tags:
   - v0.1.3
+  - v0.2.1
 # gardener-extension-provider-equinix-metal/charts/images.yaml
 - source: equinix/cloud-provider-equinix-metal
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/equinix/cloud-provider-equinix-metal


### PR DESCRIPTION
/kind task

**What this PR does / why we need it**:
Adds the latest version of AWS's ebs-csi-driver image to the list of images to copy. This needs to happen prior to updating it in the provider-extension.
