### PR TITLE
Allow `skip-review` label on all tide-enabled repos

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -237,7 +237,7 @@ tide:
   sync_period: 1m
   queries:
   # default configuration for repositories that should be onboarded to tide
-  - repos:
+  - repos: &tide-onboarded-repos
     - gardener/ci-infra
     - gardener/gardener
     - gardener/gardener-extension-registry-cache
@@ -263,8 +263,7 @@ tide:
 
   # configuration for automerging robot PRs
   - author: gardener-ci-robot
-    repos:
-    - gardener/ci-infra
+    repos: *tide-onboarded-repos
     labels:
     # gardener-ci-robot adds this label to PRs that should be merged automatically
     - skip-review

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -236,131 +236,20 @@ branch-protection:
 tide:
   sync_period: 1m
   queries:
+  # default configuration for repositories that should be onboarded to tide
   - repos:
     - gardener/ci-infra
-    labels:
-    - lgtm
-    - approved
-    - "cla: yes"
-    missingLabels:
-    - do-not-merge/blocked-paths
-    - do-not-merge/contains-merge-commits
-    - do-not-merge/hold
-    - do-not-merge/invalid-commit-message
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/needs-kind
-    - do-not-merge/release-note-label-needed
-    - do-not-merge/work-in-progress
-    - needs-rebase
-    - "cla: no"
-  - author: gardener-ci-robot
-    repos:
-    - gardener/ci-infra
-    labels: # gardener-ci-robot should only create autobump PR with this label
-    - skip-review
-    - "cla: yes"
-    missingLabels:
-    - do-not-merge/blocked-paths
-    - do-not-merge/contains-merge-commits
-    - do-not-merge/hold
-    - do-not-merge/invalid-commit-message
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/release-note-label-needed
-    - do-not-merge/work-in-progress
-    - needs-rebase
-    - "cla: no"
-  - repos:
     - gardener/gardener
-    labels:
-    - lgtm
-    - approved
-    - "cla: yes"
-    missingLabels:
-    - do-not-merge/blocked-paths
-    - do-not-merge/contains-merge-commits
-    - do-not-merge/hold
-    - do-not-merge/invalid-commit-message
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/needs-kind
-    - do-not-merge/release-note-label-needed
-    - do-not-merge/work-in-progress
-    - needs-rebase
-    - "cla: no"
-  - repos:
     - gardener/gardener-extension-registry-cache
-    labels:
-    - lgtm
-    - approved
-    - "cla: yes"
-    missingLabels:
-    - do-not-merge/blocked-paths
-    - do-not-merge/contains-merge-commits
-    - do-not-merge/hold
-    - do-not-merge/invalid-commit-message
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/needs-kind
-    - do-not-merge/release-note-label-needed
-    - do-not-merge/work-in-progress
-    - needs-rebase
-    - "cla: no"
-  - repos:
-      - gardener/dependency-watchdog
-    labels:
-      - lgtm
-      - approved
-      - "cla: yes"
-    missingLabels:
-      - do-not-merge/blocked-paths
-      - do-not-merge/contains-merge-commits
-      - do-not-merge/hold
-      - do-not-merge/invalid-commit-message
-      - do-not-merge/invalid-owners-file
-      - do-not-merge/needs-kind
-      - do-not-merge/release-note-label-needed
-      - do-not-merge/work-in-progress
-      - needs-rebase
-      - "cla: no"
-  - repos:
+    - gardener/dependency-watchdog
     - gardener/gardener-extension-shoot-rsyslog-relp
-    labels:
-    - lgtm
-    - approved
-    - "cla: yes"
-    missingLabels:
-    - do-not-merge/blocked-paths
-    - do-not-merge/contains-merge-commits
-    - do-not-merge/hold
-    - do-not-merge/invalid-commit-message
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/needs-kind
-    - do-not-merge/release-note-label-needed
-    - do-not-merge/work-in-progress
-    - needs-rebase
-    - "cla: no"
-  - repos:
     - gardener/gardener-discovery-server
-    labels:
-    - lgtm
-    - approved
-    - "cla: yes"
-    missingLabels:
-    - do-not-merge/blocked-paths
-    - do-not-merge/contains-merge-commits
-    - do-not-merge/hold
-    - do-not-merge/invalid-commit-message
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/needs-kind
-    - do-not-merge/release-note-label-needed
-    - do-not-merge/work-in-progress
-    - needs-rebase
-    - "cla: no"
-  - repos:
     - gardener/cert-management
     labels:
     - lgtm
     - approved
     - "cla: yes"
-    missingLabels:
+    missingLabels: &tide-default-missing-labels
     - do-not-merge/blocked-paths
     - do-not-merge/contains-merge-commits
     - do-not-merge/hold
@@ -371,6 +260,16 @@ tide:
     - do-not-merge/work-in-progress
     - needs-rebase
     - "cla: no"
+
+  # configuration for automerging robot PRs
+  - author: gardener-ci-robot
+    repos:
+    - gardener/ci-infra
+    labels:
+    # gardener-ci-robot adds this label to PRs that should be merged automatically
+    - skip-review
+    - "cla: yes"
+    missingLabels: *tide-default-missing-labels
 
   context_options:
     # Use branch protection options to define required and optional contexts


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR configures tide to allow the `skip-review` label on PRs from @gardener-ci-robot on all repositories, that are onboarded to tide.
When the robot adds the `skip-review` label to its PRs, they are automatically merged without human interaction.

This can be used in renovate repository configs. E.g., for automerging patch updates of go dependencies.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Along the way, I deduplicated the tide config using yaml anchors.