### PR TITLE
chore: add renovate presubmit check for traefik extension

### DIFF
--- a/config/jobs/common/renovate-presubmits.yaml
+++ b/config/jobs/common/renovate-presubmits.yaml
@@ -136,3 +136,6 @@ presubmits:
   gardener/gardener-extension-shoot-networking-traffic-gauger:
   - <<: *renovate-presubmit
     name: pull-gardener-extension-shoot-networking-traffic-gauger-renovate-config
+  gardener/gardener-extension-shoot-traefik:
+  - <<: *renovate-presubmit
+    name: pull-gardener-extension-shoot-traefik-renovate-config


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
- Adds presubmit check for the [gardener/gardener-extension-shoot-traefik](https://github.com/gardener/gardener-extension-shoot-traefik) extension renovate config
