### PR TITLE
[cert-management] Drop removed `check` step from `required_status_check`

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -273,7 +273,6 @@ branch-protection:
             - concourse-ci/build
             - concourse-ci/build_oci_image_cert-management-linux-amd64
             - concourse-ci/build_oci_image_cert-management-linux-arm64
-            - concourse-ci/check
             - concourse-ci/publish
           restrictions: # prevent everyone from pushing/merging (except admins, gardener-prow and ci robots)
             apps:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind cleanup

**What this PR does / why we need it**:
Drop `check` step from `required_status_check`, as it has been removed from the concourse build steps.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
