### PR TITLE
Update location of `prow` go dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,14 +62,14 @@
       "schedule": ["after 08:30 and before 15:30 every weekday"]
     },
     {
-      // k8s.io/test-infra is too noisy because it does not create releases but is referenced by digest
+      // sigs.k8s.io/prow is too noisy because it does not create releases but is referenced by digest.
       "matchDatasources": ["go"],
-      "matchPackagePatterns": ["k8s\\.io\/test-infra"],
+      "matchPackagePatterns": ["sigs\\.k8s\\.io\/prow"],
       "extends": ["schedule:monthly"]
     },
     {
-      // Do not update Kubernetes dependencies except k8s.io/test-infra.
-      // The versions of api, apimachiner, client-go and controller-runtime depend on k8s.io/test-infra.
+      // Do not update Kubernetes dependencies except sigs.k8s.io/prow.
+      // The versions of api, apimachiner, client-go and controller-runtime depend on sigs.k8s.io/prow.
       "matchDatasources": ["go"],
       "matchPackagePatterns": [
         "k8s\\.io\/(api|apimachinery|client-go)",
@@ -78,7 +78,16 @@
       "enabled": false
     },
     {
-      // Pin grafana to the latest minor version published with Apache 2.0 license
+      // Do not update patch versions of the Go Toolchain.
+      // Default golang images set the environment variable GOTOOLCHAIN=local
+      // and we don't want to enforce every (test-)image to be on the latest patch level.
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch"],
+      "matchPackagePatterns": ["go"],
+      "enabled": false
+    },
+    {
+      // Pin grafana to the latest minor version published with Apache 2.0 license.
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["major", "minor"],
       "matchPackagePatterns": ["grafana/grafana"],

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/ci-infra
 
-go 1.22.2
+go 1.22.0
 
 require (
 	github.com/Masterminds/semver v1.5.0
@@ -16,8 +16,8 @@ require (
 	k8s.io/api v0.25.9
 	k8s.io/apimachinery v0.26.5
 	k8s.io/client-go v0.25.9
-	k8s.io/test-infra v0.0.0-20240402200411-ae65ab3f07bf
 	sigs.k8s.io/controller-runtime v0.12.3
+	sigs.k8s.io/prow v0.0.0-20240410004112-4be743f3ec63
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -29,6 +29,7 @@ require (
 	cloud.google.com/go/storage v1.28.1 // indirect
 	contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d // indirect
 	contrib.go.opencensus.io/exporter/prometheus v0.4.0 // indirect
+	github.com/Azure/azure-pipeline-go v0.2.2 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.29 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.22 // indirect
@@ -94,6 +95,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-ieproxy v0.0.1 // indirect
 	github.com/mattn/go-zglob v0.0.2 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -436,6 +436,7 @@ github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
+github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-ieproxy v0.0.1 h1:qiyop7gCflfhwCzGyeT0gro3sF9AIg9HU98JORTkqfI=
 github.com/mattn/go-ieproxy v0.0.1/go.mod h1:pYabZ6IHcRpFh7vIaLfK7rdcWgFEb3SFJ6/gNWuh88E=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -661,6 +662,7 @@ golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191002035440-2ec189313ef0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -735,6 +737,7 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191112214154-59a1497f0cea/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1040,8 +1043,6 @@ k8s.io/klog/v2 v2.90.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6/go.mod h1:UuqjUnNftUyPE5H64/qeyjQoUZhGpeFDVdxjTeEVN2o=
 k8s.io/kube-openapi v0.0.0-20230308215209-15aac26d736a h1:gmovKNur38vgoWfGtP5QOGNOA7ki4n6qNYoFAgMlNvg=
 k8s.io/kube-openapi v0.0.0-20230308215209-15aac26d736a/go.mod h1:y5VtZWM9sHHc2ZodIH/6SHzXj+TPU5USoA8lcIeKEKY=
-k8s.io/test-infra v0.0.0-20240402200411-ae65ab3f07bf h1:0xc8wXGa9cq3Jt1kEJE2yy+968SfOJLCHrqpNzbCjAc=
-k8s.io/test-infra v0.0.0-20240402200411-ae65ab3f07bf/go.mod h1:2eoHxXPfRvETWWaYJlV3fqdDJq6PGdr2Ia2nyhmLu4I=
 k8s.io/utils v0.0.0-20230209194617-a36077c30491 h1:r0BAOLElQnnFhE/ApUsg3iHdVYYPBjNSSOMowRZxxsY=
 k8s.io/utils v0.0.0-20230209194617-a36077c30491/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 knative.dev/pkg v0.0.0-20230221145627-8efb3485adcf h1:TwvZFDpkyqpK2OCAwvNGV2Zjk14FzIh8X8Ci/du3jYI=
@@ -1054,6 +1055,8 @@ sigs.k8s.io/controller-runtime v0.12.3 h1:FCM8xeY/FI8hoAfh/V4XbbYMY20gElh9yh+A98
 sigs.k8s.io/controller-runtime v0.12.3/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
+sigs.k8s.io/prow v0.0.0-20240410004112-4be743f3ec63 h1:Mjw0svnqhh/rjkvW5bovtoAuG0zmLlNW/4ZRUbNUrrk=
+sigs.k8s.io/prow v0.0.0-20240410004112-4be743f3ec63/go.mod h1:7rsZ1ej4cIWtv+w/+62mLOaGMONtsG663VD9eJ7UKL4=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=

--- a/prow/cmd/branch-cleaner/branchcleaner.go
+++ b/prow/cmd/branch-cleaner/branchcleaner.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/config"
-	"k8s.io/test-infra/prow/github"
+	"sigs.k8s.io/prow/prow/config"
+	"sigs.k8s.io/prow/prow/github"
 )
 
 type githubClient interface {

--- a/prow/cmd/branch-cleaner/branchcleaner_test.go
+++ b/prow/cmd/branch-cleaner/branchcleaner_test.go
@@ -10,8 +10,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/test-infra/prow/github"
-	"k8s.io/test-infra/prow/github/fakegithub"
+	"sigs.k8s.io/prow/prow/github"
+	"sigs.k8s.io/prow/prow/github/fakegithub"
 )
 
 type fakeGithubClient struct {

--- a/prow/cmd/branch-cleaner/main.go
+++ b/prow/cmd/branch-cleaner/main.go
@@ -11,8 +11,8 @@ import (
 	"regexp"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/flagutil"
-	"k8s.io/test-infra/prow/logrusutil"
+	"sigs.k8s.io/prow/prow/flagutil"
+	"sigs.k8s.io/prow/prow/logrusutil"
 )
 
 type options struct {

--- a/prow/cmd/image-builder/buildcontroller.go
+++ b/prow/cmd/image-builder/buildcontroller.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/test-infra/prow/interrupts"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/prow/prow/interrupts"
 	"sigs.k8s.io/yaml"
 )
 

--- a/prow/cmd/image-builder/buildcontroller_test.go
+++ b/prow/cmd/image-builder/buildcontroller_test.go
@@ -19,11 +19,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clgofake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/test-infra/prow/flagutil"
-	"k8s.io/test-infra/prow/interrupts"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/prow/prow/flagutil"
+	"sigs.k8s.io/prow/prow/interrupts"
 	"sigs.k8s.io/yaml"
 )
 

--- a/prow/cmd/image-builder/main.go
+++ b/prow/cmd/image-builder/main.go
@@ -17,13 +17,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	"k8s.io/test-infra/prow/flagutil"
-	"k8s.io/test-infra/prow/interrupts"
-	"k8s.io/test-infra/prow/logrusutil"
-	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	prowjobv1 "sigs.k8s.io/prow/prow/apis/prowjobs/v1"
+	"sigs.k8s.io/prow/prow/flagutil"
+	"sigs.k8s.io/prow/prow/interrupts"
+	"sigs.k8s.io/prow/prow/logrusutil"
+	"sigs.k8s.io/prow/prow/pod-utils/downwardapi"
 )
 
 type options struct {

--- a/prow/cmd/job-forker/forking.go
+++ b/prow/cmd/job-forker/forking.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/config"
-	"k8s.io/test-infra/prow/github"
+	"sigs.k8s.io/prow/prow/config"
+	"sigs.k8s.io/prow/prow/github"
 	"sigs.k8s.io/yaml"
 
 	ghi "github.com/gardener/ci-infra/prow/pkg/githubinteractor"

--- a/prow/cmd/job-forker/forking_test.go
+++ b/prow/cmd/job-forker/forking_test.go
@@ -7,9 +7,9 @@ package main
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	"k8s.io/test-infra/prow/config"
-	"k8s.io/test-infra/prow/github"
+	prowapi "sigs.k8s.io/prow/prow/apis/prowjobs/v1"
+	"sigs.k8s.io/prow/prow/config"
+	"sigs.k8s.io/prow/prow/github"
 )
 
 var (

--- a/prow/cmd/job-forker/main.go
+++ b/prow/cmd/job-forker/main.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/flagutil"
-	"k8s.io/test-infra/prow/logrusutil"
-	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+	"sigs.k8s.io/prow/prow/flagutil"
+	"sigs.k8s.io/prow/prow/logrusutil"
+	"sigs.k8s.io/prow/prow/pod-utils/downwardapi"
 
 	ghi "github.com/gardener/ci-infra/prow/pkg/githubinteractor"
 )

--- a/prow/cmd/milestone-activator/activator.go
+++ b/prow/cmd/milestone-activator/activator.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/config"
-	"k8s.io/test-infra/prow/github"
+	"sigs.k8s.io/prow/prow/config"
+	"sigs.k8s.io/prow/prow/github"
 
 	ghi "github.com/gardener/ci-infra/prow/pkg/githubinteractor"
 )

--- a/prow/cmd/milestone-activator/activator_test.go
+++ b/prow/cmd/milestone-activator/activator_test.go
@@ -11,7 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/test-infra/prow/github/fakegithub"
+	"sigs.k8s.io/prow/prow/github/fakegithub"
 )
 
 var _ = Describe("activator", func() {

--- a/prow/cmd/milestone-activator/main.go
+++ b/prow/cmd/milestone-activator/main.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/flagutil"
-	"k8s.io/test-infra/prow/logrusutil"
-	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+	"sigs.k8s.io/prow/prow/flagutil"
+	"sigs.k8s.io/prow/prow/logrusutil"
+	"sigs.k8s.io/prow/prow/pod-utils/downwardapi"
 
 	ghi "github.com/gardener/ci-infra/prow/pkg/githubinteractor"
 )

--- a/prow/cmd/release-handler/main.go
+++ b/prow/cmd/release-handler/main.go
@@ -10,12 +10,12 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
-	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	"k8s.io/test-infra/prow/config/secret"
-	"k8s.io/test-infra/prow/flagutil"
-	gitv2 "k8s.io/test-infra/prow/git/v2"
-	"k8s.io/test-infra/prow/github"
-	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+	prowjobv1 "sigs.k8s.io/prow/prow/apis/prowjobs/v1"
+	"sigs.k8s.io/prow/prow/config/secret"
+	"sigs.k8s.io/prow/prow/flagutil"
+	gitv2 "sigs.k8s.io/prow/prow/git/v2"
+	"sigs.k8s.io/prow/prow/github"
+	"sigs.k8s.io/prow/prow/pod-utils/downwardapi"
 )
 
 type options struct {

--- a/prow/cmd/release-handler/releasehandler.go
+++ b/prow/cmd/release-handler/releasehandler.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/sirupsen/logrus"
-	gitv2 "k8s.io/test-infra/prow/git/v2"
+	gitv2 "sigs.k8s.io/prow/prow/git/v2"
 )
 
 const (

--- a/prow/cmd/release-handler/releasehandler_test.go
+++ b/prow/cmd/release-handler/releasehandler_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/Masterminds/semver"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/test-infra/prow/git/localgit"
-	gitv2 "k8s.io/test-infra/prow/git/v2"
+	"sigs.k8s.io/prow/prow/git/localgit"
+	gitv2 "sigs.k8s.io/prow/prow/git/v2"
 )
 
 var _ = Describe("ReleaseHandler", func() {

--- a/prow/external-plugins/cherrypicker/main.go
+++ b/prow/external-plugins/cherrypicker/main.go
@@ -25,13 +25,13 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/pkg/flagutil"
-	"k8s.io/test-infra/prow/config/secret"
-	prowflagutil "k8s.io/test-infra/prow/flagutil"
-	"k8s.io/test-infra/prow/interrupts"
-	"k8s.io/test-infra/prow/logrusutil"
-	"k8s.io/test-infra/prow/pjutil"
-	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
+	"sigs.k8s.io/prow/pkg/flagutil"
+	"sigs.k8s.io/prow/prow/config/secret"
+	prowflagutil "sigs.k8s.io/prow/prow/flagutil"
+	"sigs.k8s.io/prow/prow/interrupts"
+	"sigs.k8s.io/prow/prow/logrusutil"
+	"sigs.k8s.io/prow/prow/pjutil"
+	"sigs.k8s.io/prow/prow/pluginhelp/externalplugins"
 )
 
 type options struct {

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -31,12 +31,12 @@ import (
 	"github.com/sirupsen/logrus"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/test-infra/prow/config"
-	cherrypicker "k8s.io/test-infra/prow/external-plugins/cherrypicker/lib"
-	"k8s.io/test-infra/prow/git/v2"
-	"k8s.io/test-infra/prow/github"
-	"k8s.io/test-infra/prow/pluginhelp"
-	"k8s.io/test-infra/prow/plugins"
+	"sigs.k8s.io/prow/prow/config"
+	cherrypicker "sigs.k8s.io/prow/prow/external-plugins/cherrypicker/lib"
+	"sigs.k8s.io/prow/prow/git/v2"
+	"sigs.k8s.io/prow/prow/github"
+	"sigs.k8s.io/prow/prow/pluginhelp"
+	"sigs.k8s.io/prow/prow/plugins"
 )
 
 const pluginName = "cherrypick"

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/test-infra/prow/git/localgit"
-	v2 "k8s.io/test-infra/prow/git/v2"
-	"k8s.io/test-infra/prow/github"
+	"sigs.k8s.io/prow/prow/git/localgit"
+	v2 "sigs.k8s.io/prow/prow/git/v2"
+	"sigs.k8s.io/prow/prow/github"
 )
 
 var commentFormat = "%s/%s#%d %s"

--- a/prow/external-plugins/cla-assistant/main.go
+++ b/prow/external-plugins/cla-assistant/main.go
@@ -13,14 +13,14 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/pkg/flagutil"
-	"k8s.io/test-infra/prow/config/secret"
-	prowflagutil "k8s.io/test-infra/prow/flagutil"
-	pluginsflagutil "k8s.io/test-infra/prow/flagutil/plugins"
-	"k8s.io/test-infra/prow/interrupts"
-	"k8s.io/test-infra/prow/logrusutil"
-	"k8s.io/test-infra/prow/pjutil"
-	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
+	"sigs.k8s.io/prow/pkg/flagutil"
+	"sigs.k8s.io/prow/prow/config/secret"
+	prowflagutil "sigs.k8s.io/prow/prow/flagutil"
+	pluginsflagutil "sigs.k8s.io/prow/prow/flagutil/plugins"
+	"sigs.k8s.io/prow/prow/interrupts"
+	"sigs.k8s.io/prow/prow/logrusutil"
+	"sigs.k8s.io/prow/prow/pjutil"
+	"sigs.k8s.io/prow/prow/pluginhelp/externalplugins"
 )
 
 type options struct {

--- a/prow/external-plugins/cla-assistant/plugin.go
+++ b/prow/external-plugins/cla-assistant/plugin.go
@@ -15,10 +15,10 @@ import (
 	backoff "github.com/cenkalti/backoff/v4"
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/config"
-	"k8s.io/test-infra/prow/github"
-	"k8s.io/test-infra/prow/pluginhelp"
-	"k8s.io/test-infra/prow/plugins"
+	"sigs.k8s.io/prow/prow/config"
+	"sigs.k8s.io/prow/prow/github"
+	"sigs.k8s.io/prow/prow/pluginhelp"
+	"sigs.k8s.io/prow/prow/plugins"
 )
 
 const (

--- a/prow/external-plugins/cla-assistant/plugin_test.go
+++ b/prow/external-plugins/cla-assistant/plugin_test.go
@@ -18,10 +18,10 @@ import (
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/test-infra/prow/config"
-	"k8s.io/test-infra/prow/github"
-	"k8s.io/test-infra/prow/github/fakegithub"
-	"k8s.io/test-infra/prow/plugins"
+	"sigs.k8s.io/prow/prow/config"
+	"sigs.k8s.io/prow/prow/github"
+	"sigs.k8s.io/prow/prow/github/fakegithub"
+	"sigs.k8s.io/prow/prow/plugins"
 )
 
 const (

--- a/prow/external-plugins/cla-assistant/server.go
+++ b/prow/external-plugins/cla-assistant/server.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/github"
+	"sigs.k8s.io/prow/prow/github"
 )
 
 // httpServer implements http.Handler. It validates incoming GitHub webhooks and

--- a/prow/external-plugins/cla-assistant/server_test.go
+++ b/prow/external-plugins/cla-assistant/server_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/test-infra/prow/github"
+	"sigs.k8s.io/prow/prow/github"
 )
 
 func TestHandleEvent(t *testing.T) {

--- a/prow/pkg/git/fakegit/fakegitclient.go
+++ b/prow/pkg/git/fakegit/fakegitclient.go
@@ -4,7 +4,7 @@
 
 package fakegit
 
-import "k8s.io/test-infra/prow/git/v2"
+import "sigs.k8s.io/prow/prow/git/v2"
 
 // FakeGitClientFactory fakes the prow git client factory
 type FakeGitClientFactory struct {

--- a/prow/pkg/github/fakegithub/fakegithubclient.go
+++ b/prow/pkg/github/fakegithub/fakegithubclient.go
@@ -5,7 +5,7 @@
 package fakegithub
 
 import (
-	"k8s.io/test-infra/prow/github"
+	"sigs.k8s.io/prow/prow/github"
 )
 
 // FakeGithubClient fakes the prow GitHubClient

--- a/prow/pkg/githubinteractor/github.go
+++ b/prow/pkg/githubinteractor/github.go
@@ -12,9 +12,9 @@ import (
 	"regexp"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/config"
-	"k8s.io/test-infra/prow/git/v2"
-	"k8s.io/test-infra/prow/github"
+	"sigs.k8s.io/prow/prow/config"
+	"sigs.k8s.io/prow/prow/git/v2"
+	"sigs.k8s.io/prow/prow/github"
 )
 
 // GetFileNames returns the relative filepath to the `dir`, ignoring folders / files in `ignoredFileNames`, goes through subfolders, if `recursive` is `true`

--- a/prow/pkg/githubinteractor/github_test.go
+++ b/prow/pkg/githubinteractor/github_test.go
@@ -12,7 +12,7 @@ import (
 	ghi "github.com/gardener/ci-infra/prow/pkg/githubinteractor"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/test-infra/prow/github"
+	"sigs.k8s.io/prow/prow/github"
 )
 
 const (


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
Prow source code moved from k8s.io/test-infra to sigs.k8s.io/prow (see [here](https://github.com/kubernetes/test-infra/tree/master/prow)).
Thus, this PR updates the references to all prow go dependencies to this new location.

Additionally, it uses the `x.y.0` version of Go Toolchain `go 1.22.0` only, that we don't enforce that every golang (test-)image is on the latest patch level. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
