### PR TITLE
chore: Improve Go Renovate group

### DIFF
--- a/config/renovate/group-go-updates.json5
+++ b/config/renovate/group-go-updates.json5
@@ -8,7 +8,7 @@
       matchPackageNames: [
         'actions/go-versions',
         'go',
-        'golang',
+        '/golang/',
       ],
     },
   ],


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:

Noticed that `g/g` already has a package rule for grouping Go (Docker) updates, but it matches `golang` as a substring in package names:
https://github.com/gardener/gardener/blob/80e0ba15811d22e54b1771f60a59d066009d483e/.github/renovate.json5#L112-L121

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @tobschli 