### PR TITLE
ci: Replace Concourse with GHA in status checks of DNS-/cert-management

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -289,13 +289,11 @@ branch-protection:
           required_status_checks:
             contexts:
             - license/cla
-            - concourse-ci/build
-            - concourse-ci/build_oci_image_cert-management-linux-amd64
-            - concourse-ci/build_oci_image_cert-management-linux-arm64
-            - concourse-ci/publish
+            - "component-descriptor / component-descriptor"
           restrictions: # prevent everyone from pushing/merging (except admins, gardener-prow and ci robots)
             apps:
             - gardener-prow
+            - gardener-github-actions
             users: []
             teams:
             - ci # allow CI users (e.g. concourse) to push (e.g. release commits)
@@ -310,15 +308,11 @@ branch-protection:
           required_status_checks:
             contexts:
               - license/cla
-              - concourse-ci/build
-              - concourse-ci/build_oci_image_dns-controller-manager-linux-amd64
-              - concourse-ci/build_oci_image_dns-controller-manager-linux-arm64
-              - concourse-ci/helmcharts
-              - concourse-ci/verify
-              - concourse-ci/publish
+              - "component-descriptor / component-descriptor"
           restrictions: # prevent everyone from pushing/merging (except admins, gardener-prow and ci robots)
             apps:
               - gardener-prow
+              - gardener-github-actions
             users: []
             teams:
               - ci # allow CI users (e.g. concourse) to push (e.g. release commits)


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind cleanup

**What this PR does / why we need it**:

Akin to:
* https://github.com/gardener/ci-infra/pull/4055

This PR replaces the required status checks of `external-dns-management` and `cert-management` with the new, respective GitHub Action.
Both repositories have been migrated from Concourse to GitHub Actions:
* https://github.com/gardener/external-dns-management/pull/531
* https://github.com/gardener/cert-management/pull/520

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @oliver-goetz @MartinWeindel 