### PR TITLE
Synchronize our `cherrypicker` fork with upstream

### DIFF
--- a/prow/external-plugins/cherrypicker/README.md
+++ b/prow/external-plugins/cherrypicker/README.md
@@ -1,6 +1,6 @@
 # Cherrypicker
 
-**Note: This is a fork of [cherrypicker from kubernetes-sigs/prow (commit 6d1ac1c)](https://github.com/kubernetes-sigs/prow/tree/6d1ac1c1017a2fbf8e77048a7506f6042fb47cb8/cmd/external-plugins/cherrypicker) repository.
+**Note: This is a fork of [cherrypicker from kubernetes-sigs/prow (commit 5edbb8e)](https://github.com/kubernetes-sigs/prow/tree/5edbb8e3ab3d4033eb5fe2f735e3e061d483032b/cmd/external-plugins/cherrypicker) repository.
 It changes the release note regexp to fit the gardener release note format**
 
 Cherrypicker is an external prow plugin that can also run as a standalone bot.
@@ -11,9 +11,10 @@ For comments:
 
 ```
 /cherrypick release-1.10
+/cherrypick release-1.11
 ```
 
-The above comment will result in opening a new PR against the `release-1.10` branch
+The above comment will result in opening a new PR against the `release-1.10` and `release-1.11` branches
 once the PR where the comment was made gets merged or is already merged.
 
 To use label, you need to apply labels that contain the name of the branch in the form:

--- a/prow/external-plugins/cherrypicker/main.go
+++ b/prow/external-plugins/cherrypicker/main.go
@@ -127,10 +127,6 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting bot name.")
 	}
-	repos, err := githubClient.GetRepos(botUser.Login, true)
-	if err != nil {
-		log.WithError(err).Fatal("Error listing bot repositories.")
-	}
 
 	server := &Server{
 		tokenGenerator: secret.GetTokenGenerator(o.webhookSecretFile),
@@ -150,8 +146,6 @@ func main() {
 
 		bare:     &http.Client{},
 		patchURL: "https://patch-diff.githubusercontent.com",
-
-		repos: repos,
 	}
 
 	health := pjutil.NewHealthOnPort(o.instrumentationOptions.HealthPort)

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -17,13 +17,12 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -31,6 +30,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	cherrypicker "sigs.k8s.io/prow/cmd/external-plugins/cherrypicker/lib"
 	"sigs.k8s.io/prow/pkg/config"
 	"sigs.k8s.io/prow/pkg/git/v2"
@@ -94,9 +94,9 @@ type Server struct {
 
 	gc git.ClientFactory
 	// Used for unit testing
-	push func(forkName, newBranch string, force bool) error
-	ghc  githubClient
-	log  *logrus.Entry
+	pusher pusher
+	ghc    githubClient
+	log    logrus.FieldLogger
 
 	// Labels to apply to the cherrypicked PR.
 	labels []string
@@ -114,10 +114,26 @@ type Server struct {
 	bare     *http.Client
 	patchURL string
 
-	repoLock sync.Mutex
-	repos    []github.Repo
-	mapLock  sync.Mutex
-	lockMap  map[cherryPickRequest]*sync.Mutex
+	mapLock sync.Mutex
+	lockMap map[cherryPickRequest]*sync.Mutex
+}
+
+type pusher interface {
+	Push(r git.RepoClient, newBranch string, force bool) error
+}
+
+type forkPusher struct {
+	forkName string
+}
+
+func (p *forkPusher) Push(r git.RepoClient, newBranch string, force bool) error {
+	return r.PushToNamedFork(p.forkName, newBranch, force)
+}
+
+type centralPusher struct{}
+
+func (p *centralPusher) Push(r git.RepoClient, newBranch string, force bool) error {
+	return r.PushToCentral(newBranch, force)
 }
 
 type cherryPickRequest struct {
@@ -136,12 +152,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Event received. Have a nice day.")
 
 	if err := s.handleEvent(eventType, eventGUID, payload); err != nil {
-		logrus.WithError(err).Error("Error parsing event.")
+		s.log.WithError(err).Error("Error parsing event.")
 	}
 }
 
 func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error {
-	l := logrus.WithFields(logrus.Fields{
+	l := s.log.WithFields(logrus.Fields{
 		"event-type":     eventType,
 		github.EventGUID: eventGUID,
 	})
@@ -152,8 +168,8 @@ func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error 
 			return err
 		}
 		go func() {
-			if err := s.handleIssueComment(l, ic); err != nil {
-				s.log.WithError(err).WithFields(l.Data).Info("Cherry-pick failed.")
+			if log, err := s.handleIssueComment(l, ic); err != nil {
+				log.WithError(err).Info("Cherry-pick failed.")
 			}
 		}()
 	case "pull_request":
@@ -162,20 +178,20 @@ func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error 
 			return err
 		}
 		go func() {
-			if err := s.handlePullRequest(l, pr); err != nil {
-				s.log.WithError(err).WithFields(l.Data).Info("Cherry-pick failed.")
+			if log, err := s.handlePullRequest(l, pr); err != nil {
+				log.WithError(err).Info("Cherry-pick failed.")
 			}
 		}()
 	default:
-		logrus.Debugf("skipping event of type %q", eventType)
+		l.Debugf("skipping event of type %q", eventType)
 	}
 	return nil
 }
 
-func (s *Server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent) error {
+func (s *Server) handleIssueComment(log logrus.FieldLogger, ic github.IssueCommentEvent) (logrus.FieldLogger, error) {
 	// Only consider new comments in PRs.
 	if !ic.Issue.IsPullRequest() || ic.Action != github.IssueCommentActionCreated {
-		return nil
+		return log, nil
 	}
 
 	org := ic.Repo.Owner.Login
@@ -183,94 +199,149 @@ func (s *Server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 	num := ic.Issue.Number
 	commentAuthor := ic.Comment.User.Login
 
-	// Do not create a new logger, its fields are re-used by the caller in case of errors
-	*l = *l.WithFields(logrus.Fields{
+	log = log.WithFields(logrus.Fields{
 		github.OrgLogField:  org,
 		github.RepoLogField: repo,
 		github.PrLogField:   num,
 	})
 
-	cherryPickMatches := cherryPickRe.FindAllStringSubmatch(ic.Comment.Body, -1)
-	if len(cherryPickMatches) == 0 || len(cherryPickMatches[0]) < 2 {
-		return nil
-	}
-	branches := strings.Fields(cherryPickMatches[0][1])
-	targetBranch := branches[0]
-	var chainBranches []string
-	if len(branches) > 1 {
-		chainBranches = branches[1:]
-	}
-
-	if ic.Issue.State != "closed" {
-		if !s.allowAll {
-			// Only members or collaborators should be able to do cherry-picks.
-			ok, err := s.isTrustedUser(org, repo, commentAuthor)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				resp := fmt.Sprintf(notOrgMemberMessageTemplate, org, org, org, commentAuthor)
-				l.Info(resp)
-				return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
-			}
-		}
-		resp := fmt.Sprintf("once the present PR merges, I will cherry-pick it on top of %s in a new PR and assign it to you.", targetBranch)
-		l.Info(resp)
-		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
-	}
-
+	// fetch pull request
 	pr, err := s.ghc.GetPullRequest(org, repo, num)
 	if err != nil {
-		return fmt.Errorf("failed to get pull request %s/%s#%d: %w", org, repo, num, err)
+		return log, fmt.Errorf("failed to get pull request %s/%s#%d: %w", org, repo, num, err)
 	}
 	baseBranch := pr.Base.Ref
 	title := pr.Title
 	body := pr.Body
 
+	// Collect all branches for which a PR should be created as an immediate response
+	// to it. This excludes all subsequent branches in chained cherrypicks.
+	commands := parseComment(ic.Comment)
+
+	// Due to the regular expression, this should never happen.
+	if len(commands) == 0 {
+		return log, nil
+	}
+
+	_, hasInvalidBranch := commands[baseBranch]
+	delete(commands, baseBranch)
+
+	// If the user requested multiple cherry-picks, we inform them later if they also included
+	// the base branch by mistake.
+	if len(commands) == 0 {
+		resp := fmt.Sprintf("I cannot cherry-pick the present PR on top of its base branch (`%s`).", baseBranch)
+		log.Info(resp)
+		return log, s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
+	}
+
+	// PR is not yet done, inform the user we will remember their instructions and create PRs later.
+	if ic.Issue.State != "closed" {
+		if !s.allowAll {
+			// Only members or collaborators should be able to do cherry-picks.
+			ok, err := s.isTrustedUser(org, repo, commentAuthor)
+			if err != nil {
+				return log, err
+			}
+			if !ok {
+				resp := fmt.Sprintf(notOrgMemberMessageTemplate, org, org, org, commentAuthor)
+				log.Info(resp)
+				return log, s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
+			}
+		}
+
+		var branchNames []string
+		for _, branch := range sets.List(sets.KeySet(commands)) {
+			branchNames = append(branchNames, fmt.Sprintf("`%s`", branch))
+		}
+
+		var resp string
+		if len(branchNames) == 1 {
+			resp = fmt.Sprintf("once the present PR merges, I will cherry-pick it on top of %s in a new PR and assign it to you.", branchNames[0])
+		} else {
+			resp = fmt.Sprintf("once the present PR merges, I will cherry-pick it on top of %s in new PRs and assign them to you.", strings.Join(branchNames, ", "))
+		}
+		if hasInvalidBranch {
+			resp += fmt.Sprintf(" I cannot cherry-pick it on top of `%s` because that is already its base branch.", baseBranch)
+		}
+
+		log.Info(resp)
+		return log, s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
+	}
+
 	// Cherry-pick only merged PRs.
 	if !pr.Merged {
 		resp := "cannot cherry-pick an unmerged PR"
-		l.Info(resp)
-		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
-	}
-
-	// TODO: Use an allowlist for allowed base and target branches.
-	if baseBranch == targetBranch {
-		resp := fmt.Sprintf("base branch (%s) needs to differ from target branch (%s)", baseBranch, targetBranch)
-		l.Info(resp)
-		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
+		log.Info(resp)
+		return log, s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
 	}
 
 	if !s.allowAll {
 		// Only org members or collaborators should be able to do cherry-picks.
 		ok, err := s.isTrustedUser(org, repo, commentAuthor)
 		if err != nil {
-			return err
+			return log, err
 		}
 		if !ok {
 			resp := fmt.Sprintf(notOrgMemberMessageTemplate, org, org, org, commentAuthor)
-			l.Info(resp)
-			return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
+			log.Info(resp)
+			return log, s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
 		}
 	}
 
-	*l = *l.WithFields(logrus.Fields{
-		"requestor":     ic.Comment.User.Login,
-		"target_branch": targetBranch,
-	})
-	l.Debug("Cherrypick request.")
-	return s.handle(l, pr.User.Login, ic.Comment.User.Login, &ic.Comment, org, repo, targetBranch, baseBranch, chainBranches, title, body, num, pr.Labels)
+	// If the user requested multiple cherry-picks and one of them was invalid, warn them about it.
+	if hasInvalidBranch {
+		resp := fmt.Sprintf("I cannot cherry-pick the present PR on top of its base branch (`%s`).", baseBranch)
+		log.Info(resp)
+
+		if err := s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp)); err != nil {
+			log.WithError(err).WithField("response", resp).Error("Failed to create comment.")
+		}
+	}
+
+	// A failure in one cherry-pick must NOT prevent processing of the remaining
+	// targets, so we collect errors and continue the loop.
+	var errs []error
+
+	for _, targetBranch := range sets.List(sets.KeySet(commands)) {
+		branchLog := log.WithFields(logrus.Fields{
+			"requestor":     ic.Comment.User.Login,
+			"target_branch": targetBranch,
+		})
+		branchLog.Debug("Cherrypick request.")
+
+		if err := s.handle(branchLog, pr.User.Login, ic.Comment.User.Login, &ic.Comment, org, repo, targetBranch, baseBranch, commands[targetBranch], title, body, num, pr.Labels); err != nil {
+			errs = append(errs, fmt.Errorf("failed to handle cherrypick for %s: %w", targetBranch, err))
+			continue
+		}
+	}
+
+	return log, utilerrors.NewAggregate(errs)
 }
 
-func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent) error {
+type cherrypickCommands map[string][]string
+
+func parseComment(comment github.IssueComment) cherrypickCommands {
+	cmds := cherrypickCommands{}
+
+	for _, match := range cherryPickRe.FindAllStringSubmatch(comment.Body, -1) {
+		targetBranches := strings.Fields(match[1])
+		targetBranch := targetBranches[0]
+
+		cmds[targetBranch] = targetBranches[1:]
+	}
+
+	return cmds
+}
+
+func (s *Server) handlePullRequest(log logrus.FieldLogger, pre github.PullRequestEvent) (logrus.FieldLogger, error) {
 	// Only consider newly merged PRs
-	if pre.Action != github.PullRequestActionClosed && pre.Action != github.PullRequestActionLabeled {
-		return nil
+	if pre.Action != github.PullRequestActionClosed && pre.Action != github.PullRequestActionLabeled && pre.Action != github.PullRequestActionOpened {
+		return log, nil
 	}
 
 	pr := pre.PullRequest
 	if !pr.Merged || pr.MergeSHA == nil {
-		return nil
+		return log, nil
 	}
 
 	org := pr.Base.Repo.Owner.Login
@@ -280,8 +351,7 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 	title := pr.Title
 	body := pr.Body
 
-	// Do not create a new logger, its fields are re-used by the caller in case of errors
-	*l = *l.WithFields(logrus.Fields{
+	log = log.WithFields(logrus.Fields{
 		github.OrgLogField:  org,
 		github.RepoLogField: repo,
 		github.PrLogField:   num,
@@ -289,7 +359,7 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 
 	comments, err := s.ghc.ListIssueComments(org, repo, num)
 	if err != nil {
-		return fmt.Errorf("failed to list comments: %w", err)
+		return log, fmt.Errorf("failed to list comments: %w", err)
 	}
 
 	// requestor -> target branch -> issue comment
@@ -297,18 +367,24 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 	// target branch -> chain branches (eg. "release-1.6" -> []string{"release-1.5", "release-1.4"})
 	targetBranchToChainBranches := make(map[string][]string)
 
+	// treat PR body/description as a comment
+	comments = append([]github.IssueComment{{
+		Body: body,
+		User: pr.User,
+	}}, comments...)
+
 	// first look for our special comments
-	for i := range comments {
-		c := comments[i]
-		cherryPickMatches := cherryPickRe.FindAllStringSubmatch(c.Body, -1)
-		for _, match := range cherryPickMatches {
-			targetBranch := strings.Fields(match[1])
-			if requestorToComments[c.User.Login] == nil {
-				requestorToComments[c.User.Login] = make(map[string]*github.IssueComment)
+	for _, comment := range comments {
+		commands := parseComment(comment)
+
+		for targetBranch, chainedBranches := range commands {
+			if requestorToComments[comment.User.Login] == nil {
+				requestorToComments[comment.User.Login] = make(map[string]*github.IssueComment)
 			}
-			requestorToComments[c.User.Login][targetBranch[0]] = &c
-			if len(targetBranch) > 1 {
-				targetBranchToChainBranches[targetBranch[0]] = targetBranch[1:]
+			requestorToComments[comment.User.Login][targetBranch] = &comment
+
+			if len(chainedBranches) > 0 {
+				targetBranchToChainBranches[targetBranch] = chainedBranches
 			}
 		}
 	}
@@ -318,7 +394,7 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 	// now look for our special labels
 	labels, err := s.ghc.GetIssueLabels(org, repo, num)
 	if err != nil {
-		return fmt.Errorf("failed to get issue labels: %w", err)
+		return log, fmt.Errorf("failed to get issue labels: %w", err)
 	}
 
 	if requestorToComments[pr.User.Login] == nil {
@@ -334,11 +410,11 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 	}
 
 	if !foundCherryPickComments && !foundCherryPickLabels {
-		return nil
+		return log, nil
 	}
 
 	if !foundCherryPickLabels && pre.Action == github.PullRequestActionLabeled {
-		return nil
+		return log, nil
 	}
 
 	// Figure out membership.
@@ -346,16 +422,10 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 		// TODO: Possibly cache this.
 		logins, err := s.listTrustedUsers(org, repo)
 		if err != nil {
-			return err
+			return log, err
 		}
 		for requestor := range requestorToComments {
-			isTrusted := false
-			for _, l := range logins {
-				if requestor == l {
-					isTrusted = true
-					break
-				}
-			}
+			isTrusted := slices.Contains(logins, requestor)
 			if !isTrusted {
 				delete(requestorToComments, requestor)
 			}
@@ -374,34 +444,34 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 			}
 			if targetBranch == baseBranch {
 				resp := fmt.Sprintf("base branch (%s) needs to differ from target branch (%s)", baseBranch, targetBranch)
-				l.Info(resp)
-				if err := s.createComment(l, org, repo, num, ic, resp); err != nil {
-					l.WithError(err).WithField("response", resp).Error("Failed to create comment.")
+				log.Info(resp)
+				if err := s.createComment(log, org, repo, num, ic, resp); err != nil {
+					log.WithError(err).WithField("response", resp).Error("Failed to create comment.")
 				}
 				continue
 			}
 			handledBranches[targetBranch] = true
-			l := l.WithFields(logrus.Fields{
+			branchLog := log.WithFields(logrus.Fields{
 				"requestor":     requestor,
 				"target_branch": targetBranch,
 			})
-			l.Debug("Cherrypick request.")
+			branchLog.Debug("Cherrypick request.")
 			var chainedBranches []string
 			if branches, ok := targetBranchToChainBranches[targetBranch]; ok {
 				chainedBranches = branches
 			}
-			err := s.handle(l, pr.User.Login, requestor, ic, org, repo, targetBranch, baseBranch, chainedBranches, title, body, num, pr.Labels)
+			err := s.handle(branchLog, pr.User.Login, requestor, ic, org, repo, targetBranch, baseBranch, chainedBranches, title, body, num, pr.Labels)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to create cherrypick: %w", err))
 			}
 		}
 	}
-	return utilerrors.NewAggregate(errs)
+	return log, utilerrors.NewAggregate(errs)
 }
 
 var cherryPickBranchFmt = "cherry-pick-%d-to-%s"
 
-func (s *Server) handle(logger *logrus.Entry, author, requestor string, comment *github.IssueComment, org, repo, targetBranch, baseBranch string, chainBranches []string, title, body string, num int, labels []github.Label) error {
+func (s *Server) handle(logger logrus.FieldLogger, author, requestor string, comment *github.IssueComment, org, repo, targetBranch, baseBranch string, chainBranches []string, title, body string, num int, labels []github.Label) error {
 	var lock *sync.Mutex
 	func() {
 		s.mapLock.Lock()
@@ -417,18 +487,22 @@ func (s *Server) handle(logger *logrus.Entry, author, requestor string, comment 
 	lock.Lock()
 	defer lock.Unlock()
 
-	forkName, err := s.ensureForkExists(org, repo)
+	p, pushOrg, err := s.getPusherAndOrg(logger, org, repo)
 	if err != nil {
-		logger.WithError(err).Warn("failed to ensure fork exists")
-		resp := fmt.Sprintf("cannot fork %s/%s: %v", org, repo, err)
+		logger.WithError(err).Warn("failed get pusher")
+		resp := fmt.Sprintf("cannot decide how to push into %s/%s: %v", org, repo, err)
 		return s.createComment(logger, org, repo, num, comment, resp)
+	}
+
+	if s.pusher != nil {
+		p = s.pusher
 	}
 
 	// Clone the repo, checkout the target branch.
 	startClone := time.Now()
 	r, err := s.gc.ClientFor(org, repo)
 	if err != nil {
-		return fmt.Errorf("failed to get git client for %s/%s: %w", org, forkName, err)
+		return fmt.Errorf("failed to get git client for %s/%s: %w", org, repo, err)
 	}
 	defer func() {
 		if err := r.Clean(); err != nil {
@@ -445,7 +519,8 @@ func (s *Server) handle(logger *logrus.Entry, author, requestor string, comment 
 	// Fetch the patch from GitHub
 	localPath, err := s.getPatch(org, repo, targetBranch, num)
 	if err != nil {
-		return fmt.Errorf("failed to get patch: %w", err)
+		logger.WithError(err).Errorf("Failed to get patch for %s/%s#%d", org, repo, num)
+		return s.createComment(logger, org, repo, num, comment, fmt.Sprintf("Failed to get PR patch from GitHub. This PR will need to be manually cherrypicked.\n<details><summary>Error message</summary>%v</details>", err))
 	}
 
 	if err := r.Config("user.name", s.botUser.Login); err != nil {
@@ -506,12 +581,8 @@ func (s *Server) handle(logger *logrus.Entry, author, requestor string, comment 
 		return utilerrors.NewAggregate(errs)
 	}
 
-	push := r.PushToNamedFork
-	if s.push != nil {
-		push = s.push
-	}
-	// Push the new branch in the bot's fork.
-	if err := push(forkName, newBranch, true); err != nil {
+	// Push the new branch
+	if err := p.Push(r, newBranch, true); err != nil {
 		logger.WithError(err).Warn("failed to push chery-picked changes to GitHub")
 		resp := fmt.Sprintf("failed to push cherry-picked changes in GitHub: %v", err)
 		return utilerrors.NewAggregate([]error{err, s.createComment(logger, org, repo, num, comment, resp)})
@@ -524,14 +595,19 @@ func (s *Server) handle(logger *logrus.Entry, author, requestor string, comment 
 	} else {
 		cherryPickBody = cherrypicker.CreateCherrypickBody(num, "", releaseNoteFromParentPR(author, org, repo, num, body), chainBranches)
 	}
-	head := fmt.Sprintf("%s:%s", s.botUser.Login, newBranch)
+
+	head := fmt.Sprintf("%s:%s", pushOrg, newBranch)
+	if pushOrg == org {
+		head = newBranch
+	}
+
 	createdNum, err := s.ghc.CreatePullRequest(org, repo, title, cherryPickBody, head, targetBranch, true)
 	if err != nil {
 		logger.WithError(err).Warn("failed to create new pull request")
 		resp := fmt.Sprintf("new pull request could not be created: %v", err)
 		return utilerrors.NewAggregate([]error{err, s.createComment(logger, org, repo, num, comment, resp)})
 	}
-	*logger = *logger.WithField("new_pull_request_number", createdNum)
+	logger = logger.WithField("new_pull_request_number", createdNum)
 	resp := fmt.Sprintf("new pull request created: #%d", createdNum)
 	logger.Info("new pull request created")
 	if err := s.createComment(logger, org, repo, num, comment, resp); err != nil {
@@ -601,7 +677,7 @@ func omitBaseBranchFromTitle(title, baseBranch string) string {
 	return strings.Replace(title, fmt.Sprintf(titleTargetBranchIndicatorTemplate, baseBranch), "", 1)
 }
 
-func (s *Server) createComment(l *logrus.Entry, org, repo string, num int, comment *github.IssueComment, resp string) error {
+func (s *Server) createComment(l logrus.FieldLogger, org, repo string, num int, comment *github.IssueComment, resp string) error {
 	if err := func() error {
 		if comment != nil {
 			return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(*comment, resp))
@@ -611,12 +687,12 @@ func (s *Server) createComment(l *logrus.Entry, org, repo string, num int, comme
 		l.WithError(err).Warn("failed to create comment")
 		return err
 	}
-	logrus.Debug("Created comment")
+	l.Debug("Created comment")
 	return nil
 }
 
 // createIssue creates an issue on GitHub.
-func (s *Server) createIssue(l *logrus.Entry, org, repo, title, body string, num int, comment *github.IssueComment, labels, assignees []string) error {
+func (s *Server) createIssue(l logrus.FieldLogger, org, repo, title, body string, num int, comment *github.IssueComment, labels, assignees []string) error {
 	issueNum, err := s.ghc.CreateIssue(org, repo, title, body, 0, labels, assignees)
 	if err != nil {
 		return s.createComment(l, org, repo, num, comment, fmt.Sprintf("new issue could not be created for failed cherrypick: %v", err))
@@ -625,20 +701,22 @@ func (s *Server) createIssue(l *logrus.Entry, org, repo, title, body string, num
 	return s.createComment(l, org, repo, num, comment, fmt.Sprintf("new issue created for failed cherrypick: #%d", issueNum))
 }
 
-// ensureForkExists ensures a fork of org/repo exists for the bot.
-func (s *Server) ensureForkExists(org, repo string) (string, error) {
-	fork := s.botUser.Login + "/" + repo
-
+func (s *Server) getPusherAndOrg(l logrus.FieldLogger, org, repo string) (pusher, string, error) {
 	// fork repo if it doesn't exist
-	repo, err := s.ghc.EnsureFork(s.botUser.Login, org, repo)
-	if err != nil {
-		return repo, err
+	forkName, err := s.ghc.EnsureFork(s.botUser.Login, org, repo)
+	if err != nil && !github.IsForbidden(err) {
+		return nil, "", fmt.Errorf("failed to ensure fork exists: %w", err)
 	}
 
-	s.repoLock.Lock()
-	defer s.repoLock.Unlock()
-	s.repos = append(s.repos, github.Repo{FullName: fork, Fork: true})
-	return repo, nil
+	// private repos cannot be forked because by default it's denied on org level.
+	// Push into the same org/repo as used for the cherry pick if it's forbidden
+	if github.IsForbidden(err) {
+		l.Warnf("forking repo %s/%s is forbidden, pushing cherrypick branch into the same repo", org, repo)
+		return &centralPusher{}, org, nil
+	}
+	return &forkPusher{
+		forkName: forkName,
+	}, s.botUser.Login, nil
 }
 
 // getPatch gets the patch for the provided PR and creates a local
@@ -649,15 +727,12 @@ func (s *Server) getPatch(org, repo, targetBranch string, num int) (string, erro
 	if err != nil {
 		return "", err
 	}
+
 	localPath := fmt.Sprintf("/tmp/%s_%s_%d_%s.patch", org, repo, num, normalize(targetBranch))
-	out, err := os.Create(localPath)
-	if err != nil {
+	if err := os.WriteFile(localPath, patch, 0644); err != nil {
 		return "", err
 	}
-	defer out.Close()
-	if _, err := io.Copy(out, bytes.NewBuffer(patch)); err != nil {
-		return "", err
-	}
+
 	return localPath, nil
 }
 

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -27,13 +27,19 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/prow/pkg/git/localgit"
-	v2 "sigs.k8s.io/prow/pkg/git/v2"
+	"sigs.k8s.io/prow/pkg/git/v2"
 	"sigs.k8s.io/prow/pkg/github"
 )
 
 var commentFormat = "%s/%s#%d %s"
 
 var fakePR prNumberGenerator
+
+type testPusher struct{}
+
+func (p *testPusher) Push(_ git.RepoClient, _ string, _ bool) error {
+	return nil
+}
 
 type fghc struct {
 	sync.Mutex
@@ -148,6 +154,9 @@ func (f *fghc) EnsureFork(_, _, repo string) (string, error) {
 	}
 	if repo == "error" {
 		return repo, errors.New("errors")
+	}
+	if repo == "forbidden" {
+		return repo, github.NewForbidden()
 	}
 	return repo, nil
 }
@@ -290,7 +299,7 @@ index 1ea52dc..5bd70a9 100644
 
 var body = "This PR updates the magic number.\n\n```feature developer\nUpdate the magic number from 42 to 49\n```"
 
-func makeFakeRepoWithCommit(clients localgit.Clients, t *testing.T) (*localgit.LocalGit, v2.ClientFactory) {
+func makeFakeRepoWithCommit(clients localgit.Clients, t *testing.T) (*localgit.LocalGit, git.ClientFactory) {
 	lg, c, err := clients()
 	if err != nil {
 		t.Fatalf("Making localgit: %v", err)
@@ -377,16 +386,15 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 	s := &Server{
 		botUser:        botUser,
 		gc:             c,
-		push:           func(_, _ string, _ bool) error { return nil },
+		pusher:         &testPusher{},
 		ghc:            ghc,
 		tokenGenerator: getSecret,
 		log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
-		repos:          []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
 
 		prowAssignments: true,
 	}
 
-	if err := s.handleIssueComment(logrus.NewEntry(logrus.StandardLogger()), ic); err != nil {
+	if _, err := s.handleIssueComment(logrus.NewEntry(logrus.StandardLogger()), ic); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	got := prToString(ghc.prs[1])
@@ -515,16 +523,15 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 	s := &Server{
 		botUser:        botUser,
 		gc:             c,
-		push:           func(_, _ string, _ bool) error { return nil },
+		pusher:         &testPusher{},
 		ghc:            ghc,
 		tokenGenerator: getSecret,
 		log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
-		repos:          []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
 
 		prowAssignments: false,
 	}
 
-	if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
+	if _, err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -629,17 +636,16 @@ func testCherryPickOfCherryPickPR(clients localgit.Clients, t *testing.T) {
 	s := &Server{
 		botUser:        botUser,
 		gc:             c,
-		push:           func(_, _ string, _ bool) error { return nil },
+		pusher:         &testPusher{},
 		ghc:            ghc,
 		tokenGenerator: getSecret,
 		log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
-		repos:          []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
 
 		prowAssignments: false,
 	}
 
 	// Cherry pick master -> release-1.8
-	if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
+	if _, err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -647,7 +653,7 @@ func testCherryPickOfCherryPickPR(clients localgit.Clients, t *testing.T) {
 	pr.PullRequest.Base.Ref = "release-1.8"
 	pr.PullRequest.Title = "[release-1.8] This is a fix for Y"
 	ghc.prComments[0].Body = "/cherrypick release-1.6"
-	if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
+	if _, err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -655,7 +661,7 @@ func testCherryPickOfCherryPickPR(clients localgit.Clients, t *testing.T) {
 	pr.PullRequest.Base.Ref = "release-1.6"
 	pr.PullRequest.Title = "[release-1.6] This is a fix for Y"
 	ghc.prComments[0].Body = "/cherrypick release-1.5"
-	if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
+	if _, err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -816,18 +822,17 @@ func testCherryPickPRWithLabels(clients localgit.Clients, t *testing.T) {
 					s := &Server{
 						botUser:        botUser,
 						gc:             c,
-						push:           func(_, _ string, _ bool) error { return nil },
+						pusher:         &testPusher{},
 						ghc:            ghc,
 						tokenGenerator: getSecret,
 						log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
-						repos:          []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
 
 						labels:          []string{"cla: yes"},
 						prowAssignments: false,
 						labelPrefix:     tc.labelPrefix,
 					}
 
-					if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr(evt)); err != nil {
+					if _, err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr(evt)); err != nil {
 						t.Fatalf("unexpected error: %v", err)
 					}
 
@@ -1027,16 +1032,15 @@ func testCherryPickPRAssignments(clients localgit.Clients, t *testing.T) {
 		s := &Server{
 			botUser:        botUser,
 			gc:             c,
-			push:           func(_, _ string, _ bool) error { return nil },
+			pusher:         &testPusher{},
 			ghc:            ghc,
 			tokenGenerator: getSecret,
 			log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
-			repos:          []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
 
 			prowAssignments: prowAssignments,
 		}
 
-		if err := s.handleIssueComment(logrus.NewEntry(logrus.StandardLogger()), ic); err != nil {
+		if _, err := s.handleIssueComment(logrus.NewEntry(logrus.StandardLogger()), ic); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
@@ -1085,7 +1089,7 @@ func TestHandleLocks(t *testing.T) {
 	}
 }
 
-func TestEnsureForkExists(t *testing.T) {
+func TestGetPusherAndOrg(t *testing.T) {
 	botUser := &github.UserData{Login: "ci-robot", Email: "ci-robot@users.noreply.github.com"}
 
 	ghc := &fghc{}
@@ -1093,49 +1097,70 @@ func TestEnsureForkExists(t *testing.T) {
 	s := &Server{
 		botUser: botUser,
 		ghc:     ghc,
-		repos:   []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
 	}
 
 	testCases := []struct {
-		name     string
-		org      string
-		repo     string
-		expected string
-		errors   bool
+		name           string
+		org            string
+		repo           string
+		expectedOrg    string
+		expectedPusher string
+		errors         bool
 	}{
 		{
-			name:     "Repo name does not change after ensured",
-			org:      "whatever",
-			repo:     "repo",
-			expected: "repo",
-			errors:   false,
+			name:           "Repo name does not change after ensured",
+			org:            "whatever",
+			repo:           "repo",
+			expectedOrg:    "ci-robot",
+			expectedPusher: "forkPusher",
+			errors:         false,
 		},
 		{
-			name:     "EnsureFork changes repo name",
-			org:      "whatever",
-			repo:     "changeme",
-			expected: "changed",
-			errors:   false,
+			name:           "EnsureFork changes repo name",
+			org:            "whatever",
+			repo:           "changeme",
+			expectedOrg:    "ci-robot",
+			expectedPusher: "forkPusher",
+			errors:         false,
 		},
 		{
-			name:     "EnsureFork errors",
-			org:      "whatever",
-			repo:     "error",
-			expected: "error",
-			errors:   true,
+			name:           "EnsureFork errors",
+			org:            "whatever",
+			repo:           "error",
+			expectedOrg:    "",
+			expectedPusher: "",
+			errors:         true,
+		},
+		{
+			name:           "EnsureFork forbidden returns centralPusher",
+			org:            "whatever",
+			repo:           "forbidden",
+			expectedOrg:    "whatever",
+			expectedPusher: "centralPusher",
+			errors:         false,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			res, err := s.ensureForkExists(tc.org, tc.repo)
+			p, org, err := s.getPusherAndOrg(logrus.WithField("test", t.Name()), tc.org, tc.repo)
 			if tc.errors && err == nil {
 				t.Errorf("expected error, but did not get one")
 			}
 			if !tc.errors && err != nil {
-				t.Errorf("expected no error, but got one")
+				t.Errorf("expected no error, but got one: %v", err)
 			}
-			if res != tc.expected {
-				t.Errorf("expected %s but got %s", tc.expected, res)
+			if org != tc.expectedOrg {
+				t.Errorf("expected org %s but got %s", tc.expectedOrg, org)
+			}
+			if tc.expectedPusher == "forkPusher" {
+				if _, ok := p.(*forkPusher); !ok {
+					t.Errorf("expected forkPusher but got %T", p)
+				}
+			}
+			if tc.expectedPusher == "centralPusher" {
+				if _, ok := p.(*centralPusher); !ok {
+					t.Errorf("expected centralPusher but got %T", p)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR synchronizes our `cherrypicker` fork with [its latest state](https://github.com/kubernetes-sigs/prow/tree/e43ceff5fd11b61479ba17bc8a51ef46cf70c279/cmd/external-plugins/cherrypicker) in prow upstream.

The most notable change is that it now allows to create multiple cherrypicks with a single comment.
```
/cherry-pick release-v1.140
/cherry-pick release-v1.141
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
