### PR TITLE
Deploy peribolos config via flux

### DIFF
--- a/clusters/prow-trusted/flux-system/kustomization.yaml
+++ b/clusters/prow-trusted/flux-system/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
 - ../../base/flux-system
+- org-sync.yaml
 
 patches:
 - path: patch-kustomization.yaml

--- a/clusters/prow-trusted/flux-system/org-sync.yaml
+++ b/clusters/prow-trusted/flux-system/org-sync.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: org
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    branch: master
+  url: https://github.com/gardener/org.git
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: org-repository
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: org

--- a/clusters/prow-trusted/kustomization.yaml
+++ b/clusters/prow-trusted/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - prow-kustomization.yaml
 - oauth2-proxy-kustomization.yaml
 - renovate-kustomization.yaml
+- peribolos-config.yaml
 
 patches:
 - path: patch-athens-kustomization.yaml

--- a/clusters/prow-trusted/peribolos-config.yaml
+++ b/clusters/prow-trusted/peribolos-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: peribolos-config
+  namespace: flux-system
+spec:
+  interval: 30m
+  path: config
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: org
+  timeout: 3m
+  wait: true


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
With this PR flux deploys the Gardener Org peribolos config into the prow-trusted cluster.

**Which issue(s) this PR fixes**:
Part of gardener/org#2

**Special notes for your reviewer**:
/cc @timuthy 
