### PR TITLE
Remote `test-prometheus` rule from `gardener/gardener` unit tests

### DIFF
--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -25,7 +25,6 @@ presubmits:
         - check
         - format
         - test
-        - test-prometheus
         resources:
           limits:
             memory: 16Gi
@@ -62,7 +61,6 @@ periodics:
       - check
       - format
       - test
-      - test-prometheus
       resources:
         limits:
           memory: 16Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/9695 removes the `test-prometheus` rule. 

**Special notes for your reviewer**:
/cc @ScheererJ @oliver-goetz 