### PR TITLE
Highlight `[TIMEDOUT]` in build log

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -76,6 +76,7 @@ deck:
           - "ERROR:"
           - "Error:"
           - (FAIL|Failure \[|FAILED)\b
+          - \bTIMEDOUT\b
           - panic\b
           - level=fatal\b
           - "fatal:"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

With more extensive usage of `SpecTimeout`, we are seeing more `[TIMEDOUT]` markers in the build log, similar to `[FAILED]` markers. Let's highlight them as well to make the test results easy to find.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11379

**Special notes for your reviewer**:
