### PR TITLE
Revert "Bumping Prow and Prow - test-infra and Prow - ci-infra (#3134)"

### DIFF
--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -56,7 +56,7 @@ periodics:
     app: branchprotector
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/branchprotector:v20250202-8cd7d6837
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/branchprotector:v20250124-d572f855b
       command:
       - branchprotector
       args:
@@ -163,7 +163,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20250202-8cd7d6837
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20250124-d572f855b
       command:
       - generic-autobumper
       args:
@@ -194,7 +194,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20250202-8cd7d6837
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20250124-d572f855b
       command:
       - generic-autobumper
       args:
@@ -225,7 +225,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20250202-8cd7d6837
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20250124-d572f855b
       command:
       - generic-autobumper
       args:
@@ -256,7 +256,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20250202-8cd7d6837
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20250124-d572f855b
       command:
       - generic-autobumper
       args:
@@ -290,7 +290,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20250202-8cd7d6837
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20250124-d572f855b
       command:
       - checkconfig
       args:
@@ -322,7 +322,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20250202-8cd7d6837
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20250124-d572f855b
       command:
       - checkconfig
       args:

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       description: Runs checkconfig to validate changes to job configs, config.yaml and friends
     spec:
       containers:
-      - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20250202-8cd7d6837
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20250124-d572f855b
         command:
         - checkconfig
         args:

--- a/config/mkpj.sh
+++ b/config/mkpj.sh
@@ -17,7 +17,7 @@
 cd "$(git rev-parse --show-toplevel)"
 
 docker run -i --rm -w /etc/ci-infra -v $PWD:/etc/ci-infra \
-  us-docker.pkg.dev/k8s-infra-prow/images/mkpj:v20250202-8cd7d6837 \
+  us-docker.pkg.dev/k8s-infra-prow/images/mkpj:v20250124-d572f855b \
   --config-path=config/prow/config.yaml \
   --job-config-path=config/jobs \
   "$@"

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -17,10 +17,10 @@ plank:
       timeout: 2h
       grace_period: 15m
       utility_images:
-        clonerefs: "us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20250202-8cd7d6837"
-        initupload: "us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20250202-8cd7d6837"
-        entrypoint: "us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20250202-8cd7d6837"
-        sidecar: "us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20250202-8cd7d6837"
+        clonerefs: "us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20250124-d572f855b"
+        initupload: "us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20250124-d572f855b"
+        entrypoint: "us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20250124-d572f855b"
+        sidecar: "us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20250124-d572f855b"
       gcs_configuration:
         bucket: "gardener-prow"
         path_strategy: explicit

--- a/deploy/prow/crier_deployment.yaml
+++ b/deploy/prow/crier_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20250202-8cd7d6837
+        image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20250124-d572f855b
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/deploy/prow/deck_deployment.yaml
+++ b/deploy/prow/deck_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20250202-8cd7d6837
+        image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20250124-d572f855b
         imagePullPolicy: Always
         ports:
         - name: http

--- a/deploy/prow/ghproxy_deployment.yaml
+++ b/deploy/prow/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20250202-8cd7d6837
+        image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20250124-d572f855b
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=9

--- a/deploy/prow/hook_deployment.yaml
+++ b/deploy/prow/hook_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20250202-8cd7d6837
+        image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20250124-d572f855b
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/deploy/prow/horologium_deployment.yaml
+++ b/deploy/prow/horologium_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20250202-8cd7d6837
+        image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20250124-d572f855b
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/deploy/prow/needs-rebase_deployment.yaml
+++ b/deploy/prow/needs-rebase_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: us-docker.pkg.dev/k8s-infra-prow/images/needs-rebase:v20250202-8cd7d6837
+        image: us-docker.pkg.dev/k8s-infra-prow/images/needs-rebase:v20250124-d572f855b
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/deploy/prow/prow_controller_manager_deployment.yaml
+++ b/deploy/prow/prow_controller_manager_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20250202-8cd7d6837
+        image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20250124-d572f855b
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/deploy/prow/sinker_deployment.yaml
+++ b/deploy/prow/sinker_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20250202-8cd7d6837
+        image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20250124-d572f855b
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/deploy/prow/statusreconciler_deployment.yaml
+++ b/deploy/prow/statusreconciler_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20250202-8cd7d6837
+        image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20250124-d572f855b
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/deploy/prow/tide_deployment.yaml
+++ b/deploy/prow/tide_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20250202-8cd7d6837
+        image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20250124-d572f855b
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/hack/bootstrap-config.sh
+++ b/hack/bootstrap-config.sh
@@ -68,7 +68,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 docker run --rm -w /etc/ci-infra -v $PWD:/etc/ci-infra \
   -v "$temp_kubeconfig":/etc/kubeconfig \
-  us-docker.pkg.dev/k8s-infra-prow/images/config-bootstrapper:v20250202-8cd7d6837 \
+  us-docker.pkg.dev/k8s-infra-prow/images/config-bootstrapper:v20250124-d572f855b \
   --kubeconfig=/etc/kubeconfig \
   --source-path=.  \
   --config-path=config/prow/config.yaml \

--- a/hack/check-config.sh
+++ b/hack/check-config.sh
@@ -11,7 +11,7 @@ set -o pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 docker run --rm -w /etc/ci-infra -v $PWD:/etc/ci-infra \
-  us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20250202-8cd7d6837 \
+  us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20250124-d572f855b \
   --config-path=config/prow/config.yaml \
   --job-config-path=config/jobs \
   --plugin-config=config/prow/plugins.yaml \


### PR DESCRIPTION
This reverts commit 066e5bc616a407b8d6307bb1e8aec9e05b61c146.

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind regression

**What this PR does / why we need it**:
PR https://github.com/kubernetes-sigs/prow/pull/296 broke spyglass. See also https://github.com/kubernetes-sigs/prow/issues/369.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
