### PR TITLE
ci: Use Go 1.25 for certificate and DNS Prow jobs

### DIFF
--- a/config/jobs/cert-management/cert-management-e2e-kind.yaml
+++ b/config/jobs/cert-management/cert-management-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for cert-management developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250915-b815250-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250915-b815250-1.25
         command:
         - wrapper.sh
         - bash
@@ -59,7 +59,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250915-b815250-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250915-b815250-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/cert-management/cert-management-integration-tests.yaml
+++ b/config/jobs/cert-management/cert-management-integration-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs integration tests for cert-management developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.25
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.25
       command:
       - make
       args:

--- a/config/jobs/cert-management/cert-management-unit-tests.yaml
+++ b/config/jobs/cert-management/cert-management-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for cert-management developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.25
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.25
       command:
       - make
       args:

--- a/config/jobs/extension-shoot-cert-service/extension-shoot-cert-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-cert-service/extension-shoot-cert-service-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-cert-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250915-b815250-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250915-b815250-1.25
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250915-b815250-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20250915-b815250-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/extension-shoot-cert-service/extension-shoot-cert-service-unit-tests.yaml
+++ b/config/jobs/extension-shoot-cert-service/extension-shoot-cert-service-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-shoot-cert-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.25
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.25
       command:
       - make
       args:

--- a/config/jobs/external-dns-management/external-dns-management-integration-tests.yaml
+++ b/config/jobs/external-dns-management/external-dns-management-integration-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs integration tests for external-dns-management developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.25
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.25
       command:
       - make
       args:

--- a/config/jobs/external-dns-management/external-dns-management-unit-tests.yaml
+++ b/config/jobs/external-dns-management/external-dns-management-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for external-dns-management developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.25
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20250915-5968c7f-1.25
       command:
       - make
       args:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR changes the references to `golang-test` and `krte` images to Go 1.25 for the certificate and DNS Prow jobs.
It's a prerequisite for update PRs such as this one:
https://github.com/gardener/gardener-extension-shoot-cert-service/pull/454

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @oliver-goetz 