### PR TITLE
Skip unneeded postsubmit jobs on flux changes

### DIFF
--- a/config/jobs/ci-infra/build-ci-infra-images.yaml
+++ b/config/jobs/ci-infra/build-ci-infra-images.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - name: post-ci-infra-build-images
     cluster: gardener-prow-trusted
     # skip config/prow folder that build and autobumper do not end up in an endless loop
-    skip_if_only_changed: '^config\/|^hack\/(bootstrap|check|check-testgrid)-config\.sh|^images\/'
+    skip_if_only_changed: '^(clusters|config|deploy|hack\/(bootstrap|check|check-testgrid)-config\.sh|images)\/'
     branches:
     - ^master$
     annotations:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Similar to https://github.com/gardener/ci-infra/pull/2816 but for postsubmit jobs.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener-community/hackathon/tree/main/2024-12_Schelklingen
Follow-up to https://github.com/gardener/ci-infra/pull/2812

**Special notes for your reviewer**:
