### PR TITLE
Use the prow registry mirror for docker.io in e2e tests

### DIFF
--- a/config/prow/cluster/base/dind-docker-config_configmap.yaml
+++ b/config/prow/cluster/base/dind-docker-config_configmap.yaml
@@ -6,5 +6,7 @@ metadata:
 data:
   daemon.json: |-
     {
-      "cgroup-parent": "prowparent.slice"
+      "cgroup-parent": "prowparent.slice",
+      "insecure-registries" : ["registry-docker-io.kube-system.svc.cluster.local:5000"],
+      "registry-mirrors": ["http://registry-docker-io.kube-system.svc.cluster.local:5000"]
     }


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR enables the prow registry cache as mirror for docker.io in e2e tests to avoid rate limit issues.
https://docs.docker.com/docker-hub/mirror/#configure-the-docker-daemon

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ 
