### PR TITLE
Increase memory requests and limits for certain unit tests

### DIFF
--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
@@ -18,10 +18,10 @@ presubmits:
         - verify-extended
         resources:
           limits:
-            memory: 2Gi
+            memory: 4Gi
           requests:
             cpu: 2
-            memory: 1Gi
+            memory: 2Gi
 periodics:
 - name: ci-extension-shoot-oidc-service-unit
   cluster: gardener-prow-build
@@ -47,7 +47,7 @@ periodics:
       - verify-extended
       resources:
         limits:
-          memory: 2Gi
+          memory: 4Gi
         requests:
           cpu: 2
-          memory: 1Gi
+          memory: 2Gi

--- a/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-unit-tests.yaml
+++ b/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-unit-tests.yaml
@@ -18,10 +18,10 @@ presubmits:
         - verify-extended
         resources:
           limits:
-            memory: 2Gi
+            memory: 4Gi
           requests:
             cpu: 2
-            memory: 1Gi
+            memory: 2Gi
 periodics:
 - name: ci-extension-networking-calico
   cluster: gardener-prow-build
@@ -47,7 +47,7 @@ periodics:
       - verify-extended
       resources:
         limits:
-          memory: 2Gi
+          memory: 4Gi
         requests:
           cpu: 2
-          memory: 1Gi
+          memory: 2Gi

--- a/config/jobs/gardener-extension-networking-cilium/gardener-extension-networking-cilium-unit-tests.yaml
+++ b/config/jobs/gardener-extension-networking-cilium/gardener-extension-networking-cilium-unit-tests.yaml
@@ -18,10 +18,10 @@ presubmits:
         - verify-extended
         resources:
           limits:
-            memory: 2Gi
+            memory: 4Gi
           requests:
             cpu: 2
-            memory: 1Gi
+            memory: 2Gi
 periodics:
 - name: ci-extension-networking-cilium
   cluster: gardener-prow-build
@@ -47,7 +47,7 @@ periodics:
       - verify-extended
       resources:
         limits:
-          memory: 2Gi
+          memory: 4Gi
         requests:
           cpu: 2
-          memory: 1Gi
+          memory: 2Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
The unit tests for calico, cilium and oidc-service are OOM killed quite a few times. Thus, this PR doubles their memory requests and limits.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ 
