### PR TITLE
Use latest test image for ci-gardener-e2e-kind-gardenadm

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-gardenadm.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-gardenadm.yaml
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260217-88f94cf-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260218-481f37d-1.26
       command:
       - wrapper.sh
       - bash


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
#5434 wrongfully added an old test image for this test.
This PR updates it to the latest test image, like other tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
