### PR TITLE
Use Go 1.24 for testing `gardener/gardener`

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-gardenadm.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-gardenadm.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec: &e2e-kind-gardenadm-spec
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
         command:
         - wrapper.sh
         - bash
@@ -59,7 +59,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-migration-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration-ha-single-zone.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-operator-seed.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator-seed.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-operator.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250214-f099a65-1.24
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250214-dca87c7-1.23
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250214-dca87c7-1.24
         command:
         - make
         args:
@@ -47,7 +47,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250214-dca87c7-1.23
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250214-dca87c7-1.24
       command:
       - make
       args:

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -16,7 +16,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250214-dca87c7-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250214-dca87c7-1.24
         command:
         - make
         args:
@@ -53,7 +53,7 @@ periodics:
     containers:
     # Run all tests sequentially in one container or as separate prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250214-dca87c7-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250214-dca87c7-1.24
       command:
       - make
       args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR updates the tests of `gardener/gardener` to Go 1.24. `golangci-lint` is on version v1.64.4 which support Go 1.24. `check-apidiff` is stuck with the new Go version so it keeps using Go 1.23.

For local development Go 1.24 is available on homebrew.

When it is merged we can merge https://github.com/gardener/gardener/pull/11367 to start building Gardener with it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
