### PR TITLE
Revert "Bumping Prow jobs - prow and Prow jobs - test-infra and Prow …

### DIFF
--- a/.github/workflows/krte-images.yaml
+++ b/.github/workflows/krte-images.yaml
@@ -26,12 +26,12 @@ jobs:
               {
                 "version": "1.25",
                 "IMAGE_ARG": "europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:1.25",
-                "golangtestimage": "europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25"
+                "golangtestimage": "europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25"
               },
               {
                 "version": "1.26",
                 "IMAGE_ARG": "europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:1.26",
-                "golangtestimage": "europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26"
+                "golangtestimage": "europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26"
               }
             ]
           }

--- a/config/jobs/auditlog-forwarder/auditlog-forwarder-unit-tests.yaml
+++ b/config/jobs/auditlog-forwarder/auditlog-forwarder-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for auditlog-forwarder developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/cert-management/cert-management-e2e-kind.yaml
+++ b/config/jobs/cert-management/cert-management-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for cert-management developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -59,7 +59,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/cert-management/cert-management-integration-tests.yaml
+++ b/config/jobs/cert-management/cert-management-integration-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs integration tests for cert-management developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/cert-management/cert-management-unit-tests.yaml
+++ b/config/jobs/cert-management/cert-management-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for cert-management developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/ci-infra/ci-infra-periodics.yaml
+++ b/config/jobs/ci-infra/ci-infra-periodics.yaml
@@ -12,7 +12,7 @@ periodics:
       channel: prow-alerts
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/job-forker:v20260618-73cbe3d
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/job-forker:v20260617-b31863a
       command:
       - /job-forker
       args:
@@ -47,7 +47,7 @@ periodics:
       channel: prow-alerts
   spec:
     containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/job-forker:v20260618-73cbe3d
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/job-forker:v20260617-b31863a
         command:
           - /job-forker
         args:
@@ -83,7 +83,7 @@ periodics:
       channel: prow-alerts
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/job-forker:v20260618-73cbe3d
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/job-forker:v20260617-b31863a
       command:
       - /job-forker
       args:
@@ -122,7 +122,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20260620-cb062d241
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20260616-6b90fe349
       command:
       - generic-autobumper
       args:
@@ -153,7 +153,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20260620-cb062d241
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20260616-6b90fe349
       command:
       - generic-autobumper
       args:
@@ -184,7 +184,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20260620-cb062d241
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20260616-6b90fe349
       command:
       - generic-autobumper
       args:
@@ -215,7 +215,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20260620-cb062d241
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20260616-6b90fe349
       command:
       - generic-autobumper
       args:
@@ -249,7 +249,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20260620-cb062d241
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20260616-6b90fe349
       command:
       - checkconfig
       args:
@@ -281,7 +281,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20260620-cb062d241
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20260616-6b90fe349
       command:
       - checkconfig
       args:
@@ -314,7 +314,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:
@@ -337,7 +337,7 @@ periodics:
       channel: prow-alerts
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/branch-cleaner:v20260618-73cbe3d
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/branch-cleaner:v20260617-b31863a
       command:
       - /branch-cleaner
       args:

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       description: Runs checkconfig to validate changes to job configs, config.yaml and friends
     spec:
       containers:
-      - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20260620-cb062d241
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20260616-6b90fe349
         command:
         - checkconfig
         args:
@@ -33,7 +33,7 @@ presubmits:
       description: Runs go tests for prow developments in ci-infra 
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:

--- a/config/jobs/ci-infra/copy-images.yaml
+++ b/config/jobs/ci-infra/copy-images.yaml
@@ -17,7 +17,7 @@ postsubmits:
     spec:
       containers:
       - name: copy-images
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/copy-images:v20260618-73cbe3d
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/copy-images:v20260617-b31863a
         command:
         - ./config/images/copy-images.sh
         args:

