### PR TITLE
Fix falco service unit test

### DIFF
--- a/config/jobs/gardener-extension-shoot-falco-service/gardener-extension-shoot-falco-service-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-falco-service/gardener-extension-shoot-falco-service-unit-tests.yaml
@@ -13,10 +13,7 @@ presubmits:
       containers:
       - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260428-1b3a0a5-1.25
         command:
-        - make
-        args:
-        - import-tools-bin
-        - verify-extended
+        - .ci/verify
         resources:
           limits:
             memory: 3Gi
@@ -43,10 +40,7 @@ periodics:
     containers:
     - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260428-1b3a0a5-1.25
       command:
-      - make
-      args:
-      - import-tools-bin
-      - verify-extended
+      - .ci/verify
       resources:
         limits:
           memory: 3Gi


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The `make verify-extended` command in the falco extension also uses some `python` code. This caused the unit test to fail with python errors: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener-extension-shoot-falco-service/498/pull-gardener-extension-shoot-falco-service-unit/2049087496330940416#

Changed the unit test to use the `.ci/verify` script, that installs required `python` packages: https://github.com/gardener/gardener-extension-shoot-falco-service/blob/main/.ci/verify

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
