### PR TITLE
Build `krte` image for Go 1.26

### DIFF
--- a/images/krte/variants.yaml
+++ b/images/krte/variants.yaml
@@ -1,7 +1,7 @@
 variants:
-  "1.24":
-    IMAGE_ARG: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:1.24
-    golangtestimage: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260211-9441401-1.24
   "1.25":
     IMAGE_ARG: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:1.25
     golangtestimage: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260211-71191c9-1.25
+  "1.26":
+    IMAGE_ARG: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:1.26
+    golangtestimage: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260211-71191c9-1.26


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind TODO

**What this PR does / why we need it**:
With this PR we start building `krte` images for Go 1.24. It also retires those for Go 1.24 since it is deprecated.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @marc1404 
