### PR TITLE
Split autobump for prow components and jobs in a better way

### DIFF
--- a/config/prow/autobump-config/prow-component-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-component-autobump-config.yaml
@@ -9,7 +9,8 @@ gitHubRepo: "ci-infra"
 remoteName: "ci-infra"
 upstreamURLBase: "https://raw.githubusercontent.com/gardener/ci-infra/master"
 includedConfigPaths:
-  - "."
+  - "config/prow"
+  - "deploy/prow"
 extraFiles:
   - "config/mkpj.sh"
   - "hack/bootstrap-config.sh"
@@ -17,18 +18,18 @@ extraFiles:
   - "hack/check-testgrid-config.sh"
 targetVersion: "latest"
 prefixes:
-  - name: "Prow"
+  - name: "Prow components - prow"
     prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
     repo: "https://github.com/kubernetes-sigs/prow"
     summarise: true
     consistentImages: true
-  - name: "Prow - test-infra"
+  - name: "Prow components - test-infra"
     prefix: "gcr.io/k8s-staging-test-infra/"
     repo: "https://github.com/kubernetes/test-infra"
     summarise: true
     consistentImages: false
-  - name: "Prow - ci-infra"
+  - name: "Prow components - ci-infra"
     prefix: "europe-docker.pkg.dev/gardener-project/releases/ci-infra/"
     repo: "https://github.com/gardener/ci-infra"
     summarise: true
-    consistentImages: false
+    consistentImages: true

--- a/config/prow/autobump-config/prow-job-autobump-config.yaml
+++ b/config/prow/autobump-config/prow-job-autobump-config.yaml
@@ -11,20 +11,21 @@ headBranchName: "prowjobs-autobump"
 upstreamURLBase: "https://raw.githubusercontent.com/gardener/ci-infra/master"
 includedConfigPaths:
   - "config/jobs"
+  - "images"
 targetVersion: "latest"
 prefixes:
-  - name: "k8s-testimages images"
-    prefix: "gcr.io/k8s-testimages/"
+  - name: "Prow jobs - prow"
+    prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
+    repo: "https://github.com/kubernetes-sigs/prow"
+    summarise: false
+    consistentImages: false
+  - name: "Prow jobs - test-infra"
+    prefix: "gcr.io/k8s-staging-test-infra/"
     repo: "https://github.com/kubernetes/test-infra"
     summarise: false
     consistentImages: false
-  - name: "k8s-staging-test-infra images"
-    prefix: "gcr.io/k8s-staging-test-infra"
-    repo: "https://github.com/kubernetes/test-infra"
-    summarise: false
-    consistentImages: false
-  - name: "test-infra images"
-    prefix: "k8s.gcr.io/test-infra"
-    repo: "https://github.com/kubernetes/test-infra"
+  - name: "Prow jobs - ci-infra"
+    prefix: "europe-docker.pkg.dev/gardener-project/releases/ci-infra/"
+    repo: "https://github.com/gardener/ci-infra"
     summarise: false
     consistentImages: false


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Today, almost all prow components and prow jobs are auto-bumped by the same job.
Because of this, it is hard to find out when actual prow components have been updated (e.g. to check if there is a regression). 
There is already an own autobump config for prow jobs which is rarely used at the moment.

With this PR autobumps for prow components and for prow jobs (and related stuff) are separated more clearly between both autobump configs. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @marc1404 @LucaBernstein 
