### PR TITLE
Add more shared renovate config presets

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
   extends: [
     'config:recommended',
     'github>gardener/ci-infra//config/renovate/automerge-with-tide.json5',
+    'github>gardener/ci-infra//config/renovate/makefile-versions.json5',
   ],
   labels: ['kind/enhancement'],
   postUpdateOptions: ['gomodTidy'],
@@ -15,15 +16,6 @@
         'helm repo add .+ (?<registryUrl>.+?)\\s(.|\\n)*helm template -n .+ .+ .+\\/(?<depName>.+?) --version "(?<currentValue>.*)"\\s',
       ],
       datasourceTemplate: 'helm',
-    },
-    {
-      // Update `_VERSION` and `_version` variables in Makefiles and scripts.
-      // Inspired by `regexManagers:dockerfileVersions` preset.
-      customType: 'regex',
-      fileMatch: ['Makefile$', '\\.mk$', '\\.sh$'],
-      matchStrings: [
-        '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s.+?_(VERSION|version) *[?:]?= *"?(?<currentValue>.+?)"?\\s',
-      ],
     },
     {
       // Generic detection for pod-like and CLI-argument-like image specifications in prow jobs.

--- a/config/renovate/README.md
+++ b/config/renovate/README.md
@@ -19,6 +19,17 @@ When you want to consume a renovate preset from this repository, pick a preset f
 }
 ```
 
+When using a [parametrized preset](https://docs.renovatebot.com/config-presets/#preset-parameters), add an `extends` item like this:
+
+```json5
+{
+  extends: [
+    'github>gardener/ci-infra//config/renovate/imagevector.json5(^imagevector\/images.yaml$)',
+  ]
+}
+```
+
+
 Note that consuming repositories hosted on GitHub could also use a `local>` preset rule.
 However, `local>` preset rules are not supported with `--platform=local`, i.e., when executing a [local renovate dry-run](../../README.md#local-dry-run).
 

--- a/config/renovate/README.md
+++ b/config/renovate/README.md
@@ -13,8 +13,8 @@ When you want to consume a renovate preset from this repository, pick a preset f
 
 ```json5
 {
-  "extends": [
-    "github>gardener/ci-infra//config/renovate/automerge-with-tide.json5"
+  extends: [
+    'github>gardener/ci-infra//config/renovate/automerge-with-tide.json5',
   ]
 }
 ```

--- a/config/renovate/automerge-with-tide.json5
+++ b/config/renovate/automerge-with-tide.json5
@@ -1,11 +1,11 @@
 {
-  $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  description: "These options teach renovate to work with tide automerging. Instead of automerging PRs itself, renovate will comment on the PR to set the `skip-review` label. Tide respects the `skip-review` label on all PRs opened by the robot user and merges PRs without review as soon as tests succeed.",
-  // Note that we could also use `addLabels=["skip-review"]` instead of `automerge=true`. However, this config
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  description: 'These options teach renovate to work with tide automerging. Instead of automerging PRs itself, renovate will comment on the PR to set the `skip-review` label. Tide respects the `skip-review` label on all PRs opened by the robot user and merges PRs without review as soon as tests succeed.',
+  // Note that we could also use `addLabels=['skip-review']` instead of `automerge=true`. However, this config
   // helps with reusing automerge-based renovate presets and is more intuitive to configure in package rules.
   // Furthermore, the renovate PR description will correctly say "🚦 Automerge: Enabled".
-  automergeType: "pr-comment",
-  automergeComment: "/label skip-review",
+  automergeType: 'pr-comment',
+  automergeComment: '/label skip-review',
   // Tide always registers the `tide` status check, which is always yellow until the PR has been approved (or the
   // `skip-review` label has been set. Renovate will not consider a PR for automerge as long as status checks are
   // red/yellow. We need to teach renovate to ignore all status checks and set the `skip-review` label right away.

--- a/config/renovate/imagevector.json5
+++ b/config/renovate/imagevector.json5
@@ -1,0 +1,20 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  description: 'Regex manager for detecting dependencies in image vector files matched by the passed regex. If an image specifies a github.com sourceRepository, the manager extracts a dependency with the github-releases data source. Otherwise, it extracts a generic dependency with the docker data source.',
+  customManagers: [
+    {
+      // Generic detection of container images in imagevector via container registry.
+      customType: 'regex',
+      fileMatch: ['{{arg0}}'],
+      matchStrings: ['\\s+repository:\\s+(?<depName>.*?)\\n\\s+tag:\\s+"?(?<currentValue>.*?)"?\\n'],
+      datasourceTemplate: 'docker',
+    },
+    {
+      // Generic detection of container images in imagevector via github releases.
+      customType: 'regex',
+      fileMatch: ['{{arg0}}'],
+      matchStrings: ['\\s+sourceRepository:\\s+github.com\/(?<depName>.*?)\\n\\s+repository:\\s+.*\\n\\s+tag:\\s+"?(?<currentValue>.*?)"?\\n'],
+      datasourceTemplate: 'github-releases',
+    }
+  ]
+}

--- a/config/renovate/makefile-versions.json5
+++ b/config/renovate/makefile-versions.json5
@@ -1,0 +1,13 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  description: 'Regex manager for updating `_VERSION` and `_version` variables in Makefiles and scripts. Inspired by the `regexManagers:dockerfileVersions` preset.',
+  customManagers: [
+    {
+      customType: 'regex',
+      fileMatch: ['Makefile$', '\\.mk$', '\\.sh$'],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s.+?_(VERSION|version) *[?:]?= *"?(?<currentValue>.+?)"?\\s',
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

This PR adds more shared renovate config presets for config that we see in multiple gardener repositories:

- `makefile-versions`: Regex manager for updating `_VERSION` and `_version` variables in Makefiles and scripts
- `imagevector` (parametrized): Regex manager for detecting dependencies in image vector files matched by the passed regex

The `makefile-versions` preset is used in this repository right away.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
