### PR TITLE
pull-gardener-apidiff: Update the go version

### DIFF
--- a/config/jobs/gardener/gardener-apidiff.yaml
+++ b/config/jobs/gardener/gardener-apidiff.yaml
@@ -10,8 +10,7 @@ presubmits:
     spec:
       containers:
       - name: test
-        # don't update go version here until a go-apidiff release is available with new go version support.
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20240216-792399a-1.20
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250114-44ead50-1.23
         command:
         - make
         args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
Locally `make check-apidiff` with go1.23 runs without issues.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/11166

**Special notes for your reviewer**:
