### PR TITLE
Continue on errors when copying container images

### DIFF
--- a/config/images/copy-images.sh
+++ b/config/images/copy-images.sh
@@ -9,6 +9,9 @@ if [ -z "$filepath" ] ; then
   exit 1
 fi
 
+# Track if any errors occurred
+errors=0
+
 # Loop over the images in the YAML
 for image in $(yq '.images[] | @json' "$filepath"); do
     source=$(echo $image | yq '.source')
@@ -16,6 +19,22 @@ for image in $(yq '.images[] | @json' "$filepath"); do
     # Loop over the tags for the current image
     for tag in $(echo $image | yq '.tags[]' ); do
         # Copy the container image for the current tag using crane
+        # Temporarily disable errexit for the crane copy command
+        set +o errexit
         crane copy "$source:$tag" "$destination:$tag"
+        if [ $? -ne 0 ]; then
+            echo "Error copying $source:$tag to $destination:$tag"
+            errors=$((errors + 1))
+        fi
+        # Re-enable errexit
+        set -o errexit
     done
 done
+
+# Exit with error if any copy operation failed
+if [ $errors -gt 0 ]; then
+    echo "Failed to copy $errors image(s)"
+    exit 1
+fi
+
+echo "All images copied successfully"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
At the moment the image copy script fails on the first error.
There are a couple of rate limit errors when accessing ECR which cause an error during script execution. It is a lottery right now, if the new image which should be copied is before or after the failing image in the list. This PR increases the likelihood, that the desired images are copied. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
