### PR TITLE
Bump go version to 1.24 for gardener-discovery-server

### DIFF
--- a/config/jobs/gardener-discovery-server/gardener-discovery-server-e2e-kind.yaml
+++ b/config/jobs/gardener-discovery-server/gardener-discovery-server-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-discovery-server developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250325-6902af0-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250325-6902af0-1.24
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250325-6902af0-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250325-6902af0-1.24
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-discovery-server/gardener-discovery-server-unit-tests.yaml
+++ b/config/jobs/gardener-discovery-server/gardener-discovery-server-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-discovery-server developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250324-c046c2b-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250324-c046c2b-1.24
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250324-c046c2b-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250324-c046c2b-1.24
       command:
       - make
       args:


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:
Bump go version to 1.24 for gardener-discovery-server

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
x-ref: https://github.com/gardener/gardener-discovery-server/pull/106, vendoring github.com/gardener/gardener@v1.115.0 requires go1.24 