### PR TITLE
Add `runc@v1.24` into `krte` image

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -92,7 +92,11 @@ RUN echo "Installing Packages ..." \
         && sed -i 's/ulimit -Hn/# ulimit -Hn/g' /etc/init.d/docker \
     && echo "Ensuring Legacy Iptables ..." \
         && update-alternatives --set iptables /usr/sbin/iptables-legacy \
-        && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+        && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
+    && echo "Getting runc v1.2.4 ..." \
+        && mkdir -p /get-runc \
+        && curl -fsSL "https://github.com/opencontainers/runc/releases/download/v1.2.4/runc.$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o /get-runc/runc \
+        && chmod +x /get-runc/runc
 
 # entrypoint is our wrapper script, in Prow you will need to explicitly re-specify this
 ENTRYPOINT ["wrapper.sh"]

--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -97,6 +97,7 @@ RUN echo "Installing Packages ..." \
         && mkdir -p /get-runc \
         && curl -fsSL "https://github.com/opencontainers/runc/releases/download/v1.2.4/runc.$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o /get-runc/runc \
         && chmod +x /get-runc/runc
+    # TODO(marc1404): Remove runc part once kindest/node uses runc >= v1.2.4
 
 # entrypoint is our wrapper script, in Prow you will need to explicitly re-specify this
 ENTRYPOINT ["wrapper.sh"]


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds `runc@v1.24` into `krte` image. 
Currently it is download on every test ([ref](https://github.com/gardener/gardener/blob/master/pkg/provider-local/node/patch-runc.sh)), but this is not stable. Thus, if we add the runc binary into `krte` image, we can copy it from disk when testing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @marc1404 @rfranzke 
