### PR TITLE
Revert "Update Helm release athens-proxy to v0.16.0 (#5963)"

### DIFF
--- a/deploy/athens/base/athens.yaml
+++ b/deploy/athens/base/athens.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: athens-proxy
-      version: '0.16.0'
+      version: '0.15.5'
       sourceRef:
         kind: HelmRepository
         name: athens


### PR DESCRIPTION
This reverts commit d97fdde16360787787343b2cac90eed073c5f54f.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
[athens@v0.17.0](https://github.com/gomods/athens/releases/tag/v0.17.0) which is deployed with this version of the helm-chart breaks workload identity. The change ([ref](https://github.com/gomods/athens/pull/2105/changes#diff-06a9b71403d0771f1b627dbf1ac83575d74afea43fecb614b399809a409d4d8a)) is well hidden in an Golang update PR (https://github.com/gomods/athens/pull/2105). 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @dimityrmirchev 