--- a/config/jobs/cluster-api-provider-gardener/cluster-api-provider-gardener-e2e-kind.yaml
+++ b/config/jobs/cluster-api-provider-gardener/cluster-api-provider-gardener-e2e-kind.yaml
@@ -15,7 +15,7 @@ presubmits:
       description: Runs end-to-end tests for cluster-api-provider-gardener developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         command:
         - wrapper.sh
         - bash
@@ -60,7 +60,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/cluster-api-provider-gardener/cluster-api-provider-gardener-unit-tests.yaml
+++ b/config/jobs/cluster-api-provider-gardener/cluster-api-provider-gardener-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for Gardener Cluster API provider developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
       command:
       - make
       args:

--- a/config/jobs/dependency-watchdog/dependency-watchdog-check-vulnerabilities.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-check-vulnerabilities.yaml
@@ -13,7 +13,7 @@ presubmits:
     spec:
       containers:
       - name: test
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
         command:
         - make
         args:
@@ -36,7 +36,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
       command:
       - make
       args:

--- a/config/jobs/dependency-watchdog/dependency-watchdog-e2e-kind.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-e2e-kind.yaml
@@ -16,7 +16,7 @@ presubmits:
         description: Runs KIND cluster based e2e tests for dependency watchdog developments in pull requests
       spec:
         containers:
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
             command:
               - wrapper.sh
               - bash
@@ -50,7 +50,7 @@ periodics:
       testgrid-days-of-results: "60"
     spec:
       containers:
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
           command:
             - wrapper.sh
             - bash

--- a/config/jobs/dependency-watchdog/dependency-watchdog-unit-tests.yaml
+++ b/config/jobs/dependency-watchdog/dependency-watchdog-unit-tests.yaml
@@ -13,7 +13,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
         command:
         - make
         args:
@@ -47,7 +47,7 @@ periodics:
     containers:
     # Run all tests sequentially in one container or as separate prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
       command:
       - make
       args:

--- a/config/jobs/diki-operator/diki-operator-unit-tests.yaml
+++ b/config/jobs/diki-operator/diki-operator-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for diki-operator developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
       command:
       - make
       args:

--- a/config/jobs/diki/diki-unit-tests.yaml
+++ b/config/jobs/diki/diki-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for diki developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
       command:
       - make
       args:

--- a/config/jobs/etcd-backup-restore/etcdbr-e2e-kind.yaml
+++ b/config/jobs/etcd-backup-restore/etcdbr-e2e-kind.yaml
@@ -15,7 +15,7 @@ presubmits:
         fork-per-release: "true"
       spec:
         containers:
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
             command:
             - wrapper.sh
             - bash
@@ -56,7 +56,7 @@ periodics:
       fork-per-release: "true"
     spec:
       containers:
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
           command:
           - wrapper.sh
           - bash

--- a/config/jobs/etcd-druid/etcd-druid-api-unit-tests.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-api-unit-tests.yaml
@@ -17,7 +17,7 @@ presubmits:
         containers:
           # Run all tests sequentially in one container or as separate prow jobs.
           # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
             command:
               - make
             args:

--- a/config/jobs/etcd-druid/etcd-druid-e2e-kind.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-e2e-kind.yaml
@@ -19,7 +19,7 @@ presubmits:
       spec:
         containers:
           - &e2e_container
-            image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+            image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
             command:
               - wrapper.sh
               - bash
@@ -130,7 +130,7 @@ periodics:
       fork-per-release: "true"
     spec:
       containers:
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
           command:
             - wrapper.sh
             - bash

--- a/config/jobs/etcd-druid/etcd-druid-integration-tests.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-integration-tests.yaml
@@ -15,7 +15,7 @@ presubmits:
       spec:
         containers:
           - name: test-integration
-            image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+            image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
             command:
               - make
             args:
@@ -46,7 +46,7 @@ periodics:
     spec:
       containers:
         - name: test-integration
-          image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+          image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
           command:
             - make
           args:

