### PR TITLE
Higher memory limits for external-dns-management and cert-management unit tests

### DIFF
--- a/config/jobs/cert-management/cert-management-integration-tests.yaml
+++ b/config/jobs/cert-management/cert-management-integration-tests.yaml
@@ -19,10 +19,10 @@ presubmits:
         - test-integration
         resources:
           limits:
-            memory: 2Gi
+            memory: 4Gi
           requests:
             cpu: 2
-            memory: 1Gi
+            memory: 2Gi
 periodics:
 - name: ci-cert-management-integration
   cluster: gardener-prow-build
@@ -49,7 +49,7 @@ periodics:
       - test-integration
       resources:
         limits:
-          memory: 2Gi
+          memory: 4Gi
         requests:
           cpu: 2
-          memory: 1Gi
+          memory: 2Gi

--- a/config/jobs/cert-management/cert-management-unit-tests.yaml
+++ b/config/jobs/cert-management/cert-management-unit-tests.yaml
@@ -19,10 +19,10 @@ presubmits:
         - test
         resources:
           limits:
-            memory: 3Gi
+            memory: 4Gi
           requests:
             cpu: 2
-            memory: 1.5Gi
+            memory: 2Gi
 periodics:
 - name: ci-cert-management-unit
   cluster: gardener-prow-build
@@ -49,7 +49,7 @@ periodics:
       - test
       resources:
         limits:
-          memory: 3Gi
+          memory: 4Gi
         requests:
           cpu: 2
-          memory: 1.5Gi
+          memory: 2Gi

--- a/config/jobs/external-dns-management/external-dns-management-unit-tests.yaml
+++ b/config/jobs/external-dns-management/external-dns-management-unit-tests.yaml
@@ -19,10 +19,10 @@ presubmits:
         - unittests
         resources:
           limits:
-            memory: 4Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 2Gi
+            memory: 3Gi
 periodics:
 - name: ci-external-dns-management-unit
   cluster: gardener-prow-build
@@ -49,7 +49,7 @@ periodics:
       - unittests
       resources:
         limits:
-          memory: 4Gi
+          memory: 6Gi
         requests:
           cpu: 2
-          memory: 2Gi
+          memory: 3Gi


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
The unit test jobs of external-dns-management and cert-management are sometimes stuck with `OOMKilled` of the prow pod.
Limits have been increased once again. Values in #5435 were not sufficient.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @marc1404 