### PR TITLE
chore: Revert "Add `runc@v1.24` into `krte` image (#3250)"

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -92,12 +92,7 @@ RUN echo "Installing Packages ..." \
         && sed -i 's/ulimit -Hn/# ulimit -Hn/g' /etc/init.d/docker \
     && echo "Ensuring Legacy Iptables ..." \
         && update-alternatives --set iptables /usr/sbin/iptables-legacy \
-        && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
-    && echo "Getting runc v1.2.4 ..." \
-        && mkdir -p /get-runc \
-        && curl -fsSL "https://github.com/opencontainers/runc/releases/download/v1.2.4/runc.$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" -o /get-runc/runc \
-        && chmod +x /get-runc/runc
-    # TODO(marc1404): Remove runc part once kindest/node uses runc >= v1.2.4
+        && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
 # entrypoint is our wrapper script, in Prow you will need to explicitly re-specify this
 ENTRYPOINT ["wrapper.sh"]


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind cleanup

**What this PR does / why we need it**:

This reverts commit c36f5d15621759b2bc5a5abba6919268f79279b3 (https://github.com/gardener/ci-infra/pull/3250).

The PR below reverts the version of `kindest/node` and removes the need for overriding `runc` in the image.
https://github.com/gardener/gardener/pull/11532

Hence, we no longer need to install it into the `krte` image.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:
/cc @oliver-goetz @LucaBernstein 

Special thanks to @oliver-goetz for coming up with this idea to improve the stability of the test runs while we had the patch 👏 