### PR TITLE
Enable Static Application Security Testing (SAST) in dependency-watchdog unit tests

### DIFF
--- a/config/jobs/dependency-watchdog/dependency-watchdog-unit-tests.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-unit-tests.yaml
@@ -20,6 +20,7 @@ presubmits:
         - check
         - format
         - test
+        - sast-report
         resources:
           limits:
             memory: 16Gi
@@ -53,6 +54,7 @@ periodics:
       - check
       - format
       - test
+      - sast-report
       resources:
         limits:
           memory: 16Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Since https://github.com/gardener/dependency-watchdog/pull/130 is merged, we can enable Static Application Security Testing (SAST) in the `gardener/dependency-watchdog` repository. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
