### PR TITLE
Allow version suffixes in the container copy logic

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -137,7 +137,7 @@
         "commands": [
           "install-tool golang v1.22.3",
           "go install github.com/mikefarah/yq/v4@latest",
-          "bash -c \"sed -i `yq '(.images[] | select(.source == \\\"{{{depName}}}\\\") | key) as \\\$imagePos | (.images[\\\$imagePos].tags | length) as \\\$tagLength | .images[\\\$imagePos].tags[\\\$tagLength - 1] | line' config/images/images.yaml`'i\\\  - {{{currentVersion}}}' config/images/images.yaml\""
+          "bash -c \"sed -i `yq '(.images[] | select(.source == \\\"{{{depName}}}\\\") | key) as \\\$imagePos | (.images[\\\$imagePos].tags | length) as \\\$tagLength | .images[\\\$imagePos].tags[\\\$tagLength - 1] | line' config/images/images.yaml`'i\\\  - {{{currentValue}}}' config/images/images.yaml\""
         ],
         "executionMode": "update"
       }


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
Allow version suffixes in the container copy logic.

For example, `kindest/local-path-provisioner` has a version `v0.0.22-kind.0`. The renovate templating uses the following:

```
               "currentVersion": "v0.0.22",
               "currentValue": "v0.0.22-kind.0",
```

Therefore, we should use `currentValue` instead of `currentVersion` in the post update step.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/kind enhancement
/cc @oliver-goetz 