### PR TITLE
chore: Mirror tag `v1.35.1` for `envoy-proxy/envoy-distroless`

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -119,6 +119,7 @@ images:
   - v1.34.2
   - v1.34.3
   - v1.35.0
+  - v1.35.1
 - source: ghcr.io/credativ/vali
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/vali
   tags:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:

Adds the image tag [v1.35.1 of envoy-proxy/envoy-distroless](https://hub.docker.com/layers/envoyproxy/envoy/distroless-v1.35.1/images/sha256-dddd8708c19af12ce17d81fde9e76e6e983e156071b75ffd0babcb8e26a107c5) to be mirrored from the Docker registry to our own.
Required for: https://github.com/gardener/gardener/pull/12773

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

_n.a._