### PR TITLE
Support copying release notes with multiple lines in `cherrypicker`

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -43,7 +43,7 @@ const pluginName = "cherrypick"
 const defaultLabelPrefix = "cherrypick/"
 
 var cherryPickRe = regexp.MustCompile(`(?m)^(?:/cherrypick|/cherry-pick)\s+(.+)$`)
-var releaseNoteRe = regexp.MustCompile(`(\x60\x60\x60(breaking|feature|bugfix|doc|other) (user|operator|developer|dependency)( github\.com/\S+?/\S+?)?( #\d+?)?( @\S+?)?\s*\n(.+?)\n\x60\x60\x60)`)
+var releaseNoteRe = regexp.MustCompile(`(\x60\x60\x60(breaking|feature|bugfix|doc|other) (user|operator|developer|dependency)( github\.com/\S+?/\S+?)?( #\d+?)?( @\S+?)?\s*\n(((.+?)\n)+?)\x60\x60\x60)`)
 var titleTargetBranchIndicatorTemplate = `[%s] `
 
 var notOrgMemberMessageTemplate = "only [%s](https://github.com/orgs/%s/people) org members may request cherry picks. If you are already part of the org, make sure to [change](https://github.com/orgs/%s/people?query=%s) your membership to public. Otherwise you can still do the cherry-pick manually. "

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -1200,6 +1200,11 @@ func TestReleaseNoteFromParentPR(t *testing.T) {
 			input:    "foobar",
 			expected: "",
 		},
+		{
+			name:     "test11",
+			input:    "```feature developer\nUpdate the magic number from 42 to 49\n```\n```feature operator\nUpdate another magic number\nThis time with multiple lines\n```",
+			expected: "```feature developer github.com/foo/bar #123 @foo-author\nUpdate the magic number from 42 to 49\n```\n```feature operator github.com/foo/bar #123 @foo-author\nUpdate another magic number\nThis time with multiple lines\n```",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the regexp of `cherrypicker` that it is able to identify release note with multiple lines.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov @Kostov6 
