### PR TITLE
Removed check-generate from etcd-druid-unit-tests.yaml

### DIFF
--- a/config/jobs/etcd-druid/etcd-druid-unit-tests.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-unit-tests.yaml
@@ -20,7 +20,6 @@ presubmits:
             command:
               - make
             args:
-              - check-generate
               - check
               - test-unit
             resources:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
Removes `check-generate` make target from `etcd-druid-unit-tests.yaml`.
https://github.com/gardener/etcd-druid/pull/988 introduces a separate go module for API. `check-generate` has been moved there.
In this PR we will remove `check-generate` target. Once the etcd-druid PR has been merged then `ci-infra` can be changed again to call `check-generate` target that is defined in the `Makefile` within the API go module.

**Special notes for your reviewer**:
