### PR TITLE
Do not use ghproxy with peribolos

### DIFF
--- a/deploy/peribolos/cronjob.yaml
+++ b/deploy/peribolos/cronjob.yaml
@@ -26,8 +26,6 @@ spec:
             - --require-self
             - --config-path=/etc/config/org.yaml
             - --github-token-path=/etc/github-token/token
-            - --github-endpoint=http://ghproxy.prow.svc.cluster.local
-            - --github-endpoint=https://api.github.com
             - --github-hourly-tokens=0
             - --github-allowed-burst=0
             - --ignore-secret-teams


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Using peribolos with ghproxy spams the ghproxy logs with entries like 
```
{"component":"ghproxy","file":"sigs.k8s.io/prow/pkg/simplifypath/simplify.go:48","func":"sigs.k8s.io/prow/pkg/simplifypath.(*simplifier).Simplify","level":"debug","msg":"Path not handled. This is a bug, please open an issue against the kubernetes-sigs/prow repository with this error message.","path":"/orgs/gardener/teams/gardener-extension-registry-cache-maintainers/invitations","severity":"debug","time":"2026-06-26T13:08:22Z"}
```
Thus, let's better not use it in this context.

**Which issue(s) this PR fixes**:
Part of gardener/org#2

**Special notes for your reviewer**:
/cc @timuthy 