### PR TITLE
Change locations of prow images

### DIFF
--- a/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
+++ b/config/jobs/ci-infra/ci-infra-automate-testgrid.yaml
@@ -10,9 +10,9 @@ presubmits:
       testgrid-create-test-group: "false"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/configurator:v20240731-a5d9345e59
+      - image: gcr.io/k8s-staging-test-infra/configurator:v20240914-93a93a3da9
         command:
-        - /ko-app/configurator
+        - configurator
         args:
         - --yaml=config/testgrids/config.yaml
         - --default=config/testgrids/default.yaml
@@ -38,9 +38,9 @@ postsubmits:
       testgrid-create-test-group: "false"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/configurator:v20240731-a5d9345e59
+      - image: gcr.io/k8s-staging-test-infra/configurator:v20240914-93a93a3da9
         command:
-        - /ko-app/configurator
+        - configurator
         args:
         - --gcp-service-account=/etc/gcp-service-account/service-account.json
         - --yaml=config/testgrids/config.yaml

--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/label_sync:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/label_sync:v20240801-a5d9345e59
       command:
       - label_sync
       args:
@@ -56,7 +56,7 @@ periodics:
     app: branchprotector
   spec:
     containers:
-    - image: gcr.io/k8s-prow/branchprotector:v20240805-37a08f946
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/branchprotector:v20240930-8302b5c30
       command:
       - branchprotector
       args:
@@ -127,7 +127,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240805-37a08f946
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240930-8302b5c30
       command:
       - generic-autobumper
       args:
@@ -158,7 +158,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240805-37a08f946
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240930-8302b5c30
       command:
       - generic-autobumper
       args:
@@ -189,7 +189,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240805-37a08f946
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240930-8302b5c30
       command:
       - generic-autobumper
       args:
@@ -220,7 +220,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240805-37a08f946
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240930-8302b5c30
       command:
       - generic-autobumper
       args:
@@ -254,7 +254,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20240805-37a08f946
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20240930-8302b5c30
       command:
       - checkconfig
       args:
@@ -286,7 +286,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20240805-37a08f946
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20240930-8302b5c30
       command:
       - checkconfig
       args:

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       description: Runs checkconfig to validate changes to job configs, config.yaml and friends
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20240805-37a08f946
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20240930-8302b5c30
         command:
         - checkconfig
         args:

--- a/config/jobs/common/issue-pr-lifecycle.yaml
+++ b/config/jobs/common/issue-pr-lifecycle.yaml
@@ -11,7 +11,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240914-93a93a3da9
       command:
       - commenter
       args:
@@ -64,7 +64,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240914-93a93a3da9
       command:
       - commenter
       args:
@@ -118,7 +118,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240914-93a93a3da9
       command:
       - commenter
       args:
@@ -173,7 +173,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240914-93a93a3da9
       command:
       - commenter
       args:
@@ -226,7 +226,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240914-93a93a3da9
       command:
       - commenter
       args:
@@ -280,7 +280,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240914-93a93a3da9
       command:
       - commenter
       args:

--- a/config/mkpj.sh
+++ b/config/mkpj.sh
@@ -17,7 +17,7 @@
 cd "$(git rev-parse --show-toplevel)"
 
 docker run -i --rm -w /etc/ci-infra -v $PWD:/etc/ci-infra \
-  gcr.io/k8s-prow/mkpj:v20240805-37a08f946 \
+  us-docker.pkg.dev/k8s-infra-prow/images/mkpj:v20240930-8302b5c30 \
   --config-path=config/prow/config.yaml \
   --job-config-path=config/jobs \
   "$@"

--- a/config/prow/autobump-config/prow-component-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-component-autobump-config.yaml
@@ -18,25 +18,17 @@ extraFiles:
 targetVersion: "latest"
 prefixes:
   - name: "Prow"
-    prefix: "gcr.io/k8s-prow/"
-    refConfigFile: "config/prow/cluster/deck_deployment.yaml"
+    prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
     repo: "https://github.com/kubernetes-sigs/prow"
     summarise: true
     consistentImages: true
