### PR TITLE
Bump golang to 1.25 for `shoot-rsyslog-relp` and `pvc-autoscaler`

### DIFF
--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for Gardener extension shoot-rsyslog-relp developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20251028-b8562a1-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20251028-b8562a1-1.25
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20251028-b8562a1-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20251028-b8562a1-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-integration-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-integration-tests.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251027-8a8ded2-1.24
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251027-8a8ded2-1.25
         command:
         - make
         args:
@@ -45,7 +45,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251027-8a8ded2-1.24
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251027-8a8ded2-1.25
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-test-builds.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-test-builds.yaml
@@ -9,7 +9,7 @@ presubmits:
     spec:
       containers:
       - name: kaniko
-        image: gcr.io/kaniko-project/executor:v1.24.0
+        image: gcr.io/kaniko-project/executor:v1.25.0
         command:
         - /kaniko/executor
         args:

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for Gardener extension shoot-rsyslog-relp developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251027-8a8ded2-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251027-8a8ded2-1.25
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251027-8a8ded2-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251027-8a8ded2-1.25
       command:
       - make
       args:

--- a/config/jobs/pvc-autoscaler/pvc-autoscaler-unit-tests.yaml
+++ b/config/jobs/pvc-autoscaler/pvc-autoscaler-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for pvc-autoscaler developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251027-8a8ded2-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251027-8a8ded2-1.25
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251027-8a8ded2-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251027-8a8ded2-1.25
       command:
       - make
       args:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR bumps the golang version used for builds and tests for the [`shoot-rsyslog-relp`](https://github.com/gardener/gardener-extension-shoot-rsyslog-relp) and [`pvc-autoscaler`](https://github.com/gardener/pvc-autoscaler) repositories: 

- https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/327
- https://github.com/gardener/pvc-autoscaler/pull/90

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
