### PR TITLE
Activate `overwrite-pending-contexts` feature for `tide`

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -375,6 +375,8 @@ tide:
   context_options:
     # Use branch protection options to define required and optional contexts
     from-branch-protection: true
+    # Overwrite pending contexts of a PR when it can be merged because of a successful batch job
+    overwrite-pending-contexts: true
   merge_method:
     gardener/ci-infra: squash
     gardener/gardener: squash


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Now that https://github.com/kubernetes-sigs/prow/pull/135 is merged, `tide` offers `overwrite-pending-contexts` configuration option, which allows to overwrite pending contexts of a PR when it can be merged because of a successful batch job.
We have quite often the case, that Github branch protection prevents the first PR of a branch from being merged because of pending prow hobs. This issue should be fixed by activating this option.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
