### PR TITLE
Add Renovate preset for grouping gardener updates

### DIFF
--- a/config/renovate/group-gardener-updates.json5
+++ b/config/renovate/group-gardener-updates.json5
@@ -1,0 +1,14 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  description: 'Groups Go modules from gardener/gardener together.',
+  packageRules: [
+    {
+      groupName: 'gardener/gardener',
+      description: 'Group Go modules from gardener/gardener together.',
+      matchPackageNames: [
+        'github.com/gardener/gardener',
+        'github.com/gardener/gardener/pkg/apis',
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Adds a Renovate preset that allows repositories to group Renovate updates for Go modules from `gardener/gardener`.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

_Example PRs to group:_
* https://github.com/gardener/cert-management/pull/703
* https://github.com/gardener/cert-management/pull/704

/cc @oliver-goetz 
