### PR TITLE
gardener: Sync the timeout of the periodic jobs with the presubmit ones

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-gardenadm.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-gardenadm.yaml
@@ -45,7 +45,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 1h15m
+    timeout: 2h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
@@ -45,7 +45,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 1h30m0s
+    timeout: 2h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -45,7 +45,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 1h15m
+    timeout: 2h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone-upgrade.yaml
@@ -45,7 +45,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 60m
+    timeout: 2h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-single-zone.yaml
@@ -45,7 +45,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 1h15m
+    timeout: 2h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
@@ -47,7 +47,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 1h15m
+    timeout: 2h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind-migration-ha-single-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration-ha-single-zone.yaml
@@ -45,7 +45,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 60m
+    timeout: 2h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -45,7 +45,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 60m
+    timeout: 2h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind-operator-seed.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator-seed.yaml
@@ -45,7 +45,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 60m
+    timeout: 2h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind-operator.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator.yaml
@@ -45,7 +45,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 60m
+    timeout: 2h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
@@ -45,7 +45,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 60m
+    timeout: 2h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -45,7 +45,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 1h15m
+    timeout: 2h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:
https://github.com/gardener/ci-infra/pull/3239 increased the timeout of the gardener/gardener presubmit jobs. However, it did not change the timeout of the corresponding periodic jobs.

I was looking into https://github.com/gardener/gardener/issues/12020 and almost all `ci-gardener-e2e-kind-ipv6` runs fail due to a timeout:
- https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ipv6/1919956091110690816 
```
{"component":"entrypoint","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:169","func":"sigs.k8s.io/prow/pkg/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 1h15m0s timeout","severity":"error","time":"2025-05-07T04:38:58Z"}
```

- https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ipv6/1919835293406466048
```
https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ipv6/1919835293406466048
{"component":"entrypoint","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:169","func":"sigs.k8s.io/prow/pkg/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 1h15m0s timeout","severity":"error","time":"2025-05-06T20:38:19Z"}
```

- https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ipv6/1919774894871023616
```
{"component":"entrypoint","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:267","func":"sigs.k8s.io/prow/pkg/entrypoint.gracefullyTerminate","level":"error","msg":"Process did not exit before 15m0s grace period","severity":"error","time":"2025-05-06T16:53:19Z"}
```

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12020

**Special notes for your reviewer**:
N/A