### PR TITLE
config/images: add opentelemetry target allocator and collector images

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -217,6 +217,13 @@ images:
   - 0.127.0
   - 0.129.1
   - 0.139.0
+  - 0.140.0
+  - 0.141.0
+- source: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
+  destination: europe-docker.pkg.dev/gardener-project/releases/3rd/opentelemetry-operator/target-allocator
+  tags:
+  - v0.140.0
+  - v0.141.0
 - source: persesdev/perses
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/persesdev/perses
   tags:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR vendors the OpenTelemetry Target Allocator image. Also it adds `0.140.0` and `0.141.0`  versions of the `opentelemetry-collector-contrib` image.
