### PR TITLE
Add gardener/aws-ipam-controller to renovate automation

### DIFF
--- a/config/jobs/common/renovate-presubmits.yaml
+++ b/config/jobs/common/renovate-presubmits.yaml
@@ -112,3 +112,6 @@ presubmits:
   gardener/homebrew-tap:
   - <<: *renovate-presubmit
     name: pull-homebrew-tap-check-renovate-config
+  gardener/aws-ipam-controller:
+  - <<: *renovate-presubmit
+    name: pull-aws-ipam-controller-check-renovate-config

--- a/deploy/renovate/renovate.yaml
+++ b/deploy/renovate/renovate.yaml
@@ -77,6 +77,7 @@ spec:
             "gardener/gardener-extension-otelcol",
             "gardener/ingress-default-backend",
             "gardener/pvc-autoscaler",
+            "gardener/aws-ipam-controller",
           ],
           "allowedPostUpgradeCommands": [".*"]
         }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
- Renovate config with auto-merge was added [here](https://github.com/gardener/aws-ipam-controller/blob/master/.github/renovate.json5)
- Adding gardener/aws-ipam-controller to renovate/gardener-ci automation to automate dependency updates and migrate off dependabot in a separate step.
