### PR TITLE
chore: enable renovate for aws-custom-route-controller

### DIFF
--- a/config/jobs/common/renovate-presubmits.yaml
+++ b/config/jobs/common/renovate-presubmits.yaml
@@ -118,6 +118,9 @@ presubmits:
   gardener/aws-ipam-controller:
   - <<: *renovate-presubmit
     name: pull-aws-ipam-controller-check-renovate-config
+  gardener/aws-custom-route-controller:
+  - <<: *renovate-presubmit
+    name: pull-aws-custom-route-controller-check-renovate-config
   gardener/alpine-conntrack:
   - <<: *renovate-presubmit
     name: pull-alpine-conntrack-check-renovate-config

--- a/deploy/renovate/renovate.yaml
+++ b/deploy/renovate/renovate.yaml
@@ -79,6 +79,7 @@ spec:
             "gardener/ingress-default-backend",
             "gardener/pvc-autoscaler",
             "gardener/aws-ipam-controller",
+            "gardener/aws-custom-route-controller",
             "gardener/alpine-conntrack",
             "gardener/alpine-iptables",
             "gardener/vpn2",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
- Enable renovate for the [aws-custom-route-controller extension](https://github.com/gardener/aws-custom-route-controller)
