### PR TITLE
Pin `krte` image to the last version which is using Docker v29.5.0

### DIFF
--- a/config/jobs/cert-management/cert-management-e2e-kind.yaml
+++ b/config/jobs/cert-management/cert-management-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for cert-management developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -59,7 +59,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/cluster-api-provider-gardener/cluster-api-provider-gardener-e2e-kind.yaml
+++ b/config/jobs/cluster-api-provider-gardener/cluster-api-provider-gardener-e2e-kind.yaml
@@ -15,7 +15,7 @@ presubmits:
       description: Runs end-to-end tests for cluster-api-provider-gardener developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         command:
         - wrapper.sh
         - bash
@@ -60,7 +60,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/dependency-watchdog/dependency-watchdog-e2e-kind.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-e2e-kind.yaml
@@ -16,7 +16,7 @@ presubmits:
         description: Runs KIND cluster based e2e tests for dependency watchdog developments in pull requests
       spec:
         containers:
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
             command:
               - wrapper.sh
               - bash
@@ -50,7 +50,7 @@ periodics:
       testgrid-days-of-results: "60"
     spec:
       containers:
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
           command:
             - wrapper.sh
             - bash

--- a/config/jobs/etcd-backup-restore/etcdbr-e2e-kind.yaml
+++ b/config/jobs/etcd-backup-restore/etcdbr-e2e-kind.yaml
@@ -15,7 +15,7 @@ presubmits:
         fork-per-release: "true"
       spec:
         containers:
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
             command:
             - wrapper.sh
             - bash
@@ -56,7 +56,7 @@ periodics:
       fork-per-release: "true"
     spec:
       containers:
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
           command:
           - wrapper.sh
           - bash

--- a/config/jobs/etcd-druid/etcd-druid-e2e-kind.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-e2e-kind.yaml
@@ -19,7 +19,7 @@ presubmits:
       spec:
         containers:
           - &e2e_container
-            image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+            image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
             command:
               - wrapper.sh
               - bash
@@ -130,7 +130,7 @@ periodics:
       fork-per-release: "true"
     spec:
       containers:
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
           command:
             - wrapper.sh
             - bash

--- a/config/jobs/etcd-druid/releases/gardener-etcd-druid-hotfix-v0-35.yaml
+++ b/config/jobs/etcd-druid/releases/gardener-etcd-druid-hotfix-v0-35.yaml
@@ -25,7 +25,7 @@ periodics:
       - bash
       - -c
       - make ci-e2e-kind
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
       name: ""
       resources:
         requests:
@@ -121,7 +121,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestBasic
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         name: ""
         resources:
           requests:
@@ -154,7 +154,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestScaleOut
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         name: ""
         resources:
           requests:
@@ -187,7 +187,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestTLSAndLabelUpdates
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         name: ""
         resources:
           requests:
@@ -220,7 +220,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestRecovery
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         name: ""
         resources:
           requests:
@@ -253,7 +253,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestClusterUpdate
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         name: ""
         resources:
           requests:
@@ -286,7 +286,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestSnapshotCompaction
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         name: ""
         resources:
           requests:
@@ -319,7 +319,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestSecretFinalizers
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         name: ""
         resources:
           requests:

--- a/config/jobs/etcd-druid/releases/gardener-etcd-druid-hotfix-v0-36.yaml
+++ b/config/jobs/etcd-druid/releases/gardener-etcd-druid-hotfix-v0-36.yaml
@@ -25,7 +25,7 @@ periodics:
       - bash
       - -c
       - make ci-e2e-kind
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
       name: ""
       resources:
         requests:
@@ -121,7 +121,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestBasic
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         name: ""
         resources:
           requests:
@@ -154,7 +154,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestScaleOut
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         name: ""
         resources:
           requests:
@@ -187,7 +187,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestTLSAndLabelUpdates
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         name: ""
         resources:
           requests:
@@ -220,7 +220,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestRecovery
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         name: ""
         resources:
           requests:
@@ -253,7 +253,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestClusterUpdate
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         name: ""
         resources:
           requests:
@@ -286,7 +286,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestSnapshotCompaction
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         name: ""
         resources:
           requests:
@@ -319,7 +319,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestSecretFinalizers
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         name: ""
         resources:
           requests:

