### PR TITLE
Fix `athens` deployment in `flux`

### DIFF
--- a/deploy/athens/kustomization.yaml
+++ b/deploy/athens/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
 - athens-helmrepo.yaml
 - athens.yaml
 - athens_namespace.yaml
-- athens_deployment.yaml
 - athens_prometheus_rbac.yaml
 - athens_vpa.yaml
 


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Fixes bug in #2832.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener-community/hackathon/tree/main/2024-12_Schelklingen
Follow-up to https://github.com/gardener/ci-infra/pull/2812

**Special notes for your reviewer**:
/cc @timebertt 
