### PR TITLE
Add `dnsmasq` package to `krte` image

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -53,6 +53,7 @@ RUN echo "Installing Packages ..." \
             build-essential \
             ca-certificates \
             curl \
+            dnsmasq \
             file \
             git \
             gnupg2 \


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR adds the `dnsmasq` package to the `krte` image.
It is required by https://github.com/gardener/gardener/pull/14062 and is used to run a local DNS forwarder with conditional forwarding for the `local.gardener.cloud` zone to the local setup's authoritative DNS server (bind9).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13927
Part of https://github.com/gardener/gardener/pull/14062

**Special notes for your reviewer**:
