### PR TITLE
More memory needed for extension-shoot-dns-service-unit-tests

### DIFF
--- a/config/jobs/extension-shoot-dns-service/extension-shoot-dns-service-unit-tests.yaml
+++ b/config/jobs/extension-shoot-dns-service/extension-shoot-dns-service-unit-tests.yaml
@@ -19,10 +19,10 @@ presubmits:
         - verify-extended
         resources:
           limits:
-            memory: 4Gi
+            memory: 6Gi
           requests:
             cpu: 2
-            memory: 2Gi
+            memory: 3Gi
 periodics:
 - name: ci-extension-shoot-dns-service-unit
   cluster: gardener-prow-build
@@ -49,7 +49,7 @@ periodics:
       - verify-extended
       resources:
         limits:
-          memory: 4Gi
+          memory: 6Gi
         requests:
           cpu: 2
-          memory: 2Gi
+          memory: 3Gi


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
The job pull-extension-shoot-dns-service-unit times out probably because of insufficient memory.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
