### PR TITLE
Bump go version to 1.26 for `auditlog-forwarder` unit tests job

### DIFF
--- a/config/jobs/auditlog-forwarder/auditlog-forwarder-unit-tests.yaml
+++ b/config/jobs/auditlog-forwarder/auditlog-forwarder-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for auditlog-forwarder developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.26
       command:
       - make
       args:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
Bump go version to 1.26 for `auditlog-forwarder` unit tests job

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Required by https://github.com/gardener/auditlog-forwarder/pull/84