### PR TITLE
Manually update renovate to 42.92.4

### DIFF
--- a/config/jobs/common/renovate-presubmits.yaml
+++ b/config/jobs/common/renovate-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: ghcr.io/renovatebot/renovate:42.89.1
+      - image: ghcr.io/renovatebot/renovate:42.92.4
         command:
         - renovate-config-validator
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Manually update renovate as https://github.com/gardener/ci-infra/pull/5241 updated renovate to a version that looks broken because the image `ghcr.io/renovatebot/renovate:42.89.1-full` does not exist

```bash
$ crane manifest ghcr.io/renovatebot/renovate:42.89.1-full
Error: fetching manifest ghcr.io/renovatebot/renovate:42.89.1-full: GET https://ghcr.io/v2/renovatebot/renovate/manifests/42.89.1-full: MANIFEST_UNKNOWN: manifest unknown
```

or from the pod status

```yaml
  containerStatuses:
  - image: ghcr.io/renovatebot/renovate:42.89.1-full
    name: renovate
    state:
      waiting:
        message: 'Back-off pulling image "ghcr.io/renovatebot/renovate:42.89.1-full":
          ErrImagePull: rpc error: code = NotFound desc = failed to pull and unpack
          image "ghcr.io/renovatebot/renovate:42.89.1-full": failed to resolve reference
          "ghcr.io/renovatebot/renovate:42.89.1-full": ghcr.io/renovatebot/renovate:42.89.1-full:
          not found'
        reason: ImagePullBackOff
...
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
