### PR TITLE
Trust `gardener-github-actions` github app in networking extension repositories

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -359,6 +359,7 @@ branch-protection:
           restrictions: # prevent everyone from pushing/merging (except admins, gardener-prow and ci robots)
             apps:
               - gardener-prow
+              - gardener-github-actions
             users: []
             teams:
               - ci # allow CI users (e.g. concourse) to push (e.g. release commits)
@@ -380,6 +381,7 @@ branch-protection:
           restrictions: # prevent everyone from pushing/merging (except admins, gardener-prow and ci robots)
             apps:
               - gardener-prow
+              - gardener-github-actions
             users: []
             teams:
               - ci # allow CI users (e.g. concourse) to push (e.g. release commits)


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
`gardener-github-actions` Github app should be able to create release commits.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ 
