### PR TITLE
Correctly sort the version in branch cleaner

### DIFF
--- a/prow/cmd/branch-cleaner/branchcleaner.go
+++ b/prow/cmd/branch-cleaner/branchcleaner.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/sirupsen/logrus"
@@ -107,7 +109,20 @@ func (b *branchCleaner) getMatchingBranches() ([]string, error) {
 			matchingBranches = append(matchingBranches, branch.Name)
 		}
 	}
-	sort.Sort(sort.Reverse(sort.StringSlice(matchingBranches)))
+
+	sort.Slice(matchingBranches, func(i, j int) bool {
+		aString := strings.Split(strings.TrimPrefix(matchingBranches[i], "release-v"), ".")
+		bString := strings.Split(strings.TrimPrefix(matchingBranches[j], "release-v"), ".")
+
+		aNum, _ := strconv.Atoi(aString[1])
+		bNum, _ := strconv.Atoi(bString[1])
+
+		if aString[0] == bString[0] {
+			return aNum > bNum
+		}
+		return aString[0] > bString[0]
+	})
+
 	logrus.Infof("Found these matching branches sorted in reverse order: %v", matchingBranches)
 
 	return matchingBranches, nil

--- a/prow/cmd/branch-cleaner/branchcleaner_test.go
+++ b/prow/cmd/branch-cleaner/branchcleaner_test.go
@@ -84,10 +84,14 @@ var _ = Describe("BranchCleaner", func() {
 		JustBeforeEach(func() {
 			fakeGithub.Branches = []github.Branch{
 				{Name: "master", Protected: true},
-				{Name: "release-v1.73"},
-				{Name: "release-v1.74"},
-				{Name: "release-v1.72"},
-				{Name: "release-v1.75", Protected: true},
+				{Name: "release-v1.98"},
+				{Name: "release-v1.99"},
+				{Name: "release-v1.100"},
+				{Name: "release-v1.101", Protected: true},
+				{Name: "release-v1.201"},
+				{Name: "release-v1.202"},
+				{Name: "release-v2.15"},
+				{Name: "release-v2.16"},
 			}
 		})
 
@@ -95,7 +99,7 @@ var _ = Describe("BranchCleaner", func() {
 			bc.options.branchPattern = "^release-v\\d+\\.\\d+"
 			branches, err := bc.getMatchingBranches()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(branches).To(Equal([]string{"release-v1.75", "release-v1.74", "release-v1.73", "release-v1.72"}))
+			Expect(branches).To(Equal([]string{"release-v2.16", "release-v2.15", "release-v1.202", "release-v1.201", "release-v1.101", "release-v1.100", "release-v1.99", "release-v1.98"}))
 		})
 
 		It("should not find non matching branches", func() {


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
The branch cleaner sorts the version considering it string and in string comparison ["100" is smaller than "99"](https://go.dev/play/p/YE5bo8BMgkq).  To prevent it this PR, first convert the string to an integer and then perform the comparison.
It will still fail if the major version is 99 and 100, but this will not happen in the near future.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
