### PR TITLE
Decrease size of renovate cache volume to 10 GB

### DIFF
--- a/config/prow/cluster/renovate/helm/values.yaml
+++ b/config/prow/cluster/renovate/helm/values.yaml
@@ -38,7 +38,7 @@ renovate:
     cache:
       enabled: true
       storageClass: gce-ssd
-      storageSize: 50Gi
+      storageSize: 10Gi
 
 existingSecret: github
 

--- a/config/prow/cluster/renovate/renovate_deployment.yaml
+++ b/config/prow/cluster/renovate/renovate_deployment.yaml
@@ -62,7 +62,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 50Gi
+      storage: 10Gi
 ---
 # Source: renovate/templates/cronjob.yaml
 apiVersion: batch/v1


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Garbage collection of `renovate` has been fixed, so we can decrease the size of its cache volume.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
