### PR TITLE
Bump prow job image versions for garden-shoot-trust-configurator

### DIFF
--- a/config/jobs/garden-shoot-trust-configurator/garden-shoot-trust-configurator-e2e-kind.yaml
+++ b/config/jobs/garden-shoot-trust-configurator/garden-shoot-trust-configurator-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for garden-shoot-trust-configurator developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260505-adc3c05-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260505-adc3c05-1.26
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260505-adc3c05-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260505-adc3c05-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/garden-shoot-trust-configurator/garden-shoot-trust-configurator-unit-tests.yaml
+++ b/config/jobs/garden-shoot-trust-configurator/garden-shoot-trust-configurator-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for garden-shoot-trust-configurator developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260504-47967e6-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260504-47967e6-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260504-47967e6-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260504-47967e6-1.26
       command:
       - make
       args:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Bump prow job image versions for garden-shoot-trust-configurator to v1.26

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/garden-shoot-trust-configurator/pull/114

**Special notes for your reviewer**:
N/A

CC: @dimityrmirchev 