### PR TITLE
Add IPv6-only end-to-end tests to gardener/gardener.

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
@@ -1,0 +1,81 @@
+presubmits:
+  gardener/gardener:
+  - name: pull-gardener-e2e-kind-ipv6
+    cluster: gardener-prow-build
+    always_run: true
+    skip_branches:
+    - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for gardener developments in pull requests
+      fork-per-release: "true"
+    spec:
+      containers:
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240426-6f2d62b-1.22
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - make import-tools-bin ci-e2e-kind
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 12
+            memory: 48Gi
+        env:
+        - name: SKAFFOLD_UPDATE_CHECK
+          value: "false"
+        - name: SKAFFOLD_INTERACTIVE
+          value: "false"
+        - name: IPFAMILY
+          value: "ipv6"
+periodics:
+- name: ci-gardener-e2e-kind-ipv6
+  cluster: gardener-prow-build
+  interval: 4h
+  extra_refs:
+  - org: gardener
+    repo: gardener
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 60m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs end-to-end tests for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
+    fork-per-release: "true"
+  spec:
+    containers:
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240426-6f2d62b-1.22
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make import-tools-bin ci-e2e-kind
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 12
+          memory: 48Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"
+      - name: IPFAMILY
+        value: "ipv6"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
Add IPv6-only end-to-end tests to gardener/gardener.

The test specification is exactly the same as e2e-kind with the single exception that `IPFAMILY` is set to `ipv6`.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
Should only be merged after https://github.com/gardener/gardener/pull/9693 has been merged as it is required for the tests to succeed.