### PR TITLE
Extract renovate `automerge-with-tide` preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,23 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "github>gardener/ci-infra//config/renovate/automerge-with-tide.json5"
   ],
   "labels": ["kind/enhancement"],
-
-  // These options teach renovate to work with tide automerging. Instead of automerging PRs itself, renovate will
-  // comment on the PR to set the `skip-review` label. Tide respects the `skip-review` label on all PRs opened by
-  // the robot user and merges PRs without review as soon as tests succeed.
-  // Note that we could also use `addLabels=["skip-review"]` instead of `automerge=true`. However, this config
-  // helps with reusing automerge-based renovate presets and is more intuitive to configure in package rules.
-  "automergeType": "pr-comment",
-  "automergeComment": "/label skip-review",
-  // Tide always registers the `tide` status check, which is always yellow until the PR has been approved (or the
-  // `skip-review` label has been set. Renovate will not consider a PR for automerge as long as status checks are
-  // red/yellow. We need to teach renovate to ignore all status checks and set the `skip-review` label right away.
-  // Tide will still consider the required status checks before automerging a PR.
-  "ignoreTests": true,
-
   "postUpdateOptions": ["gomodTidy"],
   "customManagers": [
     {

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Grafana is available publicly at https://monitoring.prow.gardener.cloud (trusted
 
 You can enable it by creating a `renovate.json5` file in the respective repository. Please check the [renovate docs](https://docs.renovatebot.com/configuration-options/) for the configuration options.
 
+This repository also hosts [shared config presets](config/renovate) for renovate to reuse common configuration across gardener repositories.
 
 ### Changing Renovate Configuration
 

--- a/config/renovate/README.md
+++ b/config/renovate/README.md
@@ -1,0 +1,33 @@
+# Shared Renovate Config Presets
+
+This directory hosts [shared config presets](https://docs.renovatebot.com/config-presets/) for renovate to reuse common configuration across gardener repositories.
+One example is teaching renovate to work with tide when `automerge=true` is set.
+
+Config presets are modular and should be kept as small as possible so that consuming repositories can precisely choose which presets to use.
+Typically, config presets are consumed from the default branch of the hosting repository.
+Hence, be mindful when changing the presets in this repository.
+
+## Using Config Presets From This Repository
+
+When you want to consume a renovate preset from this repository, pick a preset file name and add a corresponding `extends` item to the renovate config in your repository as follows:
+
+```json5
+{
+  "extends": [
+    "github>gardener/ci-infra//config/renovate/automerge-with-tide.json5"
+  ]
+}
+```
+
+Note that consuming repositories hosted on GitHub could also use a `local>` preset rule.
+However, `local>` preset rules are not supported with `--platform=local`, i.e., when executing a [local renovate dry-run](../../README.md#local-dry-run).
+
+## Testing Config Preset Changes
+
+Renovate always fetches config presets remotely, i.e., from GitHub – even if the referenced repository is the repository your working with locally.
+Because of this, you have to merge the preset's config directly into the renovate config file, when you want to test your changes to config presets in this repository using a [local dry-run](../../README.md#local-dry-run).
+As long as you have a remote reference in the `extends` array, renovate will not pick up your local changes.
+
+Also note that `renovate-config-validator` will not validate the referenced config presets.
+This is a good thing, because we only need one pull request to introduce and use presets in this repository.
+However, it also means that erroneous reference will only be noticed once renovate runs and adds error messages to the dependency dashboard.

--- a/config/renovate/automerge-with-tide.json5
+++ b/config/renovate/automerge-with-tide.json5
@@ -1,0 +1,14 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  description: "These options teach renovate to work with tide automerging. Instead of automerging PRs itself, renovate will comment on the PR to set the `skip-review` label. Tide respects the `skip-review` label on all PRs opened by the robot user and merges PRs without review as soon as tests succeed.",
+  // Note that we could also use `addLabels=["skip-review"]` instead of `automerge=true`. However, this config
+  // helps with reusing automerge-based renovate presets and is more intuitive to configure in package rules.
+  // Furthermore, the renovate PR description will correctly say "🚦 Automerge: Enabled".
+  automergeType: "pr-comment",
+  automergeComment: "/label skip-review",
+  // Tide always registers the `tide` status check, which is always yellow until the PR has been approved (or the
+  // `skip-review` label has been set. Renovate will not consider a PR for automerge as long as status checks are
+  // red/yellow. We need to teach renovate to ignore all status checks and set the `skip-review` label right away.
+  // Tide will still consider the required status checks before automerging a PR.
+  ignoreTests: true
+}


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Follow-up to https://github.com/gardener/ci-infra/pull/2616:
Make the renovate config for using tide-based automerging reusable in other repositories via a shared config preset.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/hold
let's see if https://github.com/gardener/ci-infra/pull/2642 actually works before merging this PR