### PR TITLE
Support `distroless-v<version>` versioning scheme for envoy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,16 +21,6 @@
   },
   customManagers: [
     {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/config/prow/cluster/.+/helm/generate-.+-deployments.sh$/',
-      ],
-      matchStrings: [
-        'helm repo add .+ (?<registryUrl>.+?)\\s(.|\\n)*helm template -n .+ .+ .+\\/(?<depName>.+?) --version "(?<currentValue>.*)"\\s',
-      ],
-      datasourceTemplate: 'helm',
-    },
-    {
       // Generic detection for pod-like and CLI-argument-like image specifications in prow jobs.
       customType: 'regex',
       managerFilePatterns: [
@@ -54,22 +44,6 @@
     },
   ],
   packageRules: [
-    {
-      groupName: 'prow apps',
-      matchDatasources: [
-        'github-releases',
-        'helm',
-      ],
-      matchPackageNames: [
-        '/prometheus-operator/kube-prometheus/',
-      ],
-      postUpgradeTasks: {
-        commands: [
-          'make generate-prow-deployments',
-        ],
-        executionMode: 'branch',
-      },
-    },
     {
       groupName: 'renovate',
       matchDatasources: [
@@ -124,26 +98,18 @@
       ],
       enabled: false,
     },
+    // Support distroless versioning scheme for envoy images.
     {
-      // Pin grafana to the latest minor version published with Apache 2.0 license.
       matchDatasources: [
         'docker',
       ],
-      matchUpdateTypes: [
-        'major',
-        'minor',
-      ],
       matchPackageNames: [
-        '/grafana/grafana/',
+        'envoyproxy/envoy',
       ],
-      enabled: false,
-    },
-    // Support distroless versioning scheme for envoy images.
-    {
-      matchDatasources: ["docker"],
-      matchPackageNames: ["envoyproxy/envoy"],
-      matchFileNames: ["config/images/images.yaml"],
-      versioning: "regex:^distroless-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+      matchFileNames: [
+        'config/images/images.yaml',
+      ],
+      versioning: 'regex:^distroless-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$'
     },
     {
       // Pin certain components to the current version.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,7 +48,7 @@
         '/^config/images/images\\.yaml$/',
       ],
       matchStrings: [
-        '\\s+source:\\s+(?<depName>.+?)\\n\\s+destination:\\s+.*\\n\\s+tags:\\n(\\s+-\\s+v?[0-9][0-9a-zA-Z\\-\\.]*\\n)*\\s+-\\s+(?<currentValue>.+?)\\n',
+        '\\s+source:\\s+(?<depName>.+?)\\n\\s+destination:\\s+.*\\n\\s+tags:\\n(\\s+-\\s+v?[0-9a-zA-Z\\-\\.]*[0-9][0-9a-zA-Z\\-\\.]*\\n)*\\s+-\\s+(?<currentValue>.+?)\\n',
       ],
       datasourceTemplate: 'docker',
     },
@@ -137,6 +137,13 @@
         '/grafana/grafana/',
       ],
       enabled: false,
+    },
+    // Support distroless versioning scheme for envoy images.
+    {
+      matchDatasources: ["docker"],
+      matchPackageNames: ["envoyproxy/envoy"],
+      matchFileNames: ["config/images/images.yaml"],
+      versioning: "regex:^distroless-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
     },
     {
       // Pin certain components to the current version.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
`envoyproxy/envoy` is using a versioning scheme which renovate does not support by default. This PR adds support for it.

Additionally, it removes obsolete renovate config which was used before we used flux to deploy prow.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @marc1404 
