### PR TITLE
[renovate] Do not install `helm` and `go` in `postUpgradeTasks`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,7 +47,6 @@
       ],
       postUpgradeTasks: {
         commands: [
-          'install-tool helm v3.15.2',
           'make generate-prow-deployments',
         ],
         executionMode: 'branch',
@@ -62,7 +61,6 @@
       ],
       postUpgradeTasks: {
         commands: [
-          'install-tool helm v3.15.2',
           'make generate-prow-deployments',
         ],
         executionMode: 'branch',
@@ -131,7 +129,6 @@
       matchFileNames: ['config/images/images.yaml'],
       postUpgradeTasks: {
         commands: [
-          'install-tool golang 1.22.5',
           'go install github.com/mikefarah/yq/v4@latest',
           'bash -c "sed -i `yq \'(.images[] | select(.source == \\"{{{depName}}}\\") | key) as \\$imagePos | (.images[\\$imagePos].tags | length) as \\$tagLength | .images[\\$imagePos].tags[\\$tagLength - 1] | line\' config/images/images.yaml`\'i\\  - {{{currentValue}}}\' config/images/images.yaml"',
         ],


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
We are using the full image of renovate now ([ref](https://github.com/gardener/ci-infra/blob/d1a5d2120efb46d6060f669f427162c390b1edee/config/prow/cluster/renovate/helm/values.yaml#L3-L4)). This image already includes [helm](https://github.com/renovatebot/base-image/blob/332493eaece33a21ee25e40fef93341ae8bf9866/Dockerfile#L99-L100) and [go](https://github.com/renovatebot/base-image/blob/332493eaece33a21ee25e40fef93341ae8bf9866/Dockerfile#L52-L53). Thus, it should not be necessary to install (and update) them separately.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timebertt 