### PR TITLE
Increase memory requests/limits for gardener/gardener unit tests

### DIFF
--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -28,10 +28,10 @@ presubmits:
         - sast
         resources:
           limits:
-            memory: 16Gi
+            memory: 24Gi
           requests:
             cpu: 6
-            memory: 8Gi
+            memory: 16Gi
 periodics:
 - name: ci-gardener-unit
   cluster: gardener-prow-build
@@ -65,7 +65,7 @@ periodics:
       - sast
       resources:
         limits:
-          memory: 16Gi
+          memory: 24Gi
         requests:
           cpu: 6
-          memory: 8Gi
+          memory: 16Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
There are many OOMKilled Pods for Gardener unit tests at the moment. Apparently, `make check-generate` has a memory leak and consumes over 20GB of RAM.
This PR increases memory requests and limits, that we can continue to work 😅 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ 
