### PR TITLE
Revert "Pin docker-ce to `29.5.0` in krte image to avoid Docker `29.5.1` regression"

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -88,10 +88,7 @@ RUN echo "Installing Packages ..." \
             "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
             tee /etc/apt/sources.list.d/docker.list > /dev/null \
         && apt-get update \
-        && apt-get install -y --no-install-recommends \
-            "docker-ce=5:29.5.0-1~debian.12~bookworm" \
-            docker-buildx-plugin \
-            docker-compose-plugin \
+        && apt-get install -y --no-install-recommends docker-ce docker-buildx-plugin docker-compose-plugin \
         && rm -rf /var/lib/apt/lists/* \
         && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
         && sed -i 's/ulimit -Hn/# ulimit -Hn/g' /etc/init.d/docker \


### PR DESCRIPTION
Reverts gardener/ci-infra#6215

https://github.com/moby/moby/releases/tag/docker-v29.5.2 fixes the regression, we need not pin the docker version anymore.

/cc @oliver-goetz 