### PR TITLE
Configure `ipcei/(oidc|workload-identity)` labels for discovery-server

### DIFF
--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -4325,6 +4325,19 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
+      # ipcei
+      - name: ipcei/oidc
+        color: c2e0c6
+        description: Epic for Gardener OIDC scenarios
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - name: ipcei/workload-identity
+        color: c2e0c6
+        description: Epic for Gardener Workload Identity scenarios
+        target: both
+        prowPlugin: label
+        addedBy: anyone
       # kind
       - name: kind/epic
         color: c7def8


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:
Configure `ipcei/(oidc|workload-identity)` labels for discovery-server
/cc @dimityrmirchev 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
