### PR TITLE
Increase timeout for some gardener e2e tests

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-node.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-node.yaml
@@ -8,7 +8,7 @@ presubmits:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true
     decoration_config:
-      timeout: 2h
+      timeout: 3h
       grace_period: 15m
     labels:
       preset-dind-enabled: "true"
@@ -45,14 +45,14 @@ presubmits:
 periodics:
 - name: ci-gardener-e2e-kind-ha-multi-node
   cluster: gardener-prow-build
-  interval: 2h
+  interval: 3h
   extra_refs:
   - org: gardener
     repo: gardener
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 2h
+    timeout: 3h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -8,7 +8,7 @@ presubmits:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true
     decoration_config:
-      timeout: 2h
+      timeout: 3h
       grace_period: 15m
     labels:
       preset-dind-enabled: "true"
@@ -45,14 +45,14 @@ presubmits:
 periodics:
 - name: ci-gardener-e2e-kind-ha-multi-zone
   cluster: gardener-prow-build
-  interval: 2h
+  interval: 3h
   extra_refs:
   - org: gardener
     repo: gardener
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 2h
+    timeout: 3h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
@@ -8,7 +8,7 @@ presubmits:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true
     decoration_config:
-      timeout: 2h
+      timeout: 3h
       grace_period: 15m
     labels:
       preset-dind-enabled: "true"
@@ -45,14 +45,14 @@ presubmits:
 periodics:
 - name: ci-gardener-e2e-kind-ipv6
   cluster: gardener-prow-build
-  interval: 2h
+  interval: 3h
   extra_refs:
   - org: gardener
     repo: gardener
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 2h
+    timeout: 3h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -8,7 +8,7 @@ presubmits:
     - release-v\d+.\d+ # don't run on release branches for now (add a job per branch later)
     decorate: true
     decoration_config:
-      timeout: 2h
+      timeout: 3h
       grace_period: 15m
     labels:
       preset-dind-enabled: "true"
@@ -45,14 +45,14 @@ presubmits:
 periodics:
 - name: ci-gardener-e2e-kind
   cluster: gardener-prow-build
-  interval: 2h
+  interval: 3h
   extra_refs:
   - org: gardener
     repo: gardener
     base_ref: master
   decorate: true
   decoration_config:
-    timeout: 2h
+    timeout: 3h
     grace_period: 15m
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-141.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-141.yaml
@@ -185,12 +185,12 @@ periodics:
   decorate: true
   decoration_config:
     grace_period: 15m0s
-    timeout: 2h0m0s
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: release-v1.141
     org: gardener
     repo: gardener
-  interval: 2h
+  interval: 3h
   labels:
     preset-dind-enabled: "true"
     preset-gocache-mounts: "true"
@@ -276,12 +276,12 @@ periodics:
   decorate: true
   decoration_config:
     grace_period: 15m0s
-    timeout: 2h0m0s
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: release-v1.141
     org: gardener
     repo: gardener
-  interval: 2h
+  interval: 3h
   labels:
     preset-dind-enabled: "true"
     preset-gocache-mounts: "true"
@@ -321,12 +321,12 @@ periodics:
   decorate: true
   decoration_config:
     grace_period: 15m0s
-    timeout: 2h0m0s
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: release-v1.141
     org: gardener
     repo: gardener
-  interval: 2h
+  interval: 3h
   labels:
     preset-dind-enabled: "true"
     preset-gocache-mounts: "true"
@@ -542,12 +542,12 @@ periodics:
   decorate: true
   decoration_config:
     grace_period: 15m0s
-    timeout: 2h0m0s
+    timeout: 3h0m0s
   extra_refs:
   - base_ref: release-v1.141
     org: gardener
     repo: gardener
-  interval: 2h
+  interval: 3h
   labels:
     preset-dind-enabled: "true"
     preset-gocache-mounts: "true"
@@ -827,7 +827,7 @@ presubmits:
     decorate: true
     decoration_config:
       grace_period: 15m0s
-      timeout: 2h0m0s
+      timeout: 3h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-gocache-mounts: "true"
@@ -912,7 +912,7 @@ presubmits:
     decorate: true
     decoration_config:
       grace_period: 15m0s
-      timeout: 2h0m0s
+      timeout: 3h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-gocache-mounts: "true"
@@ -954,7 +954,7 @@ presubmits:
     decorate: true
     decoration_config:
       grace_period: 15m0s
-      timeout: 2h0m0s
+      timeout: 3h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-gocache-mounts: "true"
@@ -1160,7 +1160,7 @@ presubmits:
     decorate: true
     decoration_config:
       grace_period: 15m0s
-      timeout: 2h0m0s
+      timeout: 3h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-gocache-mounts: "true"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR increases the timeout of some gardener long-running e2e tests from 2h to 3h. These tests are:
- `e2e-kind-ha-multi-node`
- `e2e-kind-ha-multi-zone`
- `e2e-kind`
- `e2e-kind-ipv6`


The PR also increases the interval for the periodic tests, so that jobs do not get started when there is already another long-running job.

The timeouts for e2e tests on gardener side was already increased to 125m.
According to logs, the tests usually start 15-20 minutes after the prow job is created, then we need some time for cleanup after the job is complete, so 3h seemed like an ok timeout duration so that we have some buffer.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The previous [PR](https://github.com/gardener/ci-infra/pull/3239) that increased the timeouts to 2h did so for all test jobs. I decided to limit this only to long running tests as it also involves changing the interval for periodics, but I'm ok to apply this for all others as well. 