### PR TITLE
Bump up opentelemetry-collector-contrib image to v0.152.0

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -252,6 +252,7 @@ images:
   - 0.143.1
   - 0.144.0
   - 0.145.0
+  - 0.152.0
 - source: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/opentelemetry-operator/target-allocator
   tags:


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement

**What this PR does / why we need it**:

This PR brings opentelemetry-collector-contrib [v0.152.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.152.0)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
