### PR TITLE
Use full image of `renovate`

### DIFF
--- a/config/prow/cluster/renovate/helm/values.yaml
+++ b/config/prow/cluster/renovate/helm/values.yaml
@@ -1,5 +1,8 @@
 fullnameOverride: renovate
 
+image:
+  useFull: true
+
 cronjob:
   schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid

--- a/config/prow/cluster/renovate/renovate_deployment.yaml
+++ b/config/prow/cluster/renovate/renovate_deployment.yaml
@@ -95,7 +95,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: renovate
-              image: "ghcr.io/renovatebot/renovate:37.425.2"
+              image: "ghcr.io/renovatebot/renovate:37.425.2-full"
               imagePullPolicy: IfNotPresent
               volumeMounts:
               - name: config-volume


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR switches to the full image of `renovate`. It is bigger than the default (slim) image, but it contains [helm](https://github.com/renovatebot/base-image/blob/5dc9492849d61e6a25befb86ae9b8aca9ff6d8aa/Dockerfile#L100) and [go](https://github.com/renovatebot/base-image/blob/5dc9492849d61e6a25befb86ae9b8aca9ff6d8aa/Dockerfile#L56) tools. When trying to install the later, renovate currently fails most of the time. This is hopefully solved with the full image.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ 
