### PR TITLE
Corrected krte image and skip release regex pattern for etcd-druid jobs

### DIFF
--- a/config/jobs/etcd-druid/etcd-druid-e2e-kind-nondistroless-etcd.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-e2e-kind-nondistroless-etcd.yaml
@@ -4,7 +4,7 @@ presubmits:
       cluster: gardener-prow-build
       always_run: true
       skip_branches:
-        - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+        - hotfix-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
       decorate: true
       decoration_config:
         timeout: 60m
@@ -16,7 +16,7 @@ presubmits:
         description: Runs KIND cluster based e2e tests for etcd druid developments in pull requests with etcd-custom-image(nondistroless-etcd).
       spec:
         containers:
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240826-19b336b-1.21
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240826-19b336b-1.23
             command:
             - wrapper.sh
             - bash
@@ -54,7 +54,7 @@ periodics:
       fork-per-release: "true"
     spec:
       containers:
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240826-19b336b-1.21
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240826-19b336b-1.23
           command:
           - wrapper.sh
           - bash

--- a/config/jobs/etcd-druid/etcd-druid-e2e-kind-nondistroless-etcd.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-e2e-kind-nondistroless-etcd.yaml
@@ -16,7 +16,7 @@ presubmits:
         description: Runs KIND cluster based e2e tests for etcd druid developments in pull requests with etcd-custom-image(nondistroless-etcd).
       spec:
         containers:
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240826-19b336b-1.23
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20241114-98ed266-1.23
             command:
             - wrapper.sh
             - bash
@@ -54,7 +54,7 @@ periodics:
       fork-per-release: "true"
     spec:
       containers:
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240826-19b336b-1.23
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20241114-98ed266-1.23
           command:
           - wrapper.sh
           - bash

--- a/config/jobs/etcd-druid/etcd-druid-e2e-kind.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-e2e-kind.yaml
@@ -4,7 +4,7 @@ presubmits:
       cluster: gardener-prow-build
       always_run: true
       skip_branches:
-        - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+        - hotfix-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
       decorate: true
       decoration_config:
         timeout: 60m
@@ -16,7 +16,7 @@ presubmits:
         description: Runs KIND cluster based e2e tests for etcd druid developments in pull requests
       spec:
         containers:
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240826-19b336b-1.21
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240826-19b336b-1.23
             command:
             - wrapper.sh
             - bash
@@ -51,7 +51,7 @@ periodics:
       fork-per-release: "true"
     spec:
       containers:
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240826-19b336b-1.21
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20241114-98ed266-1.23
           command:
           - wrapper.sh
           - bash

--- a/config/jobs/etcd-druid/etcd-druid-e2e-kind.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-e2e-kind.yaml
@@ -16,7 +16,7 @@ presubmits:
         description: Runs KIND cluster based e2e tests for etcd druid developments in pull requests
       spec:
         containers:
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20240826-19b336b-1.23
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20241114-98ed266-1.23
             command:
             - wrapper.sh
             - bash

--- a/config/jobs/etcd-druid/etcd-druid-integration-tests.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-integration-tests.yaml
@@ -4,7 +4,7 @@ presubmits:
       cluster: gardener-prow-build
       always_run: true
       skip_branches:
-        - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+        - hotfix-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
       decorate: true
       decoration_config:
         timeout: 20m
@@ -15,7 +15,7 @@ presubmits:
       spec:
         containers:
           - name: test-integration
-            image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20241112-62a64b1-1.23
+            image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20241114-98ed266-1.23
             command:
               - make
             args:
@@ -46,7 +46,7 @@ periodics:
     spec:
       containers:
         - name: test-integration
-          image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20241112-62a64b1-1.23
+          image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20241114-98ed266-1.23
           command:
             - make
           args:

--- a/config/jobs/etcd-druid/etcd-druid-integration-tests.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-integration-tests.yaml
@@ -15,7 +15,7 @@ presubmits:
       spec:
         containers:
           - name: test-integration
-            image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20241114-98ed266-1.23
+            image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20241112-62a64b1-1.23
             command:
               - make
             args:
@@ -46,7 +46,7 @@ periodics:
     spec:
       containers:
         - name: test-integration
-          image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20241114-98ed266-1.23
+          image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20241112-62a64b1-1.23
           command:
             - make
           args:

--- a/config/jobs/etcd-druid/etcd-druid-test-builds.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-test-builds.yaml
@@ -4,7 +4,7 @@ presubmits:
       cluster: gardener-prow-build
       always_run: true
       skip_branches:
-        - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+        - hotfix-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
       annotations:
         description: Verify etcd-druid image build on pull requests to master branch
         fork-per-release: "true"

--- a/config/jobs/etcd-druid/etcd-druid-unit-tests.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-unit-tests.yaml
@@ -4,7 +4,7 @@ presubmits:
       cluster: gardener-prow-build
       always_run: true
       skip_branches:
-        - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+        - hotfix-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
       decorate: true
       decoration_config:
         timeout: 40m
@@ -16,7 +16,7 @@ presubmits:
         containers:
           # Run all tests sequentially in one container or as separate prow jobs.
           # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20241112-62a64b1-1.23
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20241114-98ed266-1.23
             command:
               - make
             args:
@@ -50,7 +50,7 @@ periodics:
       containers:
         # Run all tests sequentially in one container or as separate prow jobs.
         # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20241112-62a64b1-1.23
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20241114-98ed266-1.23
           command:
             - make
           args:

--- a/config/jobs/etcd-druid/etcd-druid-unit-tests.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-unit-tests.yaml
@@ -16,7 +16,7 @@ presubmits:
         containers:
           # Run all tests sequentially in one container or as separate prow jobs.
           # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20241114-98ed266-1.23
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20241112-62a64b1-1.23
             command:
               - make
             args:
@@ -50,7 +50,7 @@ periodics:
       containers:
         # Run all tests sequentially in one container or as separate prow jobs.
         # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20241114-98ed266-1.23
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20241112-62a64b1-1.23
           command:
             - make
           args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Fixes krte image for e2e jobs which now uses Golang 1.23 version.
Fixes regex pattern in skip_branches for e2e jobs to use `hotfix-v\d+.\d+` instead of `release-v\d+.\d+`

