### PR TITLE
Run renovate disk cleanup script as `preCommand`

### DIFF
--- a/deploy/renovate/renovate.yaml
+++ b/deploy/renovate/renovate.yaml
@@ -27,10 +27,10 @@ spec:
     cronjob:
       schedule: "*/5 * * * *"
       concurrencyPolicy: Forbid
-      postCommand: |
+      preCommand: |
         disk_usage=$(df /tmp/renovate | awk 'NR==2 {print $5}' | tr -d '%')
         inode_usage=$(df -i /tmp/renovate | awk 'NR==2 {print $5}' | tr -d '%')
-        if [ "$disk_usage" -gt 95 ] || [ "$inode_usage" -gt 95 ]; then
+        if [ "$disk_usage" -gt 90 ] || [ "$inode_usage" -gt 90 ]; then
           echo "Disk usage: $disk_usage %"
           echo "Inode usage: $inode_usage %"
           echo "Renovate cache disk is almost full. Deleting contents of /tmp/renovate"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
With this PR the disk cleanup script of renovate runs as `preCommand` instead of `postCommand`. Otherwise, it is not executed if renovate fails because of exhausted disk space.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
