### PR TITLE
Reduce CPU and memory requests for gobuildcache enabled tests

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-node.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-node.yaml
@@ -37,8 +37,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 12
-            memory: 48Gi
+            cpu: 6
+            memory: 12Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -85,8 +85,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 12
-          memory: 48Gi
+          cpu: 6
+          memory: 12Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -36,8 +36,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 12
-            memory: 48Gi
+            cpu: 6
+            memory: 12Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -83,8 +83,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 12
-          memory: 48Gi
+          cpu: 6
+          memory: 12Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
@@ -36,8 +36,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 12
-            memory: 48Gi
+            cpu: 6
+            memory: 12Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -85,8 +85,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 12
-          memory: 48Gi
+          cpu: 6
+          memory: 12Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-migration-ha-multi-node.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration-ha-multi-node.yaml
@@ -36,8 +36,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 6
-            memory: 24Gi
+            cpu: 4
+            memory: 12Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -83,8 +83,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 6
-          memory: 24Gi
+          cpu: 4
+          memory: 12Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -36,8 +36,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 6
-            memory: 24Gi
+            cpu: 4
+            memory: 12Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -83,8 +83,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 6
-          memory: 24Gi
+          cpu: 4
+          memory: 12Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-operator.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator.yaml
@@ -37,8 +37,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 6
-            memory: 24Gi
+            cpu: 4
+            memory: 12Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -85,8 +85,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 6
-          memory: 24Gi
+          cpu: 4
+          memory: 12Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
@@ -36,8 +36,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 6
-            memory: 24Gi
+            cpu: 4
+            memory: 12Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -83,8 +83,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 6
-          memory: 24Gi
+          cpu: 4
+          memory: 12Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -37,8 +37,8 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 12
-            memory: 48Gi
+            cpu: 6
+            memory: 24Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -85,8 +85,8 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 12
-          memory: 48Gi
+          cpu: 6
+          memory: 24Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
After https://github.com/gardener/ci-infra/pull/4926, we have seen a consistent reduction in the CPU and memory usage for the e2e test. Let's reduce the requests so that the nodes can be better utilized.

For eg, for `ci-gardener-e2e-kind`,
without cache,

<img width="4511" height="923" alt="image" src="https://github.com/user-attachments/assets/cb5937ec-27ce-485b-b340-d7b754234c78" />
<img width="4497" height="896" alt="image" src="https://github.com/user-attachments/assets/1cf18b96-2d7a-44b2-9870-f613e3421d79" />

With cache,
<img width="4441" height="1171" alt="image" src="https://github.com/user-attachments/assets/649e5e63-80d1-4a07-bb47-093c6ec90d95" />
<img width="4551" height="912" alt="image" src="https://github.com/user-attachments/assets/b1430b33-4089-4f61-b39a-774b30d94901" />


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
