### PR TITLE
Harmonize config of `approve` and `lgtm` plugins

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -29,6 +29,8 @@ approve:
   - gardener/gardener-extension-shoot-cert-service
   - gardener/gardener-discovery-server
   - gardener/cert-management
+  - gardener/gardener-extension-networking-calico
+  - gardener/gardener-extension-networking-cilium
   lgtm_acts_as_approve: false
   require_self_approval: true
   commandHelpLink: "https://prow.gardener.cloud/command-help"
@@ -75,6 +77,8 @@ lgtm:
   - gardener/gardener-extension-shoot-cert-service
   - gardener/gardener-discovery-server
   - gardener/cert-management
+  - gardener/gardener-extension-networking-calico
+  - gardener/gardener-extension-networking-cilium
   review_acts_as_lgtm: true
   store_tree_hash: true
 


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
The configuration of `approve` and `lgtm` plugins of `gardener/gardener-extension-networking-calico` and `gardener/gardener-extension-networking-cilium` repositories are different than the other prow enabled repositories.
This PR harmonizes these settings, that prow acts the same way for all repositories.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ 
