### PR TITLE
Delete content of renovate cache volume when it is almost full.

### DIFF
--- a/config/prow/cluster/renovate/helm/values.yaml
+++ b/config/prow/cluster/renovate/helm/values.yaml
@@ -6,6 +6,15 @@ image:
 cronjob:
   schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
+  postCommand: |
+    disk_usage=$(df /tmp/renovate | awk 'NR==2 {print $5}' | tr -d '%')
+    inode_usage=$(df -i /tmp/renovate | awk 'NR==2 {print $5}' | tr -d '%')
+    if [ "$disk_usage" -gt 95 ] || [ "$inode_usage" -gt 95 ]; then
+      echo "Disk usage: $disk_usage %"
+      echo "Inode usage: $inode_usage %"
+      echo "Renovate cache disk is almost full. Deleting contents of /tmp/renovate"
+      rm -rf /tmp/renovate/*
+    fi
 
 renovate:
   # See https://docs.renovatebot.com/self-hosted-configuration
@@ -42,7 +51,7 @@ renovate:
     cache:
       enabled: true
       storageClass: gce-ssd
-      storageSize: 20Gi
+      storageSize: 10Gi
 
 existingSecret: github
 

--- a/config/prow/cluster/renovate/renovate_deployment.yaml
+++ b/config/prow/cluster/renovate/renovate_deployment.yaml
@@ -63,7 +63,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi
+      storage: 10Gi
 ---
 # Source: renovate/templates/cronjob.yaml
 apiVersion: batch/v1
@@ -97,6 +97,20 @@ spec:
             - name: renovate
               image: "ghcr.io/renovatebot/renovate:37.440.7-full"
               imagePullPolicy: IfNotPresent
+              command: ["/bin/bash", "-c"]
+              args:
+                - |
+                  set -e;
+                  renovate
+                  disk_usage=$(df /tmp/renovate | awk 'NR==2 {print $5}' | tr -d '%')
+                  inode_usage=$(df -i /tmp/renovate | awk 'NR==2 {print $5}' | tr -d '%')
+                  if [ "$disk_usage" -gt 95 ] || [ "$inode_usage" -gt 95 ]; then
+                    echo "Disk usage: $disk_usage %"
+                    echo "Inode usage: $inode_usage %"
+                    echo "Renovate cache disk is almost full. Deleting contents of /tmp/renovate"
+                    rm -rf /tmp/renovate/*
+                  fi
+                  
               volumeMounts:
               - name: config-volume
                 mountPath: /usr/src/app/config.json


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Renovate has issues with an indefinitely growing cache volume again (see https://github.com/renovatebot/renovate/discussions/30525).
Thus, this PR adds a cleanup script which deletes the content of `/tmp/renovate/` if either more then 95% of disk space or 95% of inodes (which is the most likely event) are exhausted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
