### PR TITLE
Remove 'v' from otel-collector tags

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -169,8 +169,8 @@ images:
 - source: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/opentelemetry-collector-releases/opentelemetry-collector-contrib
   tags:
-  - v0.127.0
-  - v0.129.1
+  - 0.127.0
+  - 0.129.1
 - source: persesdev/perses
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/persesdev/perses
   tags:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug
**What this PR does / why we need it**:
https://github.com/gardener/ci-infra/pull/4104 added otel-collector contrib images, but the tags include a 'v' in the upstream tags that should not be there.
**Which issue(s) this PR fixes**:
NONE
**Special notes for your reviewer**:
