### PR TITLE
Add missing base kustomization include

### DIFF
--- a/clusters/base/kustomization.yaml
+++ b/clusters/base/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- flux-system
-- ../base
+- test-pods-kustomization.yaml

--- a/clusters/prow-trusted/kustomization.yaml
+++ b/clusters/prow-trusted/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - flux-system
+- ../base


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Missing piece of https://github.com/gardener/ci-infra/pull/2813:
We missed including the base kustomization in the cluster-specific `flux-system` `Kustomization`. Hence, the `test-pods` `Kustomization` never got applied.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener-community/hackathon/tree/main/2024-12_Schelklingen
Follow-up to https://github.com/gardener/ci-infra/pull/2812

**Special notes for your reviewer**:
