### PR TITLE
Add a prometheus instance for collecting performance metrics

### DIFF
--- a/config/prow/cluster/coredns/coredns-custom-config.yaml
+++ b/config/prow/cluster/coredns/coredns-custom-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  rewrites.override: |
+    rewrite stop {
+      # Add a local hostname that is rewritten to the in-cluster service name of the prow cluster.
+      # This hostname can be used by jobs to push collected performance metrics to the prometheus instance running in
+      # the prow cluster. The `cluster.local` name cannot be resolved from within e2e test setups running in a kind
+      # cluster in the test pod because the domain overlaps with the cluster domain of the inner (kind) cluster.
+      name exact prometheus-performance.prow.gardener.cloud.local prometheus-performance.monitoring.svc.cluster.local
+    }

--- a/config/prow/cluster/coredns/kustomization.yaml
+++ b/config/prow/cluster/coredns/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- coredns-custom-config.yaml

--- a/config/prow/cluster/monitoring/base-prow/grafana-deployment.yaml
+++ b/config/prow/cluster/monitoring/base-prow/grafana-deployment.yaml
@@ -15,6 +15,8 @@ spec:
           value: "true"
         - name: GF_AUTH_ORG_ROLE
           value: Viewer
+        - name: GF_USERS_VIEWERS_CAN_EDIT
+          value: "true"
         - name: GF_SECURITY_ADMIN_USER
           value: admin
         - name: GF_SECURITY_ADMIN_PASSWORD

--- a/config/prow/cluster/monitoring/build-cluster/grafana-datasources.yaml
+++ b/config/prow/cluster/monitoring/build-cluster/grafana-datasources.yaml
@@ -1,0 +1,16 @@
+apiVersion: 1
+datasources:
+- access: proxy
+  editable: false
+  name: prometheus
+  orgId: 1
+  type: prometheus
+  url: http://prometheus-k8s.monitoring.svc:9090
+  version: 1
+- access: proxy
+  editable: false
+  name: prometheus-performance
+  orgId: 1
+  type: prometheus
+  url: http://prometheus-performance.monitoring.svc:9090
+  version: 1

--- a/config/prow/cluster/monitoring/build-cluster/kustomization.yaml
+++ b/config/prow/cluster/monitoring/build-cluster/kustomization.yaml
@@ -17,6 +17,11 @@ secretGenerator:
   - cluster-name.tmpl={{ define "cluster_name" }}Build Cluster{{ end }}
   name: alertmanager-main
   namespace: monitoring
+- name: grafana-datasources
+  namespace: monitoring
+  behavior: merge
+  files:
+  - datasources.yaml=grafana-datasources.yaml
 patches:
 - path: grafana-deployment.yaml
 - path: prometheus.yaml

--- a/config/prow/cluster/monitoring/build-cluster/kustomization.yaml
+++ b/config/prow/cluster/monitoring/build-cluster/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - grafana-ingress.yaml
 - prow_prometheusrule.yaml
 - prometheus_vpa.yaml
+- prometheus-performance.yaml
 - ../base-prow
 
 secretGenerator:

--- a/config/prow/cluster/monitoring/build-cluster/prometheus-performance.yaml
+++ b/config/prow/cluster/monitoring/build-cluster/prometheus-performance.yaml
@@ -1,0 +1,101 @@
+# This prometheus instance serves as a store for performance metrics from CI jobs (e.g., e2e tests).
+# It enables the remote write receiver, so that jobs can push to this instance by adding a remote write config to
+# another prometheus instance inside the test pod.
+# Remote write configs can use the URL "http://prometheus-performance.prow.gardener.cloud.local:9090/api/v1/write",
+# where the hostname is rewritten by coredns in the prow cluster to prometheus-performance.monitoring.svc.cluster.local.
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: performance
+    app.kubernetes.io/name: prometheus
+  name: performance
+  namespace: monitoring
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: worker.gardener.cloud/system-components
+            operator: In
+            values:
+            - "true"
+  enableRemoteWriteReceiver: true
+  podMetadata:
+    labels:
+      app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: performance
+      app.kubernetes.io/name: prometheus
+  podMonitorNamespaceSelector:
+    matchLabels:
+      prometheus: performance
+  podMonitorSelector:
+    matchLabels:
+      prometheus: performance
+  probeNamespaceSelector: {}
+  probeSelector:
+    matchLabels:
+      prometheus: performance
+  replicas: 1
+  resources:
+    requests:
+      memory: 400Mi
+  retentionSize: 80GB
+  ruleNamespaceSelector: {}
+  ruleSelector:
+    matchLabels:
+      prometheus: performance
+  scrapeConfigNamespaceSelector: {}
+  scrapeConfigSelector:
+    matchLabels:
+      prometheus: performance
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
+  serviceMonitorNamespaceSelector: {}
+  serviceMonitorSelector:
+    matchLabels:
+      prometheus: performance
+  storage:
+    volumeClaimTemplate:
+      metadata:
+        name: prometheus
+        labels:
+          app.kubernetes.io/component: prometheus
+          app.kubernetes.io/instance: performance
+          app.kubernetes.io/name: prometheus
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        storageClassName: gce-ssd
+        resources:
+          requests:
+            storage: 100Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: performance
+    app.kubernetes.io/name: prometheus
+  name: prometheus-performance
+  namespace: monitoring
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: prometheus
+    operator.prometheus.io/name: performance
+  ports:
+  - name: http-web
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  - appProtocol: http
+    name: reloader-web
+    port: 8080
+    protocol: TCP
+    targetPort: reloader-web

--- a/config/prow/deploy.sh
+++ b/config/prow/deploy.sh
@@ -112,4 +112,9 @@ kubectl config use-context gardener-prow-build
 kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/athens"
 echo "$(color-green "done")"
 
+echo "$(color-step "Deploying coredns components to gardener-prow-build cluster...")"
+kubectl config use-context gardener-prow-build
+kubectl apply --server-side=true --force-conflicts -k "$SCRIPT_DIR/cluster/coredns"
+echo "$(color-green "done")"
+
 echo "$(color-green "SUCCESS")"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR adds another `Prometheus` object with the remote write receiver enabled in the prow build cluster.

Test jobs can push any performance metrics they want to persist over time to this instance by adding a remote write config to `http://prometheus-performance.monitoring.svc.cluster.local:9090/api/v1/write`.
Alternatively, the `prometheus-performance.prow.gardener.cloud.local` name is rewritten to the service in-cluster name by the prow build cluster's coredns. This is helpful for test jobs that run a kind cluster in the test pod, where a `*.svc.cluster.local` hostname from the outer cluster cannot be resolved within the inner cluster.

Furthermore, this PR allows unauthenticated users to use the `Explore` feature in Grafana, similar to https://github.com/gardener/gardener/pull/4140.

**Which issue(s) this PR fixes**:
Part of the 2024-12 Gardener Hackathon

**Special notes for your reviewer**:

https://github.com/gardener/gardener/pull/10964 is a proof-of-concept for pushing metrics to this instance

There is no visualization of the performance metrics yet.