### PR TITLE
Enable tide for the gardener organisation

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -140,29 +140,12 @@ slack_reporter_configs:
 tide:
   sync_period: 1m
   queries:
-  # default configuration for repositories that should be onboarded to tide
-  - repos: &tide-onboarded-repos
-    - gardener/ci-infra
-    - gardener/gardener
-    - gardener/gardener-extension-image-rewriter
-    - gardener/gardener-extension-registry-cache
-    - gardener/dependency-watchdog
-    - gardener/garden-shoot-trust-configurator
-    - gardener/gardener-extension-shoot-rsyslog-relp
-    - gardener/gardener-extension-shoot-cert-service
-    - gardener/gardener-extension-shoot-dns-service
-    - gardener/gardener-discovery-server
-    - gardener/cert-management
-    - gardener/external-dns-management
-    - gardener/cluster-api-provider-gardener
-    - gardener/gardener-extension-networking-calico
-    - gardener/gardener-extension-networking-cilium
-    - gardener/org
-    - gardener/auditlog-forwarder
-    - gardener/gardener-extension-auditing
-    - gardener/diki
-    - gardener/pvc-autoscaler
-    - gardener/gardener-landscape-kit
+  - orgs:
+    - gardener
+    excludedRepos: &tide-excluded-repos
+    - gardener/gardener-ai-conformance
+    - gardener/k8s-conformance
+    - gardener/demo
     labels:
     - lgtm
     - approved
@@ -181,7 +164,9 @@ tide:
 
   # configuration for automerging robot PRs
   - author: gardener-ci-robot
-    repos: *tide-onboarded-repos
+    orgs:
+    - gardener
+    excludedRepos: *tide-excluded-repos
     labels:
     # gardener-ci-robot adds this label to PRs that should be merged automatically
     - skip-review
@@ -194,27 +179,7 @@ tide:
     # Overwrite pending contexts of a PR when it can be merged because of a successful batch job
     overwrite-pending-contexts: true
   merge_method:
-    gardener/ci-infra: squash
-    gardener/gardener: squash
-    gardener/gardener-extension-registry-cache: squash
-    gardener/gardener-extension-image-rewriter: squash
-    gardener/dependency-watchdog: squash
-    gardener/garden-shoot-trust-configurator: squash
-    gardener/gardener-extension-shoot-rsyslog-relp: squash
-    gardener/gardener-extension-shoot-cert-service: squash
-    gardener/gardener-extension-shoot-dns-service: squash
-    gardener/gardener-discovery-server: squash
-    gardener/cert-management: squash
-    gardener/external-dns-management: squash
-    gardener/cluster-api-provider-gardener: squash
-    gardener/gardener-extension-networking-calico: squash
-    gardener/gardener-extension-networking-cilium: squash
-    gardener/org: squash
-    gardener/auditlog-forwarder: squash
-    gardener/gardener-extension-auditing: squash
-    gardener/diki: squash
-    gardener/pvc-autoscaler: squash
-    gardener/gardener-landscape-kit: squash
+    gardener: squash
   pr_status_base_urls:
     '*': https://prow.gardener.cloud/pr
   blocker_label: tide/merge-blocker


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR is part of a bigger effort aiming to unify the developer experience across the gardener github organisation.

With this PR we will enable tide and its capabilities (like automatic merging of PRs and testing against the most recent base branch commit) for the whole (almost) gardener organisation. Please get familiar with its features - https://docs.prow.k8s.io/docs/components/core/tide/.

After this PR is merged it will be strongly advised that people do not merge PRs, but let tide do it for them.

For maintainers of repositories the common interactions with a PR include:
- commenting a PR with /lgtm - this means that you have reviewed the PR and you are giving it a green light in terms of functionality and quality ([example](https://github.com/gardener/gardener/pull/13659#issuecomment-3777930093)). Mind that this action will be allowed if you are part of the reviewers of the repository (maintained in the [OWNERS](https://github.com/gardener/gardener/blob/527d009474638b519f00bb4c7893bfd8508c013e/OWNERS#L8) and [OWNERS_ALIASES](https://github.com/gardener/gardener/blob/527d009474638b519f00bb4c7893bfd8508c013e/OWNERS_ALIASES#L30) files). Authors are not allowed to /lgtm their own PRs.
- commenting a PR with /approve - this means that you approve a PR to be merged. The PR will be merged automatically by tide if it has both /lgtm and /approve labels. There are also additional requirements such as passing tests and correct labeling, i.e. the PR is labeled with a proper kind label and is not held by another person. Mind that a github approval of PR will act as you labeling the PR with /approve. You will only be allowed to approve a PR if you are part of the approvers for the said repository ([example](https://github.com/gardener/gardener/blob/527d009474638b519f00bb4c7893bfd8508c013e/OWNERS_ALIASES#L75))
- commenting a PR with /hold - means that you block the PR from automatic merging

> [!IMPORTANT]
> If tide is not merging your PRs because of present `do-not-merge/needs-kind` label, consider enhancing your repo PR template so that it hints authors to add this label during PR creation. Please see [gardener/gardener PR template](https://github.com/gardener/gardener/blob/master/.github/pull_request_template.md) as an example.
>
> Before merging a PR tide runs all tests against the current state of main/master branch. Thus, it might take a while until a PR is merged even when all requirements are satisfied. There is the [Tide status](https://prow.gardener.cloud/tide) page where you can see what tide is currently doing.

**Helpful links:**
- [Tide status](https://prow.gardener.cloud/tide)
- [Tide history](https://prow.gardener.cloud/tide-history)

After this PR is merged, maintainers will still have the ability to manually merge PRs, however this is discouraged as we will work towards restricting such occurrences in the future.

Part of https://github.com/gardener/org/issues/3

> [!IMPORTANT]
> Planned merge date for this PR is 16.02.2026.

/hold

/cc @oliver-goetz 