### PR TITLE
Replace `lint` and `test` with `verify-extended` for `pvc-autoscaler` unit test job

### DIFF
--- a/config/jobs/pvc-autoscaler/pvc-autoscaler-unit-tests.yaml
+++ b/config/jobs/pvc-autoscaler/pvc-autoscaler-unit-tests.yaml
@@ -16,7 +16,6 @@ presubmits:
         - make
         args:
         - verify-extended
-        - test
         resources:
           limits:
             memory: 3Gi
@@ -46,7 +45,6 @@ periodics:
       - make
       args:
       - verify-extended
-      - test
       resources:
         limits:
           memory: 3Gi


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR removes the call of the make `lint` target with `verify-extended` for `pvc-autoscaler` unit test job, since with https://github.com/gardener/pvc-autoscaler/pull/134, `make lint` is no longer available. `verify-extended` will run `test`, so this PR also removes the separate run of `test`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related to fails of unit tests on https://github.com/gardener/pvc-autoscaler/pull/134.
/cc @Kostov6 @plkokanov 