### PR TITLE
Pin docker-ce to `29.5.0` in krte image to avoid Docker `29.5.1` regression

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -88,7 +88,10 @@ RUN echo "Installing Packages ..." \
             "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
             tee /etc/apt/sources.list.d/docker.list > /dev/null \
         && apt-get update \
-        && apt-get install -y --no-install-recommends docker-ce docker-buildx-plugin docker-compose-plugin \
+        && apt-get install -y --no-install-recommends \
+            "docker-ce=5:29.5.0-1~debian.12~bookworm" \
+            docker-buildx-plugin \
+            docker-compose-plugin \
         && rm -rf /var/lib/apt/lists/* \
         && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
         && sed -i 's/ulimit -Hn/# ulimit -Hn/g' /etc/init.d/docker \


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

Docker 29.5.1 introduced a regression (moby/moby#52653) where `docker cp` fails with "mkdirat var/run: file exists" (see [failed job](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14863/pull-gardener-e2e-kind-release-v1-142/2056674180337766400#1:build-log.txt%3A331)) on containers that have `/var/run` as a symlink to `/run` (as kind node containers do). This breaks all non-upgrade kind e2e tests at the `make kind-single-node-up` step.

Pin docker-ce to `5:29.5.0-1~debian.12~bookworm` until Docker `29.5.2` ships with the fix. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