--- a/config/jobs/etcd-druid/etcd-druid-unit-tests.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-unit-tests.yaml
@@ -16,7 +16,7 @@ presubmits:
         containers:
           # Run all tests sequentially in one container or as separate prow jobs.
           # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
             command:
               - make
             args:
@@ -49,7 +49,7 @@ periodics:
       containers:
         # Run all tests sequentially in one container or as separate prow jobs.
         # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
           command:
             - make
           args:

--- a/config/jobs/etcd-druid/releases/gardener-etcd-druid-hotfix-v0-35.yaml
+++ b/config/jobs/etcd-druid/releases/gardener-etcd-druid-hotfix-v0-35.yaml
@@ -25,7 +25,7 @@ periodics:
       - bash
       - -c
       - make ci-e2e-kind
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
       name: ""
       resources:
         requests:
@@ -55,7 +55,7 @@ periodics:
       - test-integration
       command:
       - make
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
       name: test-integration
       resources:
         limits:
@@ -86,7 +86,7 @@ periodics:
       - test-unit
       command:
       - make
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
       name: ""
       resources:
         limits:
@@ -121,7 +121,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestBasic
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         name: ""
         resources:
           requests:
@@ -154,7 +154,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestScaleOut
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         name: ""
         resources:
           requests:
@@ -187,7 +187,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestTLSAndLabelUpdates
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         name: ""
         resources:
           requests:
@@ -220,7 +220,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestRecovery
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         name: ""
         resources:
           requests:
@@ -253,7 +253,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestClusterUpdate
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         name: ""
         resources:
           requests:
@@ -286,7 +286,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestSnapshotCompaction
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         name: ""
         resources:
           requests:
@@ -319,7 +319,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestSecretFinalizers
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         name: ""
         resources:
           requests:
@@ -345,7 +345,7 @@ presubmits:
         - test-integration
         command:
         - make
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
         name: test-integration
         resources:
           limits:
@@ -423,7 +423,7 @@ presubmits:
         - test-unit
         command:
         - make
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
         name: ""
         resources:
           limits:

--- a/config/jobs/etcd-druid/releases/gardener-etcd-druid-hotfix-v0-36.yaml
+++ b/config/jobs/etcd-druid/releases/gardener-etcd-druid-hotfix-v0-36.yaml
@@ -25,7 +25,7 @@ periodics:
       - bash
       - -c
       - make ci-e2e-kind
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
       name: ""
       resources:
         requests:
@@ -55,7 +55,7 @@ periodics:
       - test-integration
       command:
       - make
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
       name: test-integration
       resources:
         limits:
@@ -86,7 +86,7 @@ periodics:
       - test-unit
       command:
       - make
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
       name: ""
       resources:
         limits:
@@ -121,7 +121,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestBasic
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         name: ""
         resources:
           requests:
@@ -154,7 +154,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestScaleOut
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         name: ""
         resources:
           requests:
@@ -187,7 +187,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestTLSAndLabelUpdates
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         name: ""
         resources:
           requests:
@@ -220,7 +220,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestRecovery
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         name: ""
         resources:
           requests:
@@ -253,7 +253,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestClusterUpdate
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         name: ""
         resources:
           requests:
@@ -286,7 +286,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestSnapshotCompaction
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         name: ""
         resources:
           requests:
@@ -319,7 +319,7 @@ presubmits:
         env:
         - name: GO_TEST_ARGS
           value: -run TestSecretFinalizers
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         name: ""
         resources:
           requests:
@@ -345,7 +345,7 @@ presubmits:
         - test-integration
         command:
         - make
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
         name: test-integration
         resources:
           limits:
@@ -423,7 +423,7 @@ presubmits:
         - test-unit
         command:
         - make
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
         name: ""
         resources:
           limits:

