### PR TITLE
bump calico go version to v1.25

### DIFF
--- a/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-networking-calico developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20251023-46ec73c-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20251023-46ec73c-1.25
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20251023-46ec73c-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20251023-46ec73c-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-unit-tests.yaml
+++ b/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-networking-calico developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251023-4e03ae9-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251023-4e03ae9-1.25
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251023-4e03ae9-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251023-4e03ae9-1.25
       command:
       - make
       args:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Bump go version to v1.25 to fix issues with golangci-lint
