### PR TITLE
Bump up fluent-bit to v4.1.1

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -68,6 +68,7 @@ images:
   - v3.2.5
   - v4.0.9
   - v4.1.0
+  - v4.1.1
 # The kubesphere/fluent-operator image shall not be used anymore. Please use ghcr.io/fluent/fluent-operator/fluent-operator instead.
 - source: kubesphere/fluent-operator
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-operator


### PR DESCRIPTION
**How to categorize this PR?**
/kind enahancement

This PR brings fluent-bit version 4.1.1.

- [fluent-bit release notes v4.1.1](https://fluentbit.io/announcements/v4.1.1/)

Among updates are otel relevant improvements.
