### PR TITLE
Bump golang to 1.26 for `shoot-rsyslog-relp`

### DIFF
--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for Gardener extension shoot-rsyslog-relp developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260612-6f6cffe-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260612-6f6cffe-1.26
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260612-6f6cffe-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260612-6f6cffe-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-integration-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-integration-tests.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.26
         command:
         - make
         args:
@@ -45,7 +45,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.25
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.26
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for Gardener extension shoot-rsyslog-relp developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.26
       command:
       - make
       args:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
Bumps golang to 1.26 for `shoot-rsyslog-relp` jobs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @plkokanov 