### PR TITLE
Bump up opentelemetry-operator image to v0.153.0

### DIFF
--- a/config/images/images.yaml
+++ b/config/images/images.yaml
@@ -244,6 +244,7 @@ images:
   - v0.150.0
   - v0.151.0
   - v0.152.0
+  - v0.153.0
 - source: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   destination: europe-docker.pkg.dev/gardener-project/releases/3rd/opentelemetry-collector-releases/opentelemetry-collector-contrib
   tags:


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement

**What this PR does / why we need it**:

This PR brings opentelemetry-operator  [v0.153.0](https://github.com/open-telemetry/opentelemetry-operator/releases/tag/v0.153.0)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
