### PR TITLE
Update fluent-bits and operator

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -55,6 +55,7 @@ images:
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-bit
   tags:
   - v3.0.7
+  - v3.1.5
 # The kubesphere/fluent-operator image shall not be used anymore. Please use ghcr.io/fluent/fluent-operator/fluent-operator instead.
 - source: kubesphere/fluent-operator
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-operator
@@ -67,6 +68,7 @@ images:
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-operator
   tags:
   - v2.9.0
+  - v3.1.0
 # DO NOT ADD NEW LOKI IMAGES.
 # With https://github.com/gardener/gardener/pull/7318 loki is replaced by vali.
 - source: grafana/loki


### PR DESCRIPTION
/kind enhancement

This PR bump ups the fluent-operator and fluent-bit images to v3.1.0 and v3.1.5 versions respectivly.

- fluent-operator v3.1.0 (release notes)[https://github.com/fluent/fluent-operator/releases/tag/v3.1.0]
- fluent-bit v3.1.5 (release notes)[https://fluentbit.io/announcements/v3.1.5]