-    consistentImageExceptions:
-      - "gcr.io/k8s-prow/alpine"
-      - "gcr.io/k8s-prow/analyze"
-      - "gcr.io/k8s-prow/commenter"
-      - "gcr.io/k8s-prow/configurator"
-      - "gcr.io/k8s-prow/gcsweb"
-      - "gcr.io/k8s-prow/gencred"
-      - "gcr.io/k8s-prow/git"
-      - "gcr.io/k8s-prow/issue-creator"
-      - "gcr.io/k8s-prow/label_sync"
-      - "gcr.io/k8s-prow/pr-creator"
+  - name: "Prow - test-infra"
+    prefix: "gcr.io/k8s-staging-test-infra/"
+    repo: "https://github.com/kubernetes/test-infra"
+    summarise: true
+    consistentImages: false
   - name: "Prow - ci-infra"
     prefix: "europe-docker.pkg.dev/gardener-project/releases/ci-infra/"
-    refConfigFile: "config/prow/cluster/cla_assistant_deployment.yaml"
     repo: "https://github.com/gardener/ci-infra"
     summarise: true
     consistentImages: false

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20240930-8302b5c30
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20240930-8302b5c30
         imagePullPolicy: Always
         ports:
         - name: http

--- a/config/prow/cluster/gcsweb_deployment.yaml
+++ b/config/prow/cluster/gcsweb_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: gcsweb
-          image: gcr.io/k8s-prow/gcsweb:v20240731-a5d9345e59
+          image: gcr.io/k8s-staging-test-infra/gcsweb:v20240914-93a93a3da9
           args:
             - -upgrade-proxied-http-to-https
             # buckets owned by gardener

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20240930-8302b5c30
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=9

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20240930-8302b5c30
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20240930-8302b5c30
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/cluster/needs-rebase_deployment.yaml
+++ b/config/prow/cluster/needs-rebase_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/needs-rebase:v20240930-8302b5c30
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/config/prow/cluster/prow_controller_manager_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20240930-8302b5c30
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20240930-8302b5c30
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20240930-8302b5c30
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20240930-8302b5c30
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -17,10 +17,10 @@ plank:
       timeout: 2h
       grace_period: 15m
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20240805-37a08f946"
-        initupload: "gcr.io/k8s-prow/initupload:v20240805-37a08f946"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20240805-37a08f946"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20240805-37a08f946"
+        clonerefs: "us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20240930-8302b5c30"
+        initupload: "us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20240930-8302b5c30"
+        entrypoint: "us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20240930-8302b5c30"
+        sidecar: "us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20240930-8302b5c30"
       gcs_configuration:
         bucket: "gardener-prow"
         path_strategy: explicit

--- a/hack/bootstrap-config.sh
+++ b/hack/bootstrap-config.sh
@@ -68,7 +68,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 docker run --rm -w /etc/ci-infra -v $PWD:/etc/ci-infra \
   -v "$temp_kubeconfig":/etc/kubeconfig \
-  gcr.io/k8s-prow/config-bootstrapper:v20240805-37a08f946 \
+  us-docker.pkg.dev/k8s-infra-prow/images/config-bootstrapper:v20240930-8302b5c30 \
   --kubeconfig=/etc/kubeconfig \
   --source-path=.  \
   --config-path=config/prow/config.yaml \

--- a/hack/check-config.sh
+++ b/hack/check-config.sh
@@ -11,7 +11,7 @@ set -o pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 docker run --rm -w /etc/ci-infra -v $PWD:/etc/ci-infra \
-  gcr.io/k8s-prow/checkconfig:v20240805-37a08f946 \
+  us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20240930-8302b5c30 \
   --config-path=config/prow/config.yaml \
   --job-config-path=config/jobs \
   --plugin-config=config/prow/plugins.yaml \

--- a/hack/check-testgrid-config.sh
+++ b/hack/check-testgrid-config.sh
@@ -11,7 +11,7 @@ set -o pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 docker run --rm -w /etc/ci-infra -v $PWD:/etc/ci-infra \
-  gcr.io/k8s-prow/configurator:v20240731-a5d9345e59 \
+  gcr.io/k8s-staging-test-infra/configurator:v20240914-93a93a3da9 \
   --yaml=config/testgrids/config.yaml \
   --default=config/testgrids/default.yaml \
   --prow-config=config/prow/config.yaml \


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
The location of prow images has been changed a while ago.
Prow components moved to `us-docker.pkg.dev/k8s-infra-prow/images/*`
Helper tools can be found at `gcr.io/k8s-staging-test-infra/*`
This PR updates the references accordingly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
