### PR TITLE
Add `docker compose` to `krte` image

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -86,7 +86,7 @@ RUN echo "Installing Packages ..." \
             "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
             tee /etc/apt/sources.list.d/docker.list > /dev/null \
         && apt-get update \
-        && apt-get install -y --no-install-recommends docker-ce docker-buildx-plugin \
+        && apt-get install -y --no-install-recommends docker-ce docker-buildx-plugin docker-compose-plugin \
         && rm -rf /var/lib/apt/lists/* \
         && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
         && sed -i 's/ulimit -Hn/# ulimit -Hn/g' /etc/init.d/docker \


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

For https://github.com/gardener/gardener/pull/13551, we need to have the `docker compose` plugin available.
For users of `Docker Desktop`, it is already preinstalled.
This PR adds the `docker compose plugin` to the `krte` image (see [install docs](https://docs.docker.com/compose/install/linux/#install-using-the-repository)).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @oliver-goetz 