### PR TITLE
Run Gardener `*-multi-*` e2e tests on 32 CPU nodes

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-node.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-node.yaml
@@ -31,7 +31,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 14
+            cpu: 30
             memory: 72Gi
         env:
         - name: GOCACHEPROG
@@ -42,6 +42,10 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
+      tolerations:
+      - key: resources
+        value: 32-cpu
+        effect: NoSchedule
 periodics:
 - name: ci-gardener-e2e-kind-ha-multi-node
   cluster: gardener-prow-build
@@ -78,7 +82,7 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 14
+          cpu: 30
           memory: 72Gi
       env:
       - name: GOCACHEPROG
@@ -89,3 +93,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
+    tolerations:
+    - key: resources
+      value: 32-cpu
+      effect: NoSchedule

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -31,7 +31,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 14
+            cpu: 30
             memory: 72Gi
         env:
         - name: GOCACHEPROG
@@ -42,6 +42,10 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
+      tolerations:
+      - key: resources
+        value: 32-cpu
+        effect: NoSchedule
 periodics:
 - name: ci-gardener-e2e-kind-ha-multi-zone
   cluster: gardener-prow-build
@@ -77,7 +81,7 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 14
+          cpu: 30
           memory: 72Gi
       env:
       - name: GOCACHEPROG
@@ -88,3 +92,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
+    tolerations:
+    - key: resources
+      value: 32-cpu
+      effect: NoSchedule


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Let's see if this reduces the flakes since the CPU load on these e2e test nodes in quite high.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
