### PR TITLE
Fix required_status_checks for cert-management

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -253,7 +253,8 @@ branch-protection:
             contexts:
             - license/cla
             - concourse-ci/build
-            - concourse-ci/build_oci_image_cert-management
+            - concourse-ci/build_oci_image_cert-management-linux-amd64
+            - concourse-ci/build_oci_image_cert-management-linux-arm64
             - concourse-ci/check
             - concourse-ci/publish
           restrictions: # prevent everyone from pushing/merging (except admins, gardener-prow and ci robots)


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:
Fix required_status_checks for cert-management after switching to multi-arch builds.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
