### PR TITLE
Increase timeouts of `*-gardener-e2e-kind` and `*-gardener-e2e-kind-ipv6` to 1h15min

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
@@ -7,7 +7,7 @@ presubmits:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true
     decoration_config:
-      timeout: 60m
+      timeout: 1h15m
       grace_period: 15m
     labels:
       preset-dind-enabled: "true"
@@ -47,7 +47,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 60m
+    timeout: 1h15m
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -7,7 +7,7 @@ presubmits:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true
     decoration_config:
-      timeout: 60m
+      timeout: 1h15m
       grace_period: 15m
     labels:
       preset-dind-enabled: "true"
@@ -45,7 +45,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 60m
+    timeout: 1h15m
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
See [here](https://github.com/gardener/gardener/pull/10843#issuecomment-2474089195) for the motivation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @shafeeqes 
