### PR TITLE
Adding x509-certificate-exporter -scratch tag

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -342,3 +342,4 @@ images:
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/enix/x509-certificate-exporter
   tags:
   - 3.19.1
+  - 3.19.1-scratch


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
PR introduces the `-scratch` version of the x509-certificate-exporter image, as the tag has smaller attack vector.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
