### PR TITLE
Add e2e test for `kind-operator-seed-up` make target in `gardener/gardener` repository

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-operator-seed.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator-seed.yaml
@@ -1,0 +1,77 @@
+presubmits:
+  gardener/gardener:
+  - name: pull-gardener-e2e-kind-operator-seed
+    cluster: gardener-prow-build
+    always_run: true
+    skip_branches:
+    - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for a landscape with gardener-operator managing the Garden resource and a Soil running on a kind cluster for gardener developments in pull requests
+      fork-per-release: "true"
+    spec:
+      containers:
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240603-7af7c7b-1.22
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - make import-tools-bin ci-e2e-kind-operator-seed
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 6
+            memory: 24Gi
+        env:
+        - name: SKAFFOLD_UPDATE_CHECK
+          value: "false"
+        - name: SKAFFOLD_INTERACTIVE
+          value: "false"
+periodics:
+- name: ci-gardener-e2e-kind-operator-seed
+  cluster: gardener-prow-build
+  interval: 4h
+  extra_refs:
+  - org: gardener
+    repo: gardener
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 60m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs end-to-end tests for a landscape with gardener-operator managing the Garden resource and a Soil running on a kind cluster for gardener developments periodically
+    testgrid-dashboards: gardener-gardener
+    testgrid-days-of-results: "60"
+    fork-per-release: "true"
+  spec:
+    containers:
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240603-7af7c7b-1.22
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - make import-tools-bin ci-e2e-kind-operator-seed
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 6
+          memory: 24Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds an e2e test for the gardener-operator setup which also deploys a Soil in the same kind cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Merge after https://github.com/gardener/gardener/pull/9763 was merged

/hold