### PR TITLE
Fix `ci-prow-label-sync` job

### DIFF
--- a/config/jobs/common/label-sync.yaml
+++ b/config/jobs/common/label-sync.yaml
@@ -23,7 +23,7 @@ periodics:
       args:
       - --config=config/prow/labels.yaml
       - --confirm=true
-      - --orgs gardener
+      - --orgs=gardener
       - --endpoint=http://ghproxy.prow.svc
       - --endpoint=https://api.github.com
       # TODO: switch to GitHub App Auth, once it's implemented in label_sync


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
A missing `=` in the parameters seem to break `ci-prow-label-sync` job ([ref](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-prow-label-sync/2001688162555924480#1:build-log.txt%3A1)).
This PR add the missing character.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @dimityrmirchev 
