### PR TITLE
chore: enable renovate for gardener/coredns-config-adapter

### DIFF
--- a/config/jobs/common/renovate-presubmits.yaml
+++ b/config/jobs/common/renovate-presubmits.yaml
@@ -142,3 +142,6 @@ presubmits:
   gardener/gardener-extension-shoot-traefik:
   - <<: *renovate-presubmit
     name: pull-gardener-extension-shoot-traefik-renovate-config
+  gardener/coredns-config-adapter:
+  - <<: *renovate-presubmit
+    name: pull-coredns-config-adapter-renovate-config

--- a/deploy/renovate/renovate.yaml
+++ b/deploy/renovate/renovate.yaml
@@ -87,6 +87,7 @@ spec:
             "gardener/ext-authz-server",
             "gardener/apiserver-proxy",
             "gardener/gardener-extension-shoot-networking-traffic-gauger",
+            "gardener/coredns-config-adapter",
           ],
           "allowedPostUpgradeCommands": [".*"]
         }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
- Enable renovate for gardener/coredns-config-adapter to replace dependabot later
