### PR TITLE
increase timeout by 15 minutes as cilium test runs reach timeout

### DIFF
--- a/config/jobs/gardener-extension-networking-cilium/gardener-extension-networking-cilium-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-networking-cilium/gardener-extension-networking-cilium-e2e-kind.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     decorate: true
     decoration_config:
-      timeout: 60m
+      timeout: 75m
       grace_period: 15m
     labels:
       preset-dind-enabled: "true"
@@ -51,7 +51,7 @@ periodics:
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 60m
+    timeout: 75m
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Increase timeout by 15 minutes as cilium test runs are close to 1h for cilium and sometimes running into/reaching this timeout.


E.g.: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener-extension-networking-cilium/667/pull-extension-networking-cilium-e2e-kind/2008918677197426688:
```
...
Deleting cluster "gardener-local" ...
Deleted nodes: ["gardener-local-control-plane"]
make[1]: Leaving directory '/home/prow/go/src/github.com/gardener/gardener-extension-networking-cilium/gardener'
wrapper.sh] [TEST] Test Command exit code: 0
wrapper.sh] [CLEANUP] Waiting 30 seconds for pods stopped with terminationGracePeriod:30
{"component":"entrypoint","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:169","func":"sigs.k8s.io/prow/pkg/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 1h0m0s timeout","severity":"error","time":"2026-01-07T16:08:38Z"}
wrapper.sh] [EARLY EXIT] Interrupted, entering handler ...
wrapper.sh] [EARLY EXIT] Original exit code was 0, not preserving due to interrupt signal
wrapper.sh] [CLEANUP] Waiting 30 seconds for pods stopped with terminationGracePeriod:30
wrapper.sh] [CLEANUP] Cleaning up after Docker in Docker ...
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
