### PR TITLE
Update ghcr.io/fluent/fluent-operator/fluent-bit Docker tag to v3.2.5

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -62,6 +62,7 @@ images:
   - v3.0.7
   - v3.1.5
   - v3.1.8
+  - v3.2.5
 # The kubesphere/fluent-operator image shall not be used anymore. Please use ghcr.io/fluent/fluent-operator/fluent-operator instead.
 - source: kubesphere/fluent-operator
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-operator


### PR DESCRIPTION
/kind enhancement

This PR brings current fluent-bit version (3.1.8) to the latest released fluent-bit version (3.2.5) supported by the fluent-operator.

Fluent-bit relase notes:
- [3.1.9](https://fluentbit.io/announcements/v3.1.9/)
- [3.2.0](https://fluentbit.io/announcements/v3.2.0/)
- [3.2.1](https://fluentbit.io/announcements/v3.2.1/)
- [3.2.2](https://fluentbit.io/announcements/v3.2.2/)
- [3.2.3](https://fluentbit.io/announcements/v3.2.3/)
- [3.2.4](https://fluentbit.io/announcements/v3.2.4/)
- [3.2.5](https://fluentbit.io/announcements/v3.2.5/)

**Special notes for your reviewer**:
None
