### PR TITLE
Use go build cache for unit and integration tests

### DIFF
--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -13,20 +13,43 @@ presubmits:
       description: Runs integration tests for gardener developments in pull requests
       fork-per-release: "true"
     spec:
+      # For PR jobs, use a read-only service account
+      serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
       - name: test-integration
         image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251125-be059e9-1.25
         command:
-        - make
+          - /bin/bash
+          - -c
+        # TODO(shafeeqes): Remove time command after some days.
         args:
-        - import-tools-bin
-        - test-integration
+          - |
+            go install github.com/saracen/gobuildcache@83bfeb837b93a786ff37b33d0be108bcc74b089f
+            export GOCACHEPROG="gobuildcache -readonly gs://gardener-prow-gobuildcache"
+            time make import-tools-bin test-integration
         resources:
           limits:
             memory: 16Gi
           requests:
             cpu: 5
             memory: 8Gi
+        volumeMounts:
+        - name: oidc-config
+          readOnly: true
+          mountPath: "/root/.config/gcloud/application_default_credentials.json"
+          subPath: "credentials.json"
+        - name: oidc-token
+          mountPath: /var/run/secrets/tokens
+      volumes:
+        - name: oidc-config
+          secret:
+            secretName: gardener-prow-gobuildcache-oidc
+        - name: oidc-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: gobuildcache
+                  audience: gardener-prow-build-shoot/providers/prow-build
 periodics:
 - name: ci-gardener-integration
   cluster: gardener-prow-build
@@ -45,17 +68,40 @@ periodics:
     testgrid-days-of-results: "60"
     fork-per-release: "true"
   spec:
+    # For periodic jobs, use a read-write service account
+    serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
     - name: test-integration
       image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251125-be059e9-1.25
       command:
-      - make
+        - /bin/bash
+        - -c
+      # TODO(shafeeqes): Remove time command after some days.
       args:
-      - import-tools-bin
-      - test-integration
+        - |
+          go install github.com/saracen/gobuildcache@83bfeb837b93a786ff37b33d0be108bcc74b089f
+          export GOCACHEPROG="gobuildcache gs://gardener-prow-gobuildcache"
+          time make import-tools-bin test-integration
       resources:
         limits:
           memory: 16Gi
         requests:
           cpu: 5
           memory: 8Gi
+      volumeMounts:
+        - name: oidc-config
+          readOnly: true
+          mountPath: "/root/.config/gcloud/application_default_credentials.json"
+          subPath: "credentials.json"
+        - name: oidc-token
+          mountPath: /var/run/secrets/tokens
+    volumes:
+      - name: oidc-config
+        secret:
+          secretName: gardener-prow-gobuildcache-oidc
+      - name: oidc-token
+        projected:
+          sources:
+            - serviceAccountToken:
+                path: gobuildcache
+                audience: gardener-prow-build-shoot/providers/prow-build

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -13,25 +13,44 @@ presubmits:
       description: Runs unit tests for gardener developments in pull requests
       fork-per-release: "true"
     spec:
+      # For PR jobs, use a read-only service account
+      serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
       # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
       - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251125-be059e9-1.25
         command:
-        - make
+          - /bin/bash
+          - -c
+        # TODO(shafeeqes): Remove time command after some days.
         args:
-        - import-tools-bin
-        - check-generate
-        - check
-        - format
-        - test
-        - sast
+          - |
+            go install github.com/saracen/gobuildcache@83bfeb837b93a786ff37b33d0be108bcc74b089f
+            export GOCACHEPROG="gobuildcache -readonly gs://gardener-prow-gobuildcache"
+            time make import-tools-bin check-generate check format test sast
         resources:
           limits:
             memory: 24Gi
           requests:
             cpu: 6
             memory: 16Gi
+        volumeMounts:
+        - name: oidc-config
+          readOnly: true
+          mountPath: "/root/.config/gcloud/application_default_credentials.json"
+          subPath: "credentials.json"
+        - name: oidc-token
+          mountPath: /var/run/secrets/tokens
+      volumes:
+        - name: oidc-config
+          secret:
+            secretName: gardener-prow-gobuildcache-oidc
+        - name: oidc-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: gobuildcache
+                  audience: gardener-prow-build-shoot/providers/prow-build
 periodics:
 - name: ci-gardener-unit
   cluster: gardener-prow-build
@@ -50,22 +69,41 @@ periodics:
     testgrid-days-of-results: "60"
     fork-per-release: "true"
   spec:
+    # For periodic jobs, use a read-write service account
+    serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
     # Run all tests sequentially in one container or as separate prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
     - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251125-be059e9-1.25
       command:
-      - make
+        - /bin/bash
+        - -c
+      # TODO(shafeeqes): Remove time command after some days.
       args:
-      - import-tools-bin
-      - check-generate
-      - check
-      - format
-      - test
-      - sast
+        - |
+          go install github.com/saracen/gobuildcache@83bfeb837b93a786ff37b33d0be108bcc74b089f
+          export GOCACHEPROG="gobuildcache gs://gardener-prow-gobuildcache"
+          time make import-tools-bin check-generate check format test sast
       resources:
         limits:
           memory: 24Gi
         requests:
           cpu: 6
           memory: 16Gi
+      volumeMounts:
+        - name: oidc-config
+          readOnly: true
+          mountPath: "/root/.config/gcloud/application_default_credentials.json"
+          subPath: "credentials.json"
+        - name: oidc-token
+          mountPath: /var/run/secrets/tokens
+    volumes:
+      - name: oidc-config
+        secret:
+          secretName: gardener-prow-gobuildcache-oidc
+      - name: oidc-token
+        projected:
+          sources:
+            - serviceAccountToken:
+                path: gobuildcache
+                audience: gardener-prow-build-shoot/providers/prow-build


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This is a test implementation of `github.com/saracen/gobuildcache` for our unit and integration tests. 
We need to observe the test runs and gain some confidence before enabling it for other tests.
We can also think about making the `gobuildcache` part of the golang-test-image, and also use global config for the volume mounts.

The pre-submit jobs uses a read-only cache and the periodic tests use the read-write mode.


Co-authored by: @Shegox 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Workload identity federation is used to provide access to the GCS bucket. Documentation will follow.

/cc @oliver-goetz 
