### PR TITLE
chore: enable renovate for traffic gauger extension

### DIFF
--- a/config/jobs/common/renovate-presubmits.yaml
+++ b/config/jobs/common/renovate-presubmits.yaml
@@ -130,3 +130,6 @@ presubmits:
   gardener/apiserver-proxy:
   - <<: *renovate-presubmit
     name: pull-apiserver-proxy-renovate-config
+  gardener/gardener-extension-shoot-networking-traffic-gauger:
+  - <<: *renovate-presubmit
+    name: pull-gardener-extension-shoot-networking-traffic-gauger-renovate-config

--- a/deploy/renovate/renovate.yaml
+++ b/deploy/renovate/renovate.yaml
@@ -84,6 +84,7 @@ spec:
             "gardener/gardener-extension-shoot-networking-filter",
             "gardener/ext-authz-server",
             "gardener/apiserver-proxy",
+            "gardener/gardener-extension-shoot-networking-traffic-gauger",
           ],
           "allowedPostUpgradeCommands": [".*"]
         }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
- Enable renovate for gardener/gardener-extension-shoot-networking-traffic-gauger
