### PR TITLE
Do not run gardener e2e tests when only files in `hack/tools/image` change

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-gardenadm.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-gardenadm.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-gardener-e2e-kind-gardenadm
     cluster: gardener-prow-build
     always_run: false
-    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
+    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^hack/tools/image|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-node-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-node-upgrade.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-gardener-e2e-kind-ha-multi-node-upgrade
     cluster: gardener-prow-build
     always_run: false
-    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
+    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^hack/tools/image|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-node.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-node.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-gardener-e2e-kind-ha-multi-node
     cluster: gardener-prow-build
     always_run: false
-    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
+    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^hack/tools/image|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-gardener-e2e-kind-ha-multi-zone-upgrade
     cluster: gardener-prow-build
     always_run: false
-    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
+    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^hack/tools/image|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-gardener-e2e-kind-ha-multi-zone
     cluster: gardener-prow-build
     always_run: false
-    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
+    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^hack/tools/image|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-gardener-e2e-kind-ipv6
     cluster: gardener-prow-build
     always_run: false
-    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
+    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^hack/tools/image|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/gardener-e2e-kind-migration-ha-multi-node.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration-ha-multi-node.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-gardener-e2e-kind-migration-ha-multi-node
     cluster: gardener-prow-build
     always_run: false
-    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
+    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^hack/tools/image|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-gardener-e2e-kind-migration
     cluster: gardener-prow-build
     always_run: false
-    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
+    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^hack/tools/image|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/gardener-e2e-kind-operator.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-gardener-e2e-kind-operator
     cluster: gardener-prow-build
     always_run: false
-    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
+    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^hack/tools/image|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-gardener-e2e-kind-upgrade
     cluster: gardener-prow-build
     always_run: false
-    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
+    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^hack/tools/image|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-gardener-e2e-kind
     cluster: gardener-prow-build
     always_run: false
-    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
+    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^hack/tools/image|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
     skip_branches:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This safes some time and money since the golang-test image is unrelated to changes in gardener code base. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @marc1404 
