### PR TITLE
Add observability label

### DIFF
--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -116,6 +116,12 @@ default:
     target: both
     prowPlugin: label
     addedBy: anyone
+  - name: area/observability
+    color: 0052cc
+    description: Observability (logging, monitoring, OpenTelemetry, distributed tracing, etc.) related
+    target: both
+    prowPlugin: label
+    addedBy: anyone
   - name: area/open-source
     color: 0052cc
     description: Open Source (community, enablement, contributions, conferences, CNCF, etc.) related


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
Because logging and monitoring stacks have matured, it’s increasingly common for topics to span multiple domains, so a more general `observability` label is required.