### PR TITLE
temp: Revert mirroring `envoyproxy/envoy-distroless:v1.35.1`

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -119,7 +119,6 @@ images:
   - v1.34.2
   - v1.34.3
   - v1.35.0
-  - v1.35.1
 - source: ghcr.io/credativ/vali
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/vali
   tags:


### PR DESCRIPTION
This reverts commit 3a7f17a4137a0da5f9981bd8b3c03f72c43c064b.

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind cleanup

**What this PR does / why we need it**:

Reverts: https://github.com/gardener/ci-infra/pull/4321

I mistakenly thought the new tag `v1.35.1` had been published already, which is not the case.
We need to wait until it has been published.

**Which issue(s) this PR fixes**:

The Prow job [post-ci-infra-copy-images](https://prow.gardener.cloud/job-history/gs/gardener-prow/logs/post-ci-infra-copy-images) fails because the tag has not yet been published in the Docker registry.

**Special notes for your reviewer**:

/cc @tobschli 