### PR TITLE
Update Renovate chart version to 45.83.2

### DIFF
--- a/deploy/renovate/renovate.yaml
+++ b/deploy/renovate/renovate.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: renovate
-      version: '45.82.x'
+      version: '45.83.2'
       sourceRef:
         kind: HelmRepository
         name: renovate


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
PR updates renovate to newer version, because of:
```
message: 'Back-off pulling image "ghcr.io/renovatebot/renovate:42.89.1-full":
          ErrImagePull: rpc error: code = NotFound desc = failed to pull and unpack
          image "ghcr.io/renovatebot/renovate:42.89.1-full": failed to resolve reference
          "ghcr.io/renovatebot/renovate:42.89.1-full": ghcr.io/renovatebot/renovate:42.89.1-full:
          not found'
        reason: ImagePullBackOff
```
cc @vpnachev 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
