### PR TITLE
Replicate Perses and Perses Operator images to Gardener GCR

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -164,6 +164,17 @@ images:
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/opentelemetry-operator/opentelemetry-operator
   tags:
   - v0.127.0
+- source: persesdev/perses
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/persesdev/perses
+  tags:
+  - v0.50.3
+  - v0.51.0
+- source: persesdev/perses-operator
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/persesdev/perses-operator
+  tags:
+  - v0.1.10
+  - v0.1.12
+  - v0.2.0
 # gardener/pkg/provider-local/images.yaml
 - source: kindest/local-path-provisioner
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/kindest/local-path-provisioner


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Adds the Perses and Perses Operator images to GCR. They are hosted on docker hub and need to be replicated.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
cc @ialidzhikov 
