### PR TITLE
[discovery-server] Increase memory limit to 3Gi for unit-tests job

### DIFF
--- a/config/jobs/gardener-discovery-server/gardener-discovery-server-unit-tests.yaml
+++ b/config/jobs/gardener-discovery-server/gardener-discovery-server-unit-tests.yaml
@@ -18,7 +18,7 @@ presubmits:
         - verify-extended
         resources:
           limits:
-            memory: 2Gi
+            memory: 3Gi
           requests:
             cpu: 2
             memory: 1Gi
@@ -47,7 +47,7 @@ periodics:
       - verify-extended
       resources:
         limits:
-          memory: 2Gi
+          memory: 3Gi
         requests:
           cpu: 2
           memory: 1Gi


### PR DESCRIPTION
/kind task

**What this PR does / why we need it**:
Increase memory limit to 3Gi for unit-tests job


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I see the unit-tests job to fail with OOMKilled too often, usually during the linting phase.
Let's slightly increase the memory limit from 2Gi to 3Gi. 