### PR TITLE
registry-cache: Increase the memory requests and limits for the unit tests

### DIFF
--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
@@ -18,10 +18,10 @@ presubmits:
         - verify-extended
         resources:
           limits:
-            memory: 3Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 1Gi
+            memory: 4Gi
 periodics:
 - name: ci-gardener-extension-registry-cache-unit
   cluster: gardener-prow-build
@@ -47,7 +47,7 @@ periodics:
       - verify-extended
       resources:
         limits:
-          memory: 3Gi
+          memory: 6Gi
         requests:
           cpu: 2
-          memory: 1Gi
+          memory: 4Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Increases memory requests and limits for `registry-cache` unit tests jobs to prevent `OOMKilled` failures. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-registry-cache/issues/430

**Special notes for your reviewer**:
/cc @ialidzhikov  