--- a/config/jobs/extension-shoot-cert-service/extension-shoot-cert-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-cert-service/extension-shoot-cert-service-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-cert-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/extension-shoot-dns-service/extension-shoot-dns-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-dns-service/extension-shoot-dns-service-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-dns-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-oidc-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/garden-shoot-trust-configurator/garden-shoot-trust-configurator-e2e-kind.yaml
+++ b/config/jobs/garden-shoot-trust-configurator/garden-shoot-trust-configurator-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for garden-shoot-trust-configurator developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-discovery-server/gardener-discovery-server-e2e-kind.yaml
+++ b/config/jobs/gardener-discovery-server/gardener-discovery-server-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-discovery-server developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-networking-calico developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-networking-cilium/gardener-extension-networking-cilium-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-networking-cilium/gardener-extension-networking-cilium-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-networking-cilium developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-registry-cache developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-networking-filter developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-operator.yaml
+++ b/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-operator.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-networking-filter developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for Gardener extension shoot-rsyslog-relp developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-landscape-kit/gardener-landscape-kit-e2e-kind.yaml
+++ b/config/jobs/gardener-landscape-kit/gardener-landscape-kit-e2e-kind.yaml
@@ -18,7 +18,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
           - wrapper.sh
           - bash
@@ -58,7 +58,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-landscape-kit/releases/gardener-gardener-landscape-kit-release-v0-1.yaml
+++ b/config/jobs/gardener-landscape-kit/releases/gardener-gardener-landscape-kit-release-v0-1.yaml
@@ -30,7 +30,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -100,7 +100,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:

--- a/config/jobs/gardener/gardener-e2e-kind-gardenadm-managed-infra.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-gardenadm-managed-infra.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-gardenadm-unmanaged-infra-external-gardener.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-gardenadm-unmanaged-infra-external-gardener.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-gardenadm-unmanaged-infra.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-gardenadm-unmanaged-infra.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-node-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-node-upgrade.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-node.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-node.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -70,7 +70,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -70,7 +70,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -66,7 +66,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-migration-ha-multi-node.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration-ha-multi-node.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-operator.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         command:
           - wrapper.sh
           - bash
@@ -66,7 +66,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       command:
         - wrapper.sh
         - bash

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-140.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-140.yaml
@@ -34,7 +34,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -78,7 +78,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -122,7 +122,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -169,7 +169,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -213,7 +213,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -259,7 +259,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -304,7 +304,7 @@ periodics:
         value: "false"
       - name: IPFAMILY
         value: ipv6
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -348,7 +348,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -392,7 +392,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -436,7 +436,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -480,7 +480,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -525,7 +525,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "6"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -640,7 +640,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -681,7 +681,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -722,7 +722,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -765,7 +765,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -807,7 +807,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -850,7 +850,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -892,7 +892,7 @@ presubmits:
           value: "false"
         - name: IPFAMILY
           value: ipv6
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -933,7 +933,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -974,7 +974,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -1015,7 +1015,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -1056,7 +1056,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -1098,7 +1098,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "6"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-141.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-141.yaml
@@ -34,7 +34,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -78,7 +78,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -122,7 +122,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -166,7 +166,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -213,7 +213,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -257,7 +257,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -303,7 +303,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -348,7 +348,7 @@ periodics:
         value: "false"
       - name: IPFAMILY
         value: ipv6
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -392,7 +392,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -436,7 +436,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -480,7 +480,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -524,7 +524,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -569,7 +569,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "6"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -684,7 +684,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -725,7 +725,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -766,7 +766,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -807,7 +807,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -850,7 +850,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -892,7 +892,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -935,7 +935,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -977,7 +977,7 @@ presubmits:
           value: "false"
         - name: IPFAMILY
           value: ipv6
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -1018,7 +1018,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -1059,7 +1059,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -1100,7 +1100,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -1141,7 +1141,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -1183,7 +1183,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "6"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-142.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-142.yaml
@@ -34,7 +34,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -78,7 +78,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -122,7 +122,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -166,7 +166,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -213,7 +213,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -257,7 +257,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -303,7 +303,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -348,7 +348,7 @@ periodics:
         value: "false"
       - name: IPFAMILY
         value: ipv6
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -392,7 +392,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -436,7 +436,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -480,7 +480,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -524,7 +524,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -569,7 +569,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "6"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
       name: ""
       resources:
         requests:
@@ -684,7 +684,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -725,7 +725,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -766,7 +766,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -807,7 +807,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -850,7 +850,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -892,7 +892,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -935,7 +935,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -977,7 +977,7 @@ presubmits:
           value: "false"
         - name: IPFAMILY
           value: ipv6
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -1018,7 +1018,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -1059,7 +1059,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -1100,7 +1100,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -1141,7 +1141,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:
@@ -1183,7 +1183,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "6"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.26
         name: ""
         resources:
           requests:

--- a/config/jobs/pvc-autoscaler/pvc-autoscaler-e2e-kind.yaml
+++ b/config/jobs/pvc-autoscaler/pvc-autoscaler-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for pvc-autoscaler developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260519-c69df45-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:with-docker-v29.5.0-1.25
       command:
       - wrapper.sh
       - bash


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Docker [v29.5.1 ](https://docs.docker.com/engine/release-notes/29/#2951)introduced a regression which makes all our e2e tests fail.

Thus, this PR pins the  `krte` image to the latest version which is using Docker v29.5.0 until v29.5.2 was released.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ScheererJ 
