### PR TITLE
registry-cache: Increase the e2e tests timeout from 60m to 1h10m

### DIFF
--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     decorate: true
     decoration_config:
-      timeout: 60m
+      timeout: 1h10m
       grace_period: 15m
     labels:
       preset-dind-enabled: "true"
@@ -42,7 +42,7 @@ periodics:
     base_ref: main
   decorate: true
   decoration_config:
-    timeout: 60m
+    timeout: 1h10m
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:
We noticed that occasionally the timeout of `60m` is not enough. See occurrence in https://github.com/gardener/gardener-extension-registry-cache/pull/363#issuecomment-2684174852

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A