### PR TITLE
ci: Use Go 1.25 for testing `gardener/gardener`

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-gardenadm.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-gardenadm.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec: &e2e-kind-gardenadm-spec
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-node-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-node-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-node.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-node.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
         command:
         - wrapper.sh
         - bash
@@ -59,7 +59,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-migration-ha-multi-node.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration-ha-multi-node.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-operator-seed.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator-seed.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-operator.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -17,7 +17,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
         command:
         - wrapper.sh
         - bash
@@ -57,7 +57,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250821-f8e47e8-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250821-0dfbbc4-1.24
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250821-0dfbbc4-1.25
         command:
         - make
         args:
@@ -47,7 +47,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250821-0dfbbc4-1.24
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250821-0dfbbc4-1.25
       command:
       - make
       args:

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -16,7 +16,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250821-0dfbbc4-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250821-0dfbbc4-1.25
         command:
         - make
         args:
@@ -53,7 +53,7 @@ periodics:
     containers:
     # Run all tests sequentially in one container or as separate prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250821-0dfbbc4-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250821-0dfbbc4-1.25
       command:
       - make
       args:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:

Updates the images used for testing [gardener/gardener](https://github.com/gardener/gardener) to Go 1.25.
* [krte:v20250821-f8e47e8-1.25](https://console.cloud.google.com/artifacts/docker/gardener-project/europe/releases/ci-infra%2Fkrte/sha256:dee6c8ab38d925a6307690109a5d8ddc33f042432e0dbb2ea86772e49550bbe0)
* [golang-test:v20250821-0dfbbc4-1.25](https://console.cloud.google.com/artifacts/docker/gardener-project/europe/releases/ci-infra%2Fgolang-test/sha256:a183507d4203060f2c372ec30f284f947d7e27629c0b2f4af73e140fba6133bc)

`golangci-lint` is on version [v2.4.0](https://github.com/golangci/golangci-lint/releases/tag/v2.4.0) and supports Go 1.25.

`go-apidiff` in version [`v0.8.3`](https://github.com/joelanford/go-apidiff/blob/60c4206be8f84348ebda2a3e0c3ac9cb54b8f685/go.mod#L3) is stuck on Go 1.23 and remains there.

**Which issue(s) this PR fixes**:

Follow-up to: https://github.com/gardener/ci-infra/pull/4332
Preparation for: https://github.com/gardener/gardener/pull/12753

**Special notes for your reviewer**:

Based on the previous PR for Go 1.24:
* https://github.com/gardener/ci-infra/pull/3207

/cc @LucaBernstein 
