### PR TITLE
Skip building `ci-infra` images when there are changes in `images` folder only

### DIFF
--- a/config/jobs/ci-infra/build-ci-infra-images.yaml
+++ b/config/jobs/ci-infra/build-ci-infra-images.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - name: post-ci-infra-build-images
     cluster: gardener-prow-trusted
     # skip config/prow folder that build and autobumper do not end up in an endless loop
-    skip_if_only_changed: '^config\/|^hack\/(bootstrap|check|check-testgrid)-config\.sh'
+    skip_if_only_changed: '^config\/|^hack\/(bootstrap|check|check-testgrid)-config\.sh|^images\/'
     branches:
     - ^master$
     annotations:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
We could reduce the number of unnecessary builds if we skip building `ci-infra` images when there are changes in `images` folder only. This folder is for `krte` and `copy-images` which are not related to our `prow` images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
