### PR TITLE
ci: Maintain `krte` image variants (removed 1.23, added 1.25)

### DIFF
--- a/images/krte/variants.yaml
+++ b/images/krte/variants.yaml
@@ -1,7 +1,7 @@
 variants:
-  "1.23":
-    IMAGE_ARG: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:1.23
-    golangtestimage: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250819-c20d748-1.23
   "1.24":
     IMAGE_ARG: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:1.24
     golangtestimage: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250821-d9d7dcb-1.24
+  "1.25":
+    IMAGE_ARG: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:1.25
+    golangtestimage: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250821-b78c985-1.25


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:

* Removed `1.23` as Go `1.23` has reached end-of-life
* Added `1.25` as `golang-test:1.25` is available ([ref](https://console.cloud.google.com/artifacts/docker/gardener-project/europe/releases/ci-infra%2Fgolang-test/sha256:d1d308dc29d8b523f658455ef4cb193a4f902b916cf8caace1ff84c9e5dc310a))

**Which issue(s) this PR fixes**:

Follow-up to:
* https://github.com/gardener/gardener/pull/12770

Preparation for:
* https://github.com/gardener/gardener/pull/12753

**Special notes for your reviewer**:

/cc @LucaBernstein 
