### PR TITLE
Add e2e test jobs for gardener-discovery-server

### DIFF
--- a/config/jobs/gardener-discovery-server/gardener-discovery-server-e2e-kind.yaml
+++ b/config/jobs/gardener-discovery-server/gardener-discovery-server-e2e-kind.yaml
@@ -1,0 +1,73 @@
+presubmits:
+  gardener/gardener-discovery-server:
+  - name: pull-gardener-discovery-server-e2e-kind
+    cluster: gardener-prow-build
+    always_run: true
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for gardener-discovery-server developments in pull requests
+    spec:
+      containers:
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240515-3db9c57-1.22
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - make ci-e2e-kind
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 6
+            memory: 18Gi
+        env:
+        - name: SKAFFOLD_UPDATE_CHECK
+          value: "false"
+        - name: SKAFFOLD_INTERACTIVE
+          value: "false"
+periodics:
+- name: ci-gardener-discovery-server-e2e-kind
+  cluster: gardener-prow-build
+  interval: 48h
+  extra_refs:
+  - org: gardener
+    repo: gardener-discovery-server
+    base_ref: main
+  decorate: true
+  decoration_config:
+    timeout: 60m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs end-to-end tests for gardener-discovery-server developments periodically
+    testgrid-dashboards: gardener-discovery-server
+    testgrid-days-of-results: "60"
+  spec:
+    containers:
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240515-3db9c57-1.22
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make ci-e2e-kind
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 6
+          memory: 18Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
Adds a e2e test job for the gardener discovery server.

Depends on https://github.com/gardener/gardener-discovery-server/pull/21
/hold
/kind enhancement

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
