### PR TITLE
Don't protect branches created by dependatbot or renovate

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -134,6 +134,9 @@ branch-protection:
           protect: true
           include:
           - "master"
+          exclude:
+          - "^dependabot/" # don't protect branches created by dependabot
+          - "^renovate/" # don't protect branches created by renovate
           required_status_checks:
             contexts:
             - license/cla
@@ -148,6 +151,9 @@ branch-protection:
           include:
           - "master"
           - "release-.*"
+          exclude:
+          - "^dependabot/" # don't protect branches created by dependabot
+          - "^renovate/" # don't protect branches created by renovate
           required_status_checks:
             contexts:
             - license/cla
@@ -162,6 +168,9 @@ branch-protection:
           protect: true
           include:
           - "main"
+          exclude:
+          - "^dependabot/" # don't protect branches created by dependabot
+          - "^renovate/" # don't protect branches created by renovate
           required_status_checks:
             contexts:
             - license/cla
@@ -176,6 +185,9 @@ branch-protection:
           protect: true
           include:
             - "master"
+          exclude:
+          - "^dependabot/" # don't protect branches created by dependabot
+          - "^renovate/" # don't protect branches created by renovate
           required_status_checks:
             contexts:
               - license/cla
@@ -190,6 +202,9 @@ branch-protection:
           protect: true
           include:
           - "main"
+          exclude:
+          - "^dependabot/" # don't protect branches created by dependabot
+          - "^renovate/" # don't protect branches created by renovate
           required_status_checks:
             contexts:
             - license/cla
@@ -204,6 +219,9 @@ branch-protection:
           protect: true
           include:
           - "main"
+          exclude:
+          - "^dependabot/" # don't protect branches created by dependabot
+          - "^renovate/" # don't protect branches created by renovate
           required_status_checks:
             contexts:
             - license/cla
@@ -218,6 +236,9 @@ branch-protection:
           protect: true
           include:
           - "master"
+          exclude:
+          - "^dependabot/" # don't protect branches created by dependabot
+          - "^renovate/" # don't protect branches created by renovate
           required_status_checks:
             contexts:
             - license/cla


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
We should not protect branches created by dependabot or renovate even when their branches match include rules.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @acumino 
