### PR TITLE
Revert `gcr.io/kaniko-project/executor` image tag back to `v1.24.0` for `shoot-rsyslog-relp`

### DIFF
--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-test-builds.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-test-builds.yaml
@@ -9,7 +9,7 @@ presubmits:
     spec:
       containers:
       - name: kaniko
-        image: gcr.io/kaniko-project/executor:v1.25.0
+        image: gcr.io/kaniko-project/executor:v1.24.0
         command:
         - /kaniko/executor
         args:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind regression

**What this PR does / why we need it**:
This PR reverts the tag of the  `gcr.io/kaniko-project/executor` image back to v1.24.0
It was incorrectly set to v1.25.0 with https://github.com/gardener/ci-infra/pull/4720

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
