### PR TITLE
increase timeout to 60min

### DIFF
--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -7,7 +7,7 @@ presubmits:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true
     decoration_config:
-      timeout: 40m
+      timeout: 60m
       grace_period: 10m
     annotations:
       description: Runs unit tests for gardener developments in pull requests
@@ -42,7 +42,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 40m
+    timeout: 60m
     grace_period: 10m
   labels:
     preset-gocache-mounts: "true"


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Increases the timeout of the unit test jobs from 40 to 60min to account for the longer cache building

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
