### PR TITLE
Bump go to 1.24 for shoot-oidc-service

### DIFF
--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-oidc-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250425-dfafe09-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250425-dfafe09-1.24
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250425-dfafe09-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250425-dfafe09-1.24
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for extension-shoot-oidc-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250425-c8c49e0-1.23
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250425-c8c49e0-1.24
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250425-c8c49e0-1.23
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250425-c8c49e0-1.24
       command:
       - make
       args:


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:
Bump go to 1.24 for shoot-oidc-service

Required by https://github.com/gardener/gardener-extension-shoot-oidc-service/pull/312
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @dimityrmirchev 