### PR TITLE
Enable e2e test for gardener-extension-shoot-cert-service

### DIFF
--- a/config/jobs/extension-shoot-cert-service/extension-shoot-cert-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-cert-service/extension-shoot-cert-service-e2e-kind.yaml
@@ -1,0 +1,91 @@
+presubmits:
+  gardener/gardener-extension-shoot-cert-service:
+  - name: pull-extension-shoot-cert-service-e2e-kind
+    cluster: gardener-prow-build
+    always_run: true
+    decorate: true
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for gardener-extension-shoot-cert-service developments in pull requests
+    spec:
+      containers:
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250612-f002e5f-1.24
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - |
+          set -o nounset
+          set -o pipefail
+          set -o errexit
+
+          # https://github.com/kubernetes/test-infra/issues/23741
+          iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
+          # run test
+          make test-e2e-local
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 6
+            memory: 18Gi
+        env:
+        - name: SKAFFOLD_UPDATE_CHECK
+          value: "false"
+        - name: SKAFFOLD_INTERACTIVE
+          value: "false"
+periodics:
+- name: ci-extension-shoot-cert-service-e2e-kind
+  cluster: gardener-prow-build
+  interval: 24h
+  extra_refs:
+  - org: gardener
+    repo: gardener-extension-shoot-cert-service
+    base_ref: master
+  decorate: true
+  decoration_config:
+    timeout: 60m
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  annotations:
+    description: Runs end-to-end tests for gardener-extension-shoot-cert-service developments periodically
+    testgrid-dashboards: gardener-extension-shoot-cert-service
+    testgrid-days-of-results: "60"
+  spec:
+    containers:
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250612-f002e5f-1.24
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - |
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+
+        # https://github.com/kubernetes/test-infra/issues/23741
+        iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
+        # run test
+        make test-e2e-local
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 6
+          memory: 18Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:
Enable e2e test for gardener-extension-shoot-cert-service.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
