### PR TITLE
Bump prow job image versions for garden-shoot-trust-configurator

### DIFF
--- a/config/jobs/garden-shoot-trust-configurator/garden-shoot-trust-configurator-e2e-kind.yaml
+++ b/config/jobs/garden-shoot-trust-configurator/garden-shoot-trust-configurator-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for garden-shoot-trust-configurator developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250910-3a6d5af-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250910-3a6d5af-1.25
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250910-3a6d5af-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250910-3a6d5af-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/garden-shoot-trust-configurator/garden-shoot-trust-configurator-unit-tests.yaml
+++ b/config/jobs/garden-shoot-trust-configurator/garden-shoot-trust-configurator-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for garden-shoot-trust-configurator developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250910-18dcf47-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250910-18dcf47-1.25
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250910-18dcf47-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250910-18dcf47-1.25
       command:
       - make
       args:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Bump europe-docker.pkg.dev/gardener-project/releases/ci-infra

**Which issue(s) this PR fixes**:
Error while running `pull-garden-shoot-trust-configurator-unit`:

> The command is terminated due to an error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)

**Special notes for your reviewer**:
N/A
CC: @dimityrmirchev 