### PR TITLE
Remove `make check-generate` from etcd-druid unit tests

### DIFF
--- a/config/jobs/etcd-druid/etcd-druid-unit-tests.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-unit-tests.yaml
@@ -53,7 +53,6 @@ periodics:
           command:
             - make
           args:
-            - check-generate
             - check
             - test-unit
           resources:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
`make check-generate` was removed from the etcd-druid unit test presubmit in https://github.com/gardener/ci-infra/pull/3136, but missed removing it from periodics, which causes lot of test failures on the gardener slack workspace test-failures channel. This PR fixes that.
