### PR TITLE
Add Renovate package rule that informs about image replication PRs

### DIFF
--- a/config/renovate/imagevector.json5
+++ b/config/renovate/imagevector.json5
@@ -16,5 +16,30 @@
       matchStrings: ['\\s+sourceRepository:\\s+github.com\/(?<depName>.*?)\\n\\s+repository:\\s+.*\\n\\s+tag:\\s+"?(?<currentValue>.*?)"?\\n'],
       datasourceTemplate: 'github-releases',
     }
+  ],
+  packageRules: [
+    {
+      description: 'Adds a PR body note for images that depend on ci-infra PRs.',
+      matchManagers: [
+        'regex'
+      ],
+      matchDatasources: [
+        'docker',
+        'github-releases'
+      ],
+      matchPackageNames: [
+        'credativ/plutono',
+        'credativ/vali',
+        'credativ/valitail',
+        'envoyproxy/envoy',
+        'fluent/fluent-operator',
+        'open-telemetry/opentelemetry-operator',
+        'perses/perses',
+        'perses/perses-operator',
+      ],
+      prBodyNotes: [
+        '> [!TIP]\n> Updates to this image may depend on merging a pull request in the [ci-infra](https://github.com/gardener/ci-infra/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) repository first.'
+      ],
+    }
   ]
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

There are Renovate PRs in `g/g` that update the image vector, but they have an implicit connection to the image replication configured in `ci-infra`.

_Example:_
* Renovate PR in `g/g` that updates the `open-telemetry/opentelemetry-operator`: https://github.com/gardener/gardener/pull/13624
* Required merging the following PR in `ci-infra` first: https://github.com/gardener/ci-infra/pull/5001

We replicate certain images from 3rd party registries to our own. The versions to be replicated are listed in the configuration of this repository.

This PR adds a package rule for the `imagevector.json5` Renovate config that utilizes the [prBodyNotes](https://docs.renovatebot.com/configuration-options/#prbodynotes) option. It adds a Markdown alert that informs about the relationship towards the `ci-infra` repository and suggests checking the open PRs.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @oliver-goetz 

_Preview PR:_
https://github.com/marc1404/gardener/pull/62
