### PR TITLE
Fix `consistentImageExceptions` in `autobump-config`

### DIFF
--- a/config/prow/autobump-config/prow-component-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-component-autobump-config.yaml
@@ -23,6 +23,17 @@ prefixes:
     repo: "https://github.com/kubernetes/test-infra"
     summarise: true
     consistentImages: true
+    consistentImageExceptions:
+      - "gcr.io/k8s-prow/alpine"
+      - "gcr.io/k8s-prow/analyze"
+      - "gcr.io/k8s-prow/commenter"
+      - "gcr.io/k8s-prow/configurator"
+      - "gcr.io/k8s-prow/gcsweb"
+      - "gcr.io/k8s-prow/gencred"
+      - "gcr.io/k8s-prow/git"
+      - "gcr.io/k8s-prow/issue-creator"
+      - "gcr.io/k8s-prow/label_sync"
+      - "gcr.io/k8s-prow/pr-creator"
   - name: "Prow - ci-infra"
     prefix: "europe-docker.pkg.dev/gardener-project/releases/ci-infra/"
     refConfigFile: "config/prow/cluster/cla_assistant_deployment.yaml"

--- a/config/prow/autobump-config/prow-component-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-component-autobump-config.yaml
@@ -20,7 +20,7 @@ prefixes:
   - name: "Prow"
     prefix: "gcr.io/k8s-prow/"
     refConfigFile: "config/prow/cluster/deck_deployment.yaml"
-    repo: "https://github.com/kubernetes/test-infra"
+    repo: "https://github.com/kubernetes-sigs/prow"
     summarise: true
     consistentImages: true
     consistentImageExceptions:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
`autobump` jobs are broken since prow code moved from https://github.com/kubernetes/test-infra to https://github.com/kubernetes-sigs/prow.
This PR fixes it similar to what was done in https://github.com/kubernetes/test-infra/commit/912f1e99b4f66b4759ede148ce6534efb3df433b

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
