### PR TITLE
Replace deprecated CLI arguments in `ci-prow-label-sync` job

### DIFF
--- a/config/jobs/common/label-sync.yaml
+++ b/config/jobs/common/label-sync.yaml
@@ -24,11 +24,11 @@ periodics:
       - --config=config/prow/labels.yaml
       - --confirm=true
       - --orgs=gardener
-      - --endpoint=http://ghproxy.prow.svc
-      - --endpoint=https://api.github.com
+      - --github-endpoint=http://ghproxy.prow.svc
+      - --github-endpoint=https://api.github.com
       # TODO: switch to GitHub App Auth, once it's implemented in label_sync
       # see https://github.com/kubernetes/test-infra/issues/24143
-      - --token=/etc/github/token
+      - --github-token-path=/etc/github/token
       - --debug
       volumeMounts:
       - name: github-token


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Some CLI arguments of `label_sync` are deprecated ([ref1](https://github.com/kubernetes/test-infra/blob/88cdb30fbc0cac60a0e4a83020a847d09b9957f9/label_sync/main.go#L140), [ref2](https://github.com/kubernetes/test-infra/blob/88cdb30fbc0cac60a0e4a83020a847d09b9957f9/label_sync/main.go#L146)).
This PR replaces them.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @dimityrmirchev 
