### PR TITLE
renovate: use automerge comment

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,8 @@
     "config:recommended"
   ],
   "labels": ["kind/enhancement"],
+  "automergeType": "pr-comment",
+  "automergeComment": "/label skip-review",
   "postUpdateOptions": ["gomodTidy"],
   "customManagers": [
     {
@@ -72,7 +74,7 @@
         ],
         "executionMode": "branch"
       },
-      "addLabels": ["skip-review"],
+      "automerge": true,
       "schedule": ["after 08:30 and before 15:30 every weekday"]
     },
     {

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -49,6 +49,19 @@ label:
     - ipcei/oidc
     - ipcei/workload-identity
 
+  restricted_labels:
+    gardener:
+    # Allow gardener-ci-robot user to mark PRs for automerging without review using a `/label skip-review` command.
+    # This is useful with the following renovate configuration:
+    # {
+    #   "automergeType": "pr-comment",
+    #   "automergeComment": "/label skip-review"
+    # }
+    # Then, you can set `automerge=true` in the respective `packageRule`.
+    - allowed_users:
+      - gardener-ci-robot
+      label: skip-review
+
 lgtm:
 - repos:
   - gardener/ci-infra


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Follow-up to https://github.com/gardener/ci-infra/pull/2609:
This PR allows @gardener-ci-robot to use a `/label skip-review` comment for marking PRs to be automerged.
It also configures renovate in this repository to use the `automergeType=pr-comment` (see [docs](https://docs.renovatebot.com/configuration-options/#automergecomment)) as the first example.

With this, renovate `automerge=true` is well integrated with prow and tide.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
