### PR TITLE
Fix tls certificates for `oauth2-proxy`

### DIFF
--- a/deploy/oauth2-proxy/oauth2-proxy-gateway.yaml
+++ b/deploy/oauth2-proxy/oauth2-proxy-gateway.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     cert.gardener.cloud/issuer: ci-issuer
     cert.gardener.cloud/purpose: managed
+    cert.gardener.cloud/dnsnames: oauth2.prow.gardener.cloud
     dns.gardener.cloud/class: garden
     dns.gardener.cloud/dnsnames: oauth2.prow.gardener.cloud
 spec:

--- a/deploy/oauth2-proxy/oauth2-proxy-httproute.yaml
+++ b/deploy/oauth2-proxy/oauth2-proxy-httproute.yaml
@@ -9,6 +9,7 @@ spec:
     namespace: oauth2-proxy
     sectionName: https
   hostnames:
+  # This wildcard is required that other prow clusters can use this oauth2-proxy for ExtAuth.
   - "*.prow.gardener.cloud"
   rules:
   - matches:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Before the domains for the certificate request were automatically collected from `Gateway` and `HTTPRoute`. This does not work because you cannot include a wildcard domain (`*.prow.gardener.cloud`) and a matching subdomain (`oauth2.prow.gardener.cloud`). in the same letsencrypt request.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @MartinWeindel 
Thanks 🙂 