### PR TITLE
Fix `pvc-autoscaler-unit-tests` job

### DIFF
--- a/config/jobs/pvc-autoscaler/pvc-autoscaler-unit-tests.yaml
+++ b/config/jobs/pvc-autoscaler/pvc-autoscaler-unit-tests.yaml
@@ -11,12 +11,12 @@ presubmits:
       description: Runs unit tests for pvc-autoscaler developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251020-0861092-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251020-0861092-1.24
         command:
         - make
         args:
-        - import-tools-bin
-        - verify-extended
+        - lint
+        - test
         resources:
           limits:
             memory: 3Gi
@@ -30,23 +30,23 @@ periodics:
   extra_refs:
   - org: gardener
     repo: pvc-autoscaler
-    base_ref: main
+    base_ref: master
   decorate: true
   decoration_config:
     timeout: 20m
     grace_period: 10m
   annotations:
-    description: Periodically runs unit tests for pvc-autoscaler main branch
+    description: Periodically runs unit tests for pvc-autoscaler master branch
     testgrid-dashboards: pvc-autoscaler
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251020-0861092-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251020-0861092-1.24
       command:
       - make
       args:
-      - import-tools-bin
-      - verify-extended
+      - lint
+      - test
       resources:
         limits:
           memory: 3Gi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

This PR fixes the `pvc-autoscaler-unit-tests` job that was added in https://github.com/gardener/ci-infra/pull/4667 with the following:
1. Modifies the make command to be ` make lint test` in line with https://github.com/gardener/pvc-autoscaler/blob/85a3b5dc1e5d57478c822b0c5e04b8d635c1f0de/.ci/verify#L17 (the `import-tools-bin` and `verify-extended` make targets do not exist for the pvc-autoscaler repo, dev/test tools are downloaded differently than other g/g repos)
2. Changes the base ref for the periodics from main to master (master is the default branch on `pvc-autoscaler`
3. Changes the `golang-test` image to be 1.24 as 1.25 is still not used in `pvc-autoscaler`

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @Kostov6 @RadaBDimitrova 