### PR TITLE
Bump the memory limit for the {registry-cache,shoot-rsyslog-relp}-unit jobs from 2Gi to 3Gi

### DIFF
--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
@@ -18,7 +18,7 @@ presubmits:
         - verify-extended
         resources:
           limits:
-            memory: 2Gi
+            memory: 3Gi
           requests:
             cpu: 2
             memory: 1Gi
@@ -47,7 +47,7 @@ periodics:
       - verify-extended
       resources:
         limits:
-          memory: 2Gi
+          memory: 3Gi
         requests:
           cpu: 2
           memory: 1Gi

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
@@ -18,7 +18,7 @@ presubmits:
         - verify-extended
         resources:
           limits:
-            memory: 2Gi
+            memory: 3Gi
           requests:
             cpu: 2
             memory: 1Gi
@@ -47,7 +47,7 @@ periodics:
       - verify-extended
       resources:
         limits:
-          memory: 2Gi
+          memory: 3Gi
         requests:
           cpu: 2
           memory: 1Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
We noticed that the unit tests jobs for the registry-cache and shoot-rsyslog-relp extensions are occasionally being OOMKilled:
```
% k -n test-pods get po | grep OOMKilled
28bc384e-b37c-4901-a559-595d68c68ccb   1/2     OOMKilled   0          4h9m
3afaa139-4632-41d1-a0d4-27c8b853bbed   1/2     OOMKilled   0          41h
3d3b8284-e13f-4859-aa58-f7c33d500f05   1/2     OOMKilled   0          10h
d052792c-da22-4cbf-80c2-eff7184aed1a   1/2     OOMKilled   0          14h
```

We ran the following experiment locally to see the memory usage of `make verify`:
We started a local container with with a memory limit and with the corresponding golang version:
```
docker run --rm -v ${GOPATH}/src/github.com/gardener/gardener-extension-registry-cache:/go/src/github.com/gardener/gardener-extension-registry-cache -it golang:1.23.0-bookworm bash
```

We executed make verify inside the container.

In parallel we watched the memory usage with
```
docker stats
```

Here are some numbers for the max memory usage from the `make verify` runs:
```
Max memory usage for registry-cache@main (go@1.23):
| Run | Value  |
|-----|--------|
| 1.  | 2.62Gi |
| 2.  | 2.81Gi |
| 3.  | 2.74Gi |
| 4.  | 2.82Gi |
| 5.  | 2.66Gi |
| 6.  | 2.71Gi |


Max memory usage for shoot-rsyslog-relp@main (go@1.22):
| Run | Value  |
|-----|--------|
| 1.  | 2.50Gi |
| 2.  | 2.58Gi |
| 3.  | 2.63Gi |
| 4.  | 2.74Gi |
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A