### PR TITLE
Switch envoy image source from `envoyproxy/envoy-distroless:<version>` to `envoyproxy/envoy:distroless-<version>`

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -92,6 +92,8 @@ images:
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/grafana/promtail
   tags:
   - 2.2.1
+# This source seems to be outdated. No new images are pushed here anymore.
+# Please use envoyproxy/envoy:distroless-<version> instead.
 - source: envoyproxy/envoy-distroless
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/envoyproxy/envoy-distroless
   tags:
@@ -119,6 +121,10 @@ images:
   - v1.34.2
   - v1.34.3
   - v1.35.0
+- source: envoyproxy/envoy
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/envoyproxy/envoy
+  tags:
+  - distroless-v1.35.1
 - source: ghcr.io/credativ/vali
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/vali
   tags:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
No new images are pushed to the old place anymore.

According to https://hub.docker.com/r/envoyproxy/envoy the source for distroless images is `envoyproxy/envoy:distroless-<version>`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @marc1404 
