### PR TITLE
Reduce `PARALLEL_E2E_TESTS` for `e2e-kind` to 5

### DIFF
--- a/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
@@ -42,6 +42,8 @@ presubmits:
           value: "false"
         - name: IPFAMILY
           value: "ipv6"
+        - name: PARALLEL_E2E_TESTS
+          value: "5"
 periodics:
 - name: ci-gardener-e2e-kind-ipv6
   cluster: gardener-prow-build
@@ -88,3 +90,5 @@ periodics:
         value: "false"
       - name: IPFAMILY
         value: "ipv6"
+      - name: PARALLEL_E2E_TESTS
+        value: "5"

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -41,7 +41,7 @@ presubmits:
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
         - name: PARALLEL_E2E_TESTS
-          value: "6"
+          value: "5"
 periodics:
 - name: ci-gardener-e2e-kind
   cluster: gardener-prow-build
@@ -87,4 +87,4 @@ periodics:
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
       - name: PARALLEL_E2E_TESTS
-        value: "6"
+        value: "5"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
While the CPU utilization looks ok, the load average for `e2e-kind` tests ([ref](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind/2057726693254107136)) is very high, so we could try to reduce it a bit.
<img width="3432" height="348" alt="Screenshot 2026-05-22 at 11 11 56" src="https://github.com/user-attachments/assets/c73a318d-e9b5-48b5-9040-ae8307b809c9" />

The load average for `e2e-kind-ipv6` ([ref](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ipv6/2057731977863237632)) looks much more decent
<img width="3443" height="353" alt="Screenshot 2026-05-22 at 11 23 15" src="https://github.com/user-attachments/assets/5d55e965-84a7-4430-b567-973d163899e7" />

The average runtime of e2e-kind-ipv6 tests is even lower see:
- https://prow.gardener.cloud/?job=ci-gardener-e2e-kind-ipv6
- https://prow.gardener.cloud/?job=ci-gardener-e2e-kind

This PR also harmonizes the definition of `e2e-kind` and `e2e-kind-ipv6` prow jobs as they are very similar.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
