### PR TITLE
Introduce `prow-test-admin` role

### DIFF
--- a/deploy/test-pods/kustomization.yaml
+++ b/deploy/test-pods/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - cpu-limit-range_limitrange.yaml
 - mem-limit-range_limitrange.yaml
 - dind-docker-config_configmap.yaml
+- prow-test-admin_role.yaml

--- a/deploy/test-pods/prow-test-admin_role.yaml
+++ b/deploy/test-pods/prow-test-admin_role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prow-test-admin
+  namespace: test-pods
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "delete"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR introduces `prow-test-admin` role which can be used to debug tests and delete test pods (e.g. when they are OOMKilled) in the prow clusters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
