### PR TITLE
Update tide merge label priority

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -311,9 +311,9 @@ tide:
   rebase_label: tide/merge-method-rebase
   merge_label: tide/merge-method-merge
   priority:
-  - labels: [ "kind/flake", "priority/critical-urgent" ]
-  - labels: [ "kind/regression", "priority/critical-urgent" ]
-  - labels: [ "kind/bug", "priority/critical-urgent" ]
+  - labels: [ "kind/flake" ]
+  - labels: [ "kind/regression" ]
+  - labels: [ "kind/bug" ]
 
 github_reporter:
   job_types_to_report:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
Remove not configured `priority/critical-urgent` label from requirements.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @oliver-goetz 
