### PR TITLE
Revert "Use go build cache for unit and integration tests (#4903)"

### DIFF
--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -13,43 +13,20 @@ presubmits:
       description: Runs integration tests for gardener developments in pull requests
       fork-per-release: "true"
     spec:
-      # For PR jobs, use a read-only service account
-      serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
       - name: test-integration
         image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251125-64bf2a7-1.25
         command:
-          - /bin/bash
-          - -c
-        # TODO(shafeeqes): Remove time command after some days.
+        - make
         args:
-          - |
-            go install github.com/saracen/gobuildcache@83bfeb837b93a786ff37b33d0be108bcc74b089f
-            export GOCACHEPROG="gobuildcache -readonly gs://gardener-prow-gobuildcache"
-            time make import-tools-bin test-integration
+        - import-tools-bin
+        - test-integration
         resources:
           limits:
             memory: 16Gi
           requests:
             cpu: 5
             memory: 8Gi
-        volumeMounts:
-        - name: oidc-config
-          readOnly: true
-          mountPath: "/root/.config/gcloud/application_default_credentials.json"
-          subPath: "credentials.json"
-        - name: oidc-token
-          mountPath: /var/run/secrets/tokens
-      volumes:
-        - name: oidc-config
-          secret:
-            secretName: gardener-prow-gobuildcache-oidc
-        - name: oidc-token
-          projected:
-            sources:
-              - serviceAccountToken:
-                  path: gobuildcache
-                  audience: gardener-prow-build-shoot/providers/prow-build
 periodics:
 - name: ci-gardener-integration
   cluster: gardener-prow-build
@@ -68,40 +45,17 @@ periodics:
     testgrid-days-of-results: "60"
     fork-per-release: "true"
   spec:
-    # For periodic jobs, use a read-write service account
-    serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
     - name: test-integration
       image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251125-64bf2a7-1.25
       command:
-        - /bin/bash
-        - -c
-      # TODO(shafeeqes): Remove time command after some days.
+      - make
       args:
-        - |
-          go install github.com/saracen/gobuildcache@83bfeb837b93a786ff37b33d0be108bcc74b089f
-          export GOCACHEPROG="gobuildcache gs://gardener-prow-gobuildcache"
-          time make import-tools-bin test-integration
+      - import-tools-bin
+      - test-integration
       resources:
         limits:
           memory: 16Gi
         requests:
           cpu: 5
           memory: 8Gi
-      volumeMounts:
-        - name: oidc-config
-          readOnly: true
-          mountPath: "/root/.config/gcloud/application_default_credentials.json"
-          subPath: "credentials.json"
-        - name: oidc-token
-          mountPath: /var/run/secrets/tokens
-    volumes:
-      - name: oidc-config
-        secret:
-          secretName: gardener-prow-gobuildcache-oidc
-      - name: oidc-token
-        projected:
-          sources:
-            - serviceAccountToken:
-                path: gobuildcache
-                audience: gardener-prow-build-shoot/providers/prow-build

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -13,44 +13,25 @@ presubmits:
       description: Runs unit tests for gardener developments in pull requests
       fork-per-release: "true"
     spec:
-      # For PR jobs, use a read-only service account
-      serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
       # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
       - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251125-64bf2a7-1.25
         command:
-          - /bin/bash
-          - -c
-        # TODO(shafeeqes): Remove time command after some days.
+        - make
         args:
-          - |
-            go install github.com/saracen/gobuildcache@83bfeb837b93a786ff37b33d0be108bcc74b089f
-            export GOCACHEPROG="gobuildcache -readonly gs://gardener-prow-gobuildcache"
-            time make import-tools-bin check-generate check format test sast
+        - import-tools-bin
+        - check-generate
+        - check
+        - format
+        - test
+        - sast
         resources:
           limits:
             memory: 24Gi
           requests:
             cpu: 6
             memory: 16Gi
-        volumeMounts:
-        - name: oidc-config
-          readOnly: true
-          mountPath: "/root/.config/gcloud/application_default_credentials.json"
-          subPath: "credentials.json"
-        - name: oidc-token
-          mountPath: /var/run/secrets/tokens
-      volumes:
-        - name: oidc-config
-          secret:
-            secretName: gardener-prow-gobuildcache-oidc
-        - name: oidc-token
-          projected:
-            sources:
-              - serviceAccountToken:
-                  path: gobuildcache
-                  audience: gardener-prow-build-shoot/providers/prow-build
 periodics:
 - name: ci-gardener-unit
   cluster: gardener-prow-build
@@ -69,41 +50,22 @@ periodics:
     testgrid-days-of-results: "60"
     fork-per-release: "true"
   spec:
-    # For periodic jobs, use a read-write service account
-    serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
     # Run all tests sequentially in one container or as separate prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
     - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20251125-64bf2a7-1.25
       command:
-        - /bin/bash
-        - -c
-      # TODO(shafeeqes): Remove time command after some days.
+      - make
       args:
-        - |
-          go install github.com/saracen/gobuildcache@83bfeb837b93a786ff37b33d0be108bcc74b089f
-          export GOCACHEPROG="gobuildcache gs://gardener-prow-gobuildcache"
-          time make import-tools-bin check-generate check format test sast
+      - import-tools-bin
+      - check-generate
+      - check
+      - format
+      - test
+      - sast
       resources:
         limits:
           memory: 24Gi
         requests:
           cpu: 6
           memory: 16Gi
-      volumeMounts:
-        - name: oidc-config
-          readOnly: true
-          mountPath: "/root/.config/gcloud/application_default_credentials.json"
-          subPath: "credentials.json"
-        - name: oidc-token
-          mountPath: /var/run/secrets/tokens
-    volumes:
-      - name: oidc-config
-        secret:
-          secretName: gardener-prow-gobuildcache-oidc
-      - name: oidc-token
-        projected:
-          sources:
-            - serviceAccountToken:
-                path: gobuildcache
-                audience: gardener-prow-build-shoot/providers/prow-build


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug
/kind regression


**What this PR does / why we need it**:
This PR reverts commit baccdc042283db9bac5c8ebcb9375332c4e8587a (PR https://github.com/gardener/ci-infra/pull/4903).

`pull-gardener-unit` fails with:
```
> Generate
Error during calling make tools-for-generate: make[1]: Entering directory '/home/prow/go/src/github.com/gardener/gardener'
go build -o hack/tools/bin/linux-amd64/extension-generator ./hack/tools/extension-generator
error starting GOCACHEPROG program "gobuildcache": exec: "gobuildcache": executable file not found in $PATH
make[1]: *** [hack/tools.mk:249: hack/tools/bin/linux-amd64/extension-generator] Error 1
make[1]: Leaving directory '/home/prow/go/src/github.com/gardener/gardener'
make: *** [Makefile:157: check-generate] Error 1
```

Ref https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13537/pull-gardener-unit/1993581461457866752

**Which issue(s) this PR fixes**:
Reverts https://github.com/gardener/ci-infra/pull/4903

**Special notes for your reviewer**:
N/A