### PR TITLE
ci: add chocolatey-packages and homebrew-tap to renovate autodiscover

### DIFF
--- a/config/jobs/common/renovate-presubmits.yaml
+++ b/config/jobs/common/renovate-presubmits.yaml
@@ -94,3 +94,21 @@ presubmits:
   gardener/gardener-landscape-kit:
   - <<: *renovate-presubmit
     name: pull-gardener-landscape-kit-check-renovate-config
+  gardener/dashboard:
+  - <<: *renovate-presubmit
+    name: pull-dashboard-check-renovate-config
+  gardener/gardenctl-v2:
+  - <<: *renovate-presubmit
+    name: pull-gardenctl-v2-check-renovate-config
+  gardener/gardenlogin:
+  - <<: *renovate-presubmit
+    name: pull-gardenlogin-check-renovate-config
+  gardener/terminal-controller-manager:
+  - <<: *renovate-presubmit
+    name: pull-terminal-controller-manager-check-renovate-config
+  gardener/chocolatey-packages:
+  - <<: *renovate-presubmit
+    name: pull-chocolatey-packages-check-renovate-config
+  gardener/homebrew-tap:
+  - <<: *renovate-presubmit
+    name: pull-homebrew-tap-check-renovate-config

--- a/deploy/renovate/renovate.yaml
+++ b/deploy/renovate/renovate.yaml
@@ -64,6 +64,8 @@ spec:
             "gardener/gardenctl-v2",
             "gardener/gardenlogin",
             "gardener/terminal-controller-manager",
+            "gardener/chocolatey-packages",
+            "gardener/homebrew-tap",
             "gardener/diki",
             "gardener/diki-operator",
             "gardener/cert-management",


### PR DESCRIPTION
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Add `gardener/chocolatey-packages` and `gardener/homebrew-tap` to the renovate autodiscover filter so that renovate manages GitHub Actions updates in these repos.

Ref: gardener/chocolatey-packages#86
Ref: gardener/homebrew-tap#107

**Release note**:
```other developer
NONE
```