### PR TITLE
Fix athens deployment

### DIFF
--- a/deploy/athens/athens.yaml
+++ b/deploy/athens/athens.yaml
@@ -78,7 +78,6 @@ spec:
             kind: Deployment
             metadata:
               name: athens-proxy
-              namespace: athens
             spec:
               strategy:
                 type: RollingUpdate


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Fixes more bugs in #2832.

The athens chart doesn't set `metadata.namespace` in the deployment: https://github.com/gomods/athens-charts/blob/590014ace16e4a0fd12635aaa80b38c8dbdf9d4d/charts/athens-proxy/templates/deployment.yaml#L3-L6
Hence, we must omit it from the `postRenderer`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener-community/hackathon/tree/main/2024-12_Schelklingen
Follow-up to https://github.com/gardener/ci-infra/pull/2812

**Special notes for your reviewer**:
/cc @oliver-goetz 