### PR TITLE
Run `make generate-prow-deployments` when auto-updating `renovate`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -45,7 +45,7 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "install-tool helm v3.14.0",
+          "install-tool helm v3.14.4",
           "make generate-prow-deployments"
         ],
         "executionMode": "branch"
@@ -58,6 +58,13 @@
         "^renovate$",
         "^ghcr\\.io\/renovatebot\/renovate$"
       ],
+      "postUpgradeTasks": {
+        "commands": [
+          "install-tool helm v3.14.4",
+          "make generate-prow-deployments"
+        ],
+        "executionMode": "branch"
+      },
       "addLabels": ["skip-review"],
       "schedule": ["after 08:30 and before 15:30 every weekday"]
     },


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
`make generate-prow-deployments` should run on auto-update PRs of `renovate`. Otherwise, its helm chart is not templated with the new version.

Alongside, helm is updated to the latest version [v3.14.4](https://github.com/helm/helm/releases/tag/v3.14.4).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
