### PR TITLE
[shoot-oidc-service] bump golang to 1.23

### DIFF
--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-oidc-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240826-19b336b-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240913-96cd6ec-1.23
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240826-19b336b-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240913-96cd6ec-1.23
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for extension-shoot-oidc-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240826-b4745f5-1.21
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240913-029dd81-1.23
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240826-b4745f5-1.21
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240913-029dd81-1.23
       command:
       - make
       args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement
-->

**What this PR does / why we need it**:
Bump golang to 1.23 for shoot-oidc-service component

/cc @dimityrmirchev 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
