### PR TITLE
Enable registry-cache for docker.io in image-builder

### DIFF
--- a/config/jobs/ci-infra/build-ci-infra-images.yaml
+++ b/config/jobs/ci-infra/build-ci-infra-images.yaml
@@ -37,6 +37,8 @@ postsubmits:
         - --add-date-sha-tag=true
         - --add-fixed-tag=latest
         - --kaniko-arg=--build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,direct
+        - --kaniko-arg=--registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
+        - --kaniko-arg=--insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
         - --kaniko-image=gcr.io/kaniko-project/executor:v1.23.2
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted

--- a/config/jobs/ci-infra/build-job-images.yaml
+++ b/config/jobs/ci-infra/build-job-images.yaml
@@ -29,6 +29,8 @@ postsubmits:
         - --dockerfile=images/copy-images/Dockerfile
         - --add-date-sha-tag=true
         - --add-fixed-tag=latest
+        - --kaniko-arg=--registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
+        - --kaniko-arg=--insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
         - --kaniko-image=gcr.io/kaniko-project/executor:v1.23.2
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted
@@ -75,6 +77,8 @@ postsubmits:
         - --registry=europe-docker.pkg.dev/gardener-project/releases/ci-infra
         - --target=krte
         - --context=images/krte
+        - --kaniko-arg=--registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
+        - --kaniko-arg=--insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
         - --kaniko-image=gcr.io/kaniko-project/executor:v1.23.2
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted

--- a/config/jobs/gardener/gardener-build-dev-images.yaml
+++ b/config/jobs/gardener/gardener-build-dev-images.yaml
@@ -28,6 +28,8 @@ postsubmits:
         - --target=golang-test
         - --context=hack/tools/image
         - --kaniko-arg=--build-arg=GOPROXY=http://athens-proxy.athens.svc.cluster.local,direct
+        - --kaniko-arg=--registry-mirror=registry-docker-io.kube-system.svc.cluster.local:5000
+        - --kaniko-arg=--insecure-registry=registry-docker-io.kube-system.svc.cluster.local:5000
         - --kaniko-image=gcr.io/kaniko-project/executor:v1.23.2
         # image-builder is the pod which is "scheduled" to a node. The pods created by image-builder have an affinity rule
         # which schedules them to the same node as their parent image-builder. This needs to be done, that PVCs could be mounted


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
We are currently facing rate limits from docker.io when building our dev images
- https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-gardener-build-golang-test-images/1900150703351926784
- https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-gardener-build-golang-test-images/1900148224694423552
- https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-gardener-build-golang-test-images/1900147451294126080

Thus, this PR activates a registry-mirror for docker.io for prow jobs which are using image-builder in trusted cluster.
I already activated the corresponding registry-cache in the cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