--- a/config/jobs/extension-shoot-cert-service/extension-shoot-cert-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-cert-service/extension-shoot-cert-service-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-cert-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/extension-shoot-cert-service/extension-shoot-cert-service-unit-tests.yaml
+++ b/config/jobs/extension-shoot-cert-service/extension-shoot-cert-service-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-shoot-cert-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/extension-shoot-dns-service/extension-shoot-dns-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-dns-service/extension-shoot-dns-service-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-dns-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/extension-shoot-dns-service/extension-shoot-dns-service-unit-tests.yaml
+++ b/config/jobs/extension-shoot-dns-service/extension-shoot-dns-service-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-shoot-dns-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-oidc-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
+++ b/config/jobs/extension-shoot-oidc-service/extension-shoot-oidc-service-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for extension-shoot-oidc-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/external-dns-management/external-dns-management-integration-tests.yaml
+++ b/config/jobs/external-dns-management/external-dns-management-integration-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs integration tests for external-dns-management developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/external-dns-management/external-dns-management-unit-tests.yaml
+++ b/config/jobs/external-dns-management/external-dns-management-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for external-dns-management developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/garden-shoot-trust-configurator/garden-shoot-trust-configurator-e2e-kind.yaml
+++ b/config/jobs/garden-shoot-trust-configurator/garden-shoot-trust-configurator-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for garden-shoot-trust-configurator developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/garden-shoot-trust-configurator/garden-shoot-trust-configurator-unit-tests.yaml
+++ b/config/jobs/garden-shoot-trust-configurator/garden-shoot-trust-configurator-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for garden-shoot-trust-configurator developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/gardener-discovery-server/gardener-discovery-server-e2e-kind.yaml
+++ b/config/jobs/gardener-discovery-server/gardener-discovery-server-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-discovery-server developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-discovery-server/gardener-discovery-server-unit-tests.yaml
+++ b/config/jobs/gardener-discovery-server/gardener-discovery-server-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-discovery-server developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-auditing/gardener-extension-auditing-unit-tests.yaml
+++ b/config/jobs/gardener-extension-auditing/gardener-extension-auditing-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-auditing developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-image-rewriter/gardener-extension-image-rewriter-unit-tests.yaml
+++ b/config/jobs/gardener-extension-image-rewriter/gardener-extension-image-rewriter-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for Gardener extension image-rewriter developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-networking-calico developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-unit-tests.yaml
+++ b/config/jobs/gardener-extension-networking-calico/gardener-extension-networking-calico-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-networking-calico developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-networking-cilium/gardener-extension-networking-cilium-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-networking-cilium/gardener-extension-networking-cilium-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-networking-cilium developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-networking-cilium/gardener-extension-networking-cilium-unit-tests.yaml
+++ b/config/jobs/gardener-extension-networking-cilium/gardener-extension-networking-cilium-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-networking-cilium developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-registry-cache developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for Gardener extension registry-cache developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-shoot-falco-service/gardener-extension-shoot-falco-service-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-falco-service/gardener-extension-shoot-falco-service-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-shoot-falco-service developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
         command:
         - .ci/verify
         resources:
@@ -38,7 +38,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
       command:
       - .ci/verify
       resources:

--- a/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for gardener-extension-shoot-networking-filter developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -62,7 +62,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-networking-filter/gardener-extension-shoot-networking-filter-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for gardener-extension-shoot-networking-filter developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for Gardener extension shoot-rsyslog-relp developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-integration-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-integration-tests.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       - name: test-integration
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -45,7 +45,7 @@ periodics:
   spec:
     containers:
     - name: test-integration
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
+++ b/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for Gardener extension shoot-rsyslog-relp developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -41,7 +41,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/gardener-landscape-kit/gardener-landscape-kit-branch-cleaner.yaml
+++ b/config/jobs/gardener-landscape-kit/gardener-landscape-kit-branch-cleaner.yaml
@@ -11,7 +11,7 @@ periodics:
       channel: prow-alerts
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/branch-cleaner:v20260618-73cbe3d
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/branch-cleaner:v20260617-b31863a
       command:
       - /branch-cleaner
       args:

