### PR TITLE
chore(deps): bump up fluent-operator to v3.3.0

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -77,6 +77,7 @@ images:
   - v2.9.0
   - v3.1.0
   - v3.2.0
+  - v3.3.0
 # DO NOT ADD NEW LOKI IMAGES.
 # With https://github.com/gardener/gardener/pull/7318 loki is replaced by vali.
 - source: grafana/loki


### PR DESCRIPTION
/kind enhancement

This PR updates fluent-operator image to v3.3.0
- [Release Notes v3.3.0](https://github.com/fluent/fluent-operator/releases/tag/v3.3.0)