### PR TITLE
Clean up test logs from gardener-prow GCS bucket

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -362,3 +362,56 @@ periodics:
     - name: github-token
       secret:
         secretName: github-token
+- cron: "0 23 * * *"
+  name: ci-gardener-cleanup-gardener-prow-gcs
+  cluster: gardener-prow-trusted
+  decorate: true
+  decoration_config:
+    timeout: 6h0m0s
+    grace_period: 15m
+  annotations:
+    description: Clean up test logs from gardener-prow GCS bucket
+    testgrid-create-test-group: "false"
+  reporter_config:
+    slack:
+      channel: prow-alerts
+  spec:
+    containers:
+    - image: rclone/rclone:1.68.1
+      command:
+      - rclone
+      args:
+      - delete
+      - gcs:gardener-prow
+      - --min-age
+      - 6M
+      - --include
+      - '*/artifacts/**{.log,flb_kube.db}*'
+      - --disable
+      - ListR
+      - --use-server-modtime
+      - --transfers
+      - "1000"
+      - --checkers
+      - "2000"
+      - --max-backlog
+      - "1000000"
+      resources:
+        requests:
+          cpu: 3
+          memory: 1Gi
+      volumeMounts:
+      - name: gcp-service-account
+        mountPath: /etc/gcp-service-account
+        readOnly: true
+      - name: rclone-config
+        mountPath: /config/rclone/rclone.conf
+        subPath: rclone.conf
+        readOnly: true
+    volumes:
+    - name: gcp-service-account
+      secret:
+        secretName: gardener-prow-gcr
+    - name: rclone-config
+      configMap:
+        name: rclone-config

--- a/config/prow/cluster/kustomization.yaml
+++ b/config/prow/cluster/kustomization.yaml
@@ -44,6 +44,7 @@ resources:
 - prow_controller_manager_rbac.yaml
 - prow_controller_manager_service.yaml
 - prow_controller_manager_vpa.yaml
+- rclone_config.yaml
 - sinker_deployment.yaml
 - sinker_rbac.yaml
 - sinker_service.yaml

--- a/config/prow/cluster/rclone_config.yaml
+++ b/config/prow/cluster/rclone_config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rclone-config
+  namespace: test-pods
+data:
+  rclone.conf: |
+    [gcs]
+    type = google cloud storage
+    service_account_file = /etc/gcp-service-account/service-account.json
+    location = europe-west3


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR deletes test logs from gardener-prow GCS bucket which are older than 6 months.
It deletes the logs from artifacts directory only. This includes logs created by our kind based e2e tests. Those logs a quite big and deleting them saves storage space and money.
The prow jobs themselves and their output are kept.

Base on PR #2637 with optimized parameters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timebertt 
