### PR TITLE
Rely on `OWNERS` file for `approve` and `lgtm` in the whole gardener organization

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -113,6 +113,10 @@ blunderbuss:
   max_request_count: 2
   use_status_availability: true
 
+owners:
+  skip_collaborators:
+  - gardener  # Rely on OWNERS file for the whole organization
+
 heart:
   commentregexp: ".*"
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
We decided to rely on `OWNERS` file for `approve` and `lgtm` in the whole gardener organization (see https://github.com/gardener/gardener/pull/13024).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
