### PR TITLE
rsyslog-relp: Increase the memory requests and limits for the unit tests

### DIFF
--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
@@ -18,10 +18,10 @@ presubmits:
         - verify-extended
         resources:
           limits:
-            memory: 3Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 1Gi
+            memory: 4Gi
 periodics:
 - name: ci-gardener-extension-shoot-rsyslog-relp
   cluster: gardener-prow-build
@@ -47,7 +47,7 @@ periodics:
       - verify-extended
       resources:
         limits:
-          memory: 3Gi
+          memory: 6Gi
         requests:
           cpu: 2
-          memory: 1Gi
+          memory: 4Gi


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Increases memory requests and limits for `rsyslog-relp` unit tests jobs to prevent `OOMKilled` failures and `golangci-lint` timeouts.
<img width="356" height="182" alt="image" src="https://github.com/user-attachments/assets/7de62170-e32f-4eeb-98b6-695fb5de1136" />


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Similar to #4153 
/cc @ialidzhikov @plkokanov 