--- a/config/jobs/gardener-landscape-kit/gardener-landscape-kit-e2e-kind.yaml
+++ b/config/jobs/gardener-landscape-kit/gardener-landscape-kit-e2e-kind.yaml
@@ -18,7 +18,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
           - wrapper.sh
           - bash
@@ -58,7 +58,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener-landscape-kit/gardener-landscape-kit-release-handler.yaml
+++ b/config/jobs/gardener-landscape-kit/gardener-landscape-kit-release-handler.yaml
@@ -15,7 +15,7 @@ postsubmits:
     spec:
       containers:
       - name: release-handler
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/release-handler:v20260618-73cbe3d
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/release-handler:v20260617-b31863a
         command:
         - /release-handler
         args:

--- a/config/jobs/gardener-landscape-kit/gardener-landscape-kit-unit-tests.yaml
+++ b/config/jobs/gardener-landscape-kit/gardener-landscape-kit-unit-tests.yaml
@@ -14,7 +14,7 @@ presubmits:
       fork-per-release: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -45,7 +45,7 @@ periodics:
     fork-per-release: "true"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
       - make
       args:

--- a/config/jobs/gardener-landscape-kit/releases/gardener-gardener-landscape-kit-release-v0-1.yaml
+++ b/config/jobs/gardener-landscape-kit/releases/gardener-gardener-landscape-kit-release-v0-1.yaml
@@ -30,7 +30,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -61,7 +61,7 @@ periodics:
       - verify-extended
       command:
       - make
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
       name: ""
       resources:
         limits:
@@ -100,7 +100,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -128,7 +128,7 @@ presubmits:
         - verify-extended
         command:
         - make
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
         name: ""
         resources:
           limits:

--- a/config/jobs/gardener/gardener-apidiff.yaml
+++ b/config/jobs/gardener/gardener-apidiff.yaml
@@ -10,7 +10,7 @@ presubmits:
     spec:
       containers:
       - name: test
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:

--- a/config/jobs/gardener/gardener-branch-cleaner.yaml
+++ b/config/jobs/gardener/gardener-branch-cleaner.yaml
@@ -11,7 +11,7 @@ periodics:
       channel: prow-alerts
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/branch-cleaner:v20260618-73cbe3d
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/branch-cleaner:v20260617-b31863a
       command:
       - /branch-cleaner
       args:

--- a/config/jobs/gardener/gardener-e2e-kind-gardenadm-managed-infra.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-gardenadm-managed-infra.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-gardenadm-unmanaged-infra-external-gardener.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-gardenadm-unmanaged-infra-external-gardener.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-gardenadm-unmanaged-infra.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-gardenadm-unmanaged-infra.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-node-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-node-upgrade.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-node.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-node.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -70,7 +70,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone-upgrade.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ha-multi-zone.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -70,7 +70,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-ipv6.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -68,7 +68,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-migration-ha-multi-node.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration-ha-multi-node.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-migration.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-migration.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-operator.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-operator.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind-upgrade.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
         - wrapper.sh
         - bash
@@ -64,7 +64,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/gardener/gardener-e2e-kind.yaml
+++ b/config/jobs/gardener/gardener-e2e-kind.yaml
@@ -20,7 +20,7 @@ presubmits:
     spec:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         command:
           - wrapper.sh
           - bash
@@ -66,7 +66,7 @@ periodics:
   spec:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       command:
         - wrapper.sh
         - bash

--- a/config/jobs/gardener/gardener-integration-tests.yaml
+++ b/config/jobs/gardener/gardener-integration-tests.yaml
@@ -19,7 +19,7 @@ presubmits:
       serviceAccountName: gardener-prow-gobuildcache-ro
       containers:
       - name: test-integration
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
           - make
         args:
@@ -58,7 +58,7 @@ periodics:
     serviceAccountName: gardener-prow-gobuildcache-rw
     containers:
     - name: test-integration
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
         - make
       args:

