### PR TITLE
Increase renovate-cache volume size to 20Gi

### DIFF
--- a/config/prow/cluster/renovate/helm/values.yaml
+++ b/config/prow/cluster/renovate/helm/values.yaml
@@ -39,7 +39,7 @@ renovate:
     cache:
       enabled: true
       storageClass: gce-ssd
-      storageSize: 10Gi
+      storageSize: 20Gi
 
 existingSecret: github
 

--- a/config/prow/cluster/renovate/renovate_deployment.yaml
+++ b/config/prow/cluster/renovate/renovate_deployment.yaml
@@ -63,7 +63,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 20Gi
 ---
 # Source: renovate/templates/cronjob.yaml
 apiVersion: batch/v1


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
The inodes of renovate-cache volume are exhausted. Increasing the volume size also increases the number of inodes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
