### PR TITLE
Upgraded images to use go 1.24 for dependency-watchdog

### DIFF
--- a/config/jobs/dependency-watchdog/dependency-watchdog-check-vulnerabilities.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-check-vulnerabilities.yaml
@@ -13,7 +13,7 @@ presubmits:
     spec:
       containers:
       - name: test
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250406-bcc745a-1.23
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250406-bcc745a-1.24
         command:
         - make
         args:
@@ -36,7 +36,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250406-bcc745a-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250406-bcc745a-1.24
       command:
       - make
       args:

--- a/config/jobs/dependency-watchdog/dependency-watchdog-e2e-kind.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-e2e-kind.yaml
@@ -16,7 +16,7 @@ presubmits:
         description: Runs KIND cluster based e2e tests for dependency watchdog developments in pull requests
       spec:
         containers:
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250407-a63e909-1.23
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250407-a63e909-1.24
             command:
               - wrapper.sh
               - bash
@@ -50,7 +50,7 @@ periodics:
       testgrid-days-of-results: "60"
     spec:
       containers:
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250407-a63e909-1.23
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250407-a63e909-1.24
           command:
             - wrapper.sh
             - bash

--- a/config/jobs/dependency-watchdog/dependency-watchdog-unit-tests.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-unit-tests.yaml
@@ -13,7 +13,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250406-bcc745a-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250406-bcc745a-1.24
         command:
         - make
         args:
@@ -47,7 +47,7 @@ periodics:
     containers:
     # Run all tests sequentially in one container or as separate prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250406-bcc745a-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250406-bcc745a-1.24
       command:
       - make
       args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
This PR upgrades the images used for DWD jobs.

**Which issue(s) this PR fixes**:
Fixes #3540
