### PR TITLE
Limit crypto label description to 100 characters

### DIFF
--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -775,7 +775,7 @@ default:
     addedBy: prow
   - name: crypto
     color: f9d0c4
-    description: Changes that affect cryptography or security mechanisms, such as encryption, keys, ciphers, hashes, signatures, or related configuration. Used to ensure visibility and review of crypto-impacting changes.
+    description: Affecting cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.).
     target: both
     prowPlugin: label
     addedBy: anyone


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Github does not allow descriptions over 100 characters for labels. Issue was introduced by me with https://github.com/gardener/ci-infra/pull/5317

Prow is logging
```
{"component":"unset","error":"invalid config: description for crypto is too long","file":"k8s.io/test-infra/label_sync/main.go:757","func":"main.main","level":"fatal","msg":"failed to load --config=config/prow/labels.yaml","severity":"fatal","time":"2026-02-05T12:17:44Z"}
```