### PR TITLE
[discovery server] bump golang to 1.23

### DIFF
--- a/config/jobs/gardener-discovery-server/gardener-discovery-server-e2e-kind.yaml
+++ b/config/jobs/gardener-discovery-server/gardener-discovery-server-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-discovery-server developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240913-96cd6ec-1.22
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240913-96cd6ec-1.23
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240913-96cd6ec-1.22
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240913-96cd6ec-1.23
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-discovery-server/gardener-discovery-server-unit-tests.yaml
+++ b/config/jobs/gardener-discovery-server/gardener-discovery-server-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-discovery-server developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240913-029dd81-1.22
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240913-029dd81-1.23
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240913-029dd81-1.22
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240913-029dd81-1.23
       command:
       - make
       args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
[discovery server] bump golang to 1.23

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @dimityrmirchev 