### PR TITLE
Bump go version to 1.26 for `extension-auditing` jobs

### DIFF
--- a/config/jobs/gardener-extension-auditing/gardener-extension-auditing-unit-tests.yaml
+++ b/config/jobs/gardener-extension-auditing/gardener-extension-auditing-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-auditing developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260612-340643c-1.26
       command:
       - make
       args:


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
Bump go version to 1.26 for `extension-auditing` jobs

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Required by https://github.com/gardener/gardener-extension-auditing/pull/100