### PR TITLE
Configure IPv4/IPv6 dual stack for `ingress-nginx` 💡 

### DIFF
--- a/deploy/ingress-nginx/ingress-nginx.yaml
+++ b/deploy/ingress-nginx/ingress-nginx.yaml
@@ -68,6 +68,10 @@ spec:
       service:
         annotations:
           service.kubernetes.io/topology-mode: Auto
+        ipFamilyPolicy: PreferDualStack
+        ipFamilies:
+        - IPv4
+        - IPv6
       admissionWebhooks:
         service:
           annotations:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

**What this PR does / why we need it**:
Prow clusters run in IPv4/IPv6 dual stack, so we could enable it for the `ingress-nginx` load-balancer service.

Ref: Ref: https://github.com/kubernetes/ingress-nginx/blob/9dc73d17c76e2289408ebff2f3446b8b13c3e72e/charts/ingress-nginx/values.yaml#L537-L544

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ 
