### PR TITLE
Shoot-networking-filter extension job should use go 1.25

### DIFF
--- a/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-networking-filter developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260108-1b9ac95-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260108-1b9ac95-1.25
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260108-1b9ac95-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260108-1b9ac95-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-operator.yaml
+++ b/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-operator.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-networking-filter developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260108-1b9ac95-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260108-1b9ac95-1.25
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260108-1b9ac95-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260108-1b9ac95-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-shoot-networking-filter developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260107-d2846f2-1.24
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260107-d2846f2-1.25
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260107-d2846f2-1.24
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260107-d2846f2-1.25
       command:
       - make
       args:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
Shoot-networking-filter extension job should use go 1.25

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