--- a/config/jobs/gardener/gardener-release-handler.yaml
+++ b/config/jobs/gardener/gardener-release-handler.yaml
@@ -15,7 +15,7 @@ postsubmits:
     spec:
       containers:
       - name: release-handler
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/release-handler:v20260618-73cbe3d
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/release-handler:v20260617-b31863a
         command:
         - /release-handler
         args:

--- a/config/jobs/gardener/gardener-unit-tests.yaml
+++ b/config/jobs/gardener/gardener-unit-tests.yaml
@@ -16,7 +16,7 @@ presubmits:
       containers:
       # Run all tests sequentially in one container or as separate prow jobs.
       # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         command:
         - make
         args:
@@ -53,7 +53,7 @@ periodics:
     containers:
     # Run all tests sequentially in one container or as separate prow jobs.
     # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       command:
         - make
       args:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-143.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-143.yaml
@@ -34,7 +34,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -78,7 +78,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -122,7 +122,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -166,7 +166,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -213,7 +213,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -261,7 +261,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -307,7 +307,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -356,7 +356,7 @@ periodics:
         value: "false"
       - name: IPFAMILY
         value: ipv6
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -400,7 +400,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -444,7 +444,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -488,7 +488,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -532,7 +532,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -577,7 +577,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "6"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -614,7 +614,7 @@ periodics:
       env:
       - name: GOCACHEPROG
         value: gobuildcache gs://gardener-prow-gobuildcache
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       name: test-integration
       resources:
         limits:
@@ -650,7 +650,7 @@ periodics:
       - sast
       command:
       - make
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       name: ""
       resources:
         limits:
@@ -692,7 +692,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -733,7 +733,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -774,7 +774,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -815,7 +815,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -858,7 +858,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -904,7 +904,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -947,7 +947,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -993,7 +993,7 @@ presubmits:
           value: "false"
         - name: IPFAMILY
           value: ipv6
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1034,7 +1034,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1075,7 +1075,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1116,7 +1116,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1157,7 +1157,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1199,7 +1199,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "6"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1232,7 +1232,7 @@ presubmits:
         env:
         - name: GOCACHEPROG
           value: gobuildcache -readonly gs://gardener-prow-gobuildcache
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         name: test-integration
         resources:
           limits:
@@ -1337,7 +1337,7 @@ presubmits:
         - sast
         command:
         - make
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         name: ""
         resources:
           limits:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-144.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-144.yaml
@@ -34,7 +34,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -78,7 +78,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -122,7 +122,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -166,7 +166,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -213,7 +213,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -261,7 +261,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -307,7 +307,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -358,7 +358,7 @@ periodics:
         value: ipv6
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -402,7 +402,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -446,7 +446,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -490,7 +490,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -534,7 +534,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -579,7 +579,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -616,7 +616,7 @@ periodics:
       env:
       - name: GOCACHEPROG
         value: gobuildcache gs://gardener-prow-gobuildcache
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       name: test-integration
       resources:
         limits:
@@ -652,7 +652,7 @@ periodics:
       - sast
       command:
       - make
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       name: ""
       resources:
         limits:
@@ -694,7 +694,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -735,7 +735,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -776,7 +776,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -817,7 +817,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -860,7 +860,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -906,7 +906,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -949,7 +949,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -997,7 +997,7 @@ presubmits:
           value: ipv6
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1038,7 +1038,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1079,7 +1079,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1120,7 +1120,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1161,7 +1161,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1203,7 +1203,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1236,7 +1236,7 @@ presubmits:
         env:
         - name: GOCACHEPROG
           value: gobuildcache -readonly gs://gardener-prow-gobuildcache
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         name: test-integration
         resources:
           limits:
@@ -1341,7 +1341,7 @@ presubmits:
         - sast
         command:
         - make
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         name: ""
         resources:
           limits:

