### PR TITLE
New prow job for etcd-druid API go module

### DIFF
--- a/config/jobs/etcd-druid/etcd-druid-api-unit-tests.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-api-unit-tests.yaml
@@ -12,53 +12,22 @@ presubmits:
         grace_period: 10m
       annotations:
         description: Runs unit tests for etcd-druid API in pull requests
-        fork-per-release: "true"
+        #fork-per-release: "true"
       spec:
         containers:
           # Run all tests sequentially in one container or as separate prow jobs.
           # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
           - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250129-fcd6b72-1.23
             command:
-              - bash
+              - make
             args:
-              - c
-              - "cd api && make check check-generate test-unit"
+              - --directory=api
+              - check
+              - check-generate
+              - test-unit
             resources:
               limits:
                 memory: 16Gi
               requests:
                 cpu: 4
                 memory: 8Gi
-periodics:
-  - name: ci-etcd-druid-api-unit
-    cluster: gardener-prow-build
-    interval: 4h
-    extra_refs:
-      - org: gardener
-        repo: etcd-druid
-        base_ref: master
-    decorate: true
-    decoration_config:
-      timeout: 40m
-      grace_period: 10m
-    annotations:
-      description: Runs unit tests for etcd-druid periodically
-      testgrid-dashboards: gardener-etcd-druid
-      testgrid-days-of-results: "60"
-      #fork-per-release: "true"
-    spec:
-      containers:
-        # Run all tests sequentially in one container or as separate prow jobs.
-        # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250129-fcd6b72-1.23
-          command:
-            - bash
-          args:
-            - c
-            - "cd api && make check check-generate test-unit"
-          resources:
-            limits:
-              memory: 16Gi
-            requests:
-              cpu: 4
-              memory: 8Gi

--- a/config/jobs/etcd-druid/etcd-druid-api-unit-tests.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-api-unit-tests.yaml
@@ -1,0 +1,64 @@
+presubmits:
+  gardener/etcd-druid:
+    - name: pull-etcd-druid-api-unit
+      cluster: gardener-prow-build
+      always_run: true
+      optional: true
+      skip_branches:
+        - hotfix-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
+      decorate: true
+      decoration_config:
+        timeout: 40m
+        grace_period: 10m
+      annotations:
+        description: Runs unit tests for etcd-druid API in pull requests
+        fork-per-release: "true"
+      spec:
+        containers:
+          # Run all tests sequentially in one container or as separate prow jobs.
+          # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250129-fcd6b72-1.23
+            command:
+              - bash
+            args:
+              - c
+              - "cd api && make check check-generate test-unit"
+            resources:
+              limits:
+                memory: 16Gi
+              requests:
+                cpu: 4
+                memory: 8Gi
+periodics:
+  - name: ci-etcd-druid-api-unit
+    cluster: gardener-prow-build
+    interval: 4h
+    extra_refs:
+      - org: gardener
+        repo: etcd-druid
+        base_ref: master
+    decorate: true
+    decoration_config:
+      timeout: 40m
+      grace_period: 10m
+    annotations:
+      description: Runs unit tests for etcd-druid periodically
+      testgrid-dashboards: gardener-etcd-druid
+      testgrid-days-of-results: "60"
+      #fork-per-release: "true"
+    spec:
+      containers:
+        # Run all tests sequentially in one container or as separate prow jobs.
+        # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250129-fcd6b72-1.23
+          command:
+            - bash
+          args:
+            - c
+            - "cd api && make check check-generate test-unit"
+          resources:
+            limits:
+              memory: 16Gi
+            requests:
+              cpu: 4
+              memory: 8Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
As part of https://github.com/gardener/etcd-druid/pull/988 a new API go module is being introduced. There are make targets specific to the API go module which needs to be run. This PR introduces a new job to change directory into the API go module and run the make targets defined there.

> NOTE: Since the above etcd-druid PR is still not merged, this job is marked as `optional` and also `fork-per-release: "true"` has been commented out. Once the etcd-druid PR gets merged another PR will be raised to remove optional and uncomment `fork-per-release`.

**Special notes for your reviewer**:
