### PR TITLE
Bump go version to 1.26 for `discovery-server` jobs

### DIFF
--- a/config/jobs/gardener-discovery-server/gardener-discovery-server-e2e-kind.yaml
+++ b/config/jobs/gardener-discovery-server/gardener-discovery-server-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-discovery-server developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260612-6f6cffe-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260612-6f6cffe-1.26
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260612-6f6cffe-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260612-6f6cffe-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-discovery-server/gardener-discovery-server-unit-tests.yaml
+++ b/config/jobs/gardener-discovery-server/gardener-discovery-server-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-discovery-server developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.26
       command:
       - make
       args:


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
Bump go version to 1.26 for `discovery-server` jobs

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Required by https://github.com/gardener/gardener-discovery-server/pull/208