--- a/config/jobs/gardener/releases/gardener-gardener-release-v1-145.yaml
+++ b/config/jobs/gardener/releases/gardener-gardener-release-v1-145.yaml
@@ -34,7 +34,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -78,7 +78,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -122,7 +122,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -166,7 +166,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -213,7 +213,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -261,7 +261,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -307,7 +307,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -358,7 +358,7 @@ periodics:
         value: ipv6
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -402,7 +402,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -446,7 +446,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -490,7 +490,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -534,7 +534,7 @@ periodics:
         value: "false"
       - name: SKAFFOLD_INTERACTIVE
         value: "false"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -579,7 +579,7 @@ periodics:
         value: "false"
       - name: PARALLEL_E2E_TESTS
         value: "5"
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
       name: ""
       resources:
         requests:
@@ -616,7 +616,7 @@ periodics:
       env:
       - name: GOCACHEPROG
         value: gobuildcache gs://gardener-prow-gobuildcache
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       name: test-integration
       resources:
         limits:
@@ -652,7 +652,7 @@ periodics:
       - sast
       command:
       - make
-      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+      image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
       name: ""
       resources:
         limits:
@@ -694,7 +694,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -735,7 +735,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -776,7 +776,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -817,7 +817,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -860,7 +860,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -906,7 +906,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -949,7 +949,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -997,7 +997,7 @@ presubmits:
           value: ipv6
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1038,7 +1038,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1079,7 +1079,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1120,7 +1120,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1161,7 +1161,7 @@ presubmits:
           value: "false"
         - name: SKAFFOLD_INTERACTIVE
           value: "false"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1203,7 +1203,7 @@ presubmits:
           value: "false"
         - name: PARALLEL_E2E_TESTS
           value: "5"
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.26
         name: ""
         resources:
           requests:
@@ -1236,7 +1236,7 @@ presubmits:
         env:
         - name: GOCACHEPROG
           value: gobuildcache -readonly gs://gardener-prow-gobuildcache
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         name: test-integration
         resources:
           limits:
@@ -1341,7 +1341,7 @@ presubmits:
         - sast
         command:
         - make
-        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.26
+        image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.26
         name: ""
         resources:
           limits:

--- a/config/jobs/pvc-autoscaler/pvc-autoscaler-e2e-kind.yaml
+++ b/config/jobs/pvc-autoscaler/pvc-autoscaler-e2e-kind.yaml
@@ -14,7 +14,7 @@ presubmits:
       description: Runs end-to-end tests for pvc-autoscaler developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
         command:
         - wrapper.sh
         - bash
@@ -53,7 +53,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260618-73cbe3d-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260617-b31863a-1.25
       command:
       - wrapper.sh
       - bash

--- a/config/jobs/pvc-autoscaler/pvc-autoscaler-unit-tests.yaml
+++ b/config/jobs/pvc-autoscaler/pvc-autoscaler-unit-tests.yaml
@@ -11,7 +11,7 @@ presubmits:
       description: Runs unit tests for pvc-autoscaler developments in pull requests
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
         command:
         - make
         args:
@@ -40,7 +40,7 @@ periodics:
     testgrid-days-of-results: "60"
   spec:
     containers:
-    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260618-1a164d6-1.25
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260617-3cf87f0-1.25
       command:
       - make
       args:


### PR DESCRIPTION
…jobs - ci-infra (#6461)"

This reverts commit 5378161a6c8bd8dc527de6d7c324dd10e5116194.

Sorry, once more, due to unit test failing:

```
 Executing golangci-lint
Error: build linters: unable to load custom analyzer "logcheck": hack/tools/bin/linux-amd64/logcheck.so, plugin.Open("/home/prow/go/src/github.com/gardener/gardener/hack/tools/bin/linux-amd64/logcheck"): plugin was built with a different version of package golang.org/x/tools/go/analysis
The command is terminated due to an error: build linters: unable to load custom analyzer "logcheck": hack/tools/bin/linux-amd64/logcheck.so, plugin.Open("/home/prow/go/src/github.com/gardener/gardener/hack/tools/bin/linux-amd64/logcheck"): plugin was built with a different version of package golang.org/x/tools/go/analysis
```

E.g.: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/15091/pull-gardener-unit/2068957097076199424

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
