### PR TITLE
renovate: ignore status checks for automerging

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,8 +4,20 @@
     "config:recommended"
   ],
   "labels": ["kind/enhancement"],
+
+  // These options teach renovate to work with tide automerging. Instead of automerging PRs itself, renovate will
+  // comment on the PR to set the `skip-review` label. Tide respects the `skip-review` label on all PRs opened by
+  // the robot user and merges PRs without review as soon as tests succeed.
+  // Note that we could also use `addLabels=["skip-review"]` instead of `automerge=true`. However, this config
+  // helps with reusing automerge-based renovate presets and is more intuitive to configure in package rules.
   "automergeType": "pr-comment",
   "automergeComment": "/label skip-review",
+  // Tide always registers the `tide` status check, which is always yellow until the PR has been approved (or the
+  // `skip-review` label has been set. Renovate will not consider a PR for automerge as long as status checks are
+  // red/yellow. We need to teach renovate to ignore all status checks and set the `skip-review` label right away.
+  // Tide will still consider the required status checks before automerging a PR.
+  "ignoreTests": true,
+
   "postUpdateOptions": ["gomodTidy"],
   "customManagers": [
     {


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Follow-up to https://github.com/gardener/ci-infra/pull/2616.
Without `ignoreTests=true`, renovate will never set the `skip-review` label on PRs because of the yellow `tide` status (e.g., https://github.com/gardener/ci-infra/pull/2639):
```
DEBUG: Branch status yellow (repository=gardener/ci-infra, branch=renovate/auto-update-renovate)
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Thanks @oliver-goetz for the analysis and suggestion :) 