### PR TITLE
Restore previous prow tide image

### DIFF
--- a/deploy/prow/tide_deployment.yaml
+++ b/deploy/prow/tide_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20251211-8a9b5e47b
+        image: us-docker.pkg.dev/k8s-infra-prow/images/tide@sha256:e5d377b958c4811c74a6474e8c8f1611e5c11ae687b7aa9fb156de6cc6d1fc83
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind regression

**What this PR does / why we need it**:
Since https://github.com/kubernetes-sigs/prow/pull/537 `tide` does not work anymore when `Restrict Updates` is enabled via a Github `Ruleset` and `tide` is on the `bypass list`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
