### PR TITLE
fix fluent-operator source

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -56,7 +56,7 @@ images:
   - v2.3.0
   - v2.7.0
 # It follows the switch in the upstream fluent-operator project. The kubsphere/fluent-operator image shall not be used anymore.
-- source: ghcr.io/fluent/fluent-operator
+- source: ghcr.io/fluent/fluent-operator/fluent-operator
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-operator
   tags:
   - v2.9.0


### PR DESCRIPTION
This PR fixes the source of fluent-operator. The correct one shall be `ghcr.io/fluent/fluent-operator/fluent-operator`
