### PR TITLE
Update fluent-operator and fluent-bit versions"

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -71,6 +71,7 @@ images:
   - v4.0.9
   - v4.1.0
   - v4.1.1
+  - v4.2.2
 # The kubesphere/fluent-operator image shall not be used anymore. Please use ghcr.io/fluent/fluent-operator/fluent-operator instead.
 - source: kubesphere/fluent-operator
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-operator
@@ -87,6 +88,7 @@ images:
   - v3.2.0
   - v3.3.0
   - v3.5.0
+  - v3.6.0
 # DO NOT ADD NEW LOKI IMAGES.
 # With https://github.com/gardener/gardener/pull/7318 loki is replaced by vali.
 - source: grafana/loki


### PR DESCRIPTION
/kind enhancement

Thist PR brings latest releases of fluent-operator and fluent-bit:

- fluent-opertor to version [v3.6.0](https://github.com/fluent/fluent-operator/releases/tag/v3.6.0)
- fluent-bit to version [v4.2.2](https://github.com/fluent/fluent-bit/releases/tag/v4.2.2)
