### PR TITLE
Deactivate `blunderbuss`

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -94,10 +94,6 @@ lgtm:
   review_acts_as_lgtm: true
   store_tree_hash: true
 
-blunderbuss:
-  max_request_count: 2
-  use_status_availability: true
-
 owners:
   skip_collaborators:
   - gardener  # Rely on OWNERS file for the whole organization
@@ -482,7 +478,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - config-updater
     - dog
     - golint
@@ -514,7 +509,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -545,7 +539,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -576,7 +569,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -612,7 +604,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -643,7 +634,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -684,7 +674,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -715,7 +704,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -751,7 +739,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -782,7 +769,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -813,7 +799,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -844,7 +829,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -880,7 +864,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -911,7 +894,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -942,7 +924,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -973,7 +954,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -1004,7 +984,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -1035,7 +1014,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -1066,7 +1044,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart
@@ -1097,7 +1074,6 @@ plugins:
     plugins:
     - approve
     - assign
-    - blunderbuss
     - dog
     - golint
     - heart


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
`blunderbuss` does not work well with the new concept of [Gardener Community Roles ](https://gardener.cloud/docs/contribute/code/roles/_index#community-roles) and their implementation (https://github.com/gardener/gardener/pull/13024). It does not propose reviewers in a meaningful way.
We cannot solve this issue by defining `OWNERS` file in a more granular way (see [prow docs](https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/#blunderbuss-and-reviewers)), because the Gardener code is not structured in a way that you could identify reviewers on a directory level.

Thus, let's deactivate it and rely on the Github reviewer proposals.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
