### PR TITLE
Skip unneeded presubmit jobs on flux changes

### DIFF
--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -28,7 +28,7 @@ presubmits:
   - name: pull-ci-infra-prow-go-tests
     cluster: gardener-prow-build
     decorate: true
-    always_run: true
+    skip_if_only_changed: '^(clusters|config|deploy)\/'
     annotations:
       description: Runs go tests for prow developments in ci-infra 
     spec:
@@ -46,7 +46,7 @@ presubmits:
             memory: 2Gi
   - name: pull-ci-infra-verify-image-build
     cluster: gardener-prow-build
-    always_run: true
+    skip_if_only_changed: '^(clusters|config|deploy)\/'
     annotations:
       description: Verify ci-infra image build on pull requests to master branch
     decorate: true


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

When only changing contents of the flux or config-related directories, we don't need to run go-related test jobs.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener-community/hackathon/tree/main/2024-12_Schelklingen
Follow-up to https://github.com/gardener/ci-infra/pull/2812

**Special notes for your reviewer**:
