### PR TITLE
Add e2e job for extension auditing

### DIFF
--- a/config/jobs/gardener-extension-auditing/gardener-extension-auditing-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-auditing/gardener-extension-auditing-e2e-kind.yaml
@@ -1,0 +1,88 @@
+presubmits:
+  gardener/gardener-extension-auditing:
+  - name: pull-gardener-extension-auditing-e2e-kind
+    cluster: gardener-prow-build
+    always_run: false
+    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs)/|\\.md$|^hack/tools/image|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
+    decorate: true
+    decoration_config:
+      timeout: 2h
+      grace_period: 15m
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-gocache-mounts: "true"
+    annotations:
+      description: Runs end-to-end tests for gardener-extension-auditing
+    spec:
+      serviceAccountName: gardener-prow-gobuildcache-ro
+      containers:
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260223-c2ad828-1.26
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        args:
+        - |
+          go install github.com/saracen/gobuildcache@83bfeb837b93a786ff37b33d0be108bcc74b089f
+          PATH=/home/prow/go/bin:$PATH
+          export GOCACHEPROG="gobuildcache -readonly gs://gardener-prow-gobuildcache"
+          make ci-e2e-kind
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 6
+            memory: 24Gi
+        env:
+        - name: SKAFFOLD_UPDATE_CHECK
+          value: "false"
+        - name: SKAFFOLD_INTERACTIVE
+          value: "false"
+periodics:
+- name: ci-gardener-extension-auditing-e2e-kind
+  cluster: gardener-prow-build
+  interval: 24h
+  extra_refs:
+  - org: gardener
+    repo: gardener-extension-auditing
+    base_ref: main
+  decorate: true
+  decoration_config:
+    timeout: 2h
+    grace_period: 15m
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-gocache-mounts: "true"
+  annotations:
+    description: Runs end-to-end tests for gardener-extension-auditing periodically
+    testgrid-dashboards: gardener-extension-auditing
+    testgrid-days-of-results: "60"
+  spec:
+    serviceAccountName: gardener-prow-gobuildcache-rw
+    containers:
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260223-c2ad828-1.26
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      args:
+      - |
+        go install github.com/saracen/gobuildcache@83bfeb837b93a786ff37b33d0be108bcc74b089f
+        PATH=/home/prow/go/bin:$PATH
+        export GOCACHEPROG="gobuildcache gs://gardener-prow-gobuildcache"
+        make ci-e2e-kind
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 6
+          memory: 24Gi
+      env:
+      - name: SKAFFOLD_UPDATE_CHECK
+        value: "false"
+      - name: SKAFFOLD_INTERACTIVE
+        value: "false"

--- a/config/jobs/gardener-extension-auditing/gardener-extension-auditing-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-auditing/gardener-extension-auditing-e2e-kind.yaml
@@ -34,7 +34,7 @@ presubmits:
         resources:
           requests:
             cpu: 6
-            memory: 24Gi
+            memory: 18Gi
         env:
         - name: SKAFFOLD_UPDATE_CHECK
           value: "false"
@@ -80,7 +80,7 @@ periodics:
       resources:
         requests:
           cpu: 6
-          memory: 24Gi
+          memory: 18Gi
       env:
       - name: SKAFFOLD_UPDATE_CHECK
         value: "false"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
I want to enable e2e testing for https://github.com/gardener/gardener-extension-auditing.

The plan is:
- run the gardener's operator setup
- configure the extension for Garden and Shoot
- assert results

As I have limited knowledge on testing in prow I am not sure if I copied everything right. Can you please help review @oliver-goetz ?

@shafeeqes can you please elaborate if I need the gobuild cache stuff? I copied the manifests from https://github.com/gardener/ci-infra/blob/master/config/jobs/gardener/gardener-e2e-kind-operator.yaml, however I see that https://github.com/gardener/ci-infra/blob/master/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-operator.yaml for example does not set the cache configurations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
