### PR TITLE
Enable renovate for gardener/opentelemetry-collector

### DIFF
--- a/config/jobs/common/renovate-presubmits.yaml
+++ b/config/jobs/common/renovate-presubmits.yaml
@@ -160,3 +160,6 @@ presubmits:
   gardener/oidc-apps-controller:
   - <<: *renovate-presubmit
     name: pull-oidc-apps-controller-check-renovate-config
+gardener/opentelemetry-collector:
+  - <<: *renovate-presubmit
+    name: pull-opentelemetry-collector-check-renovate-config

--- a/config/jobs/common/renovate-presubmits.yaml
+++ b/config/jobs/common/renovate-presubmits.yaml
@@ -160,6 +160,6 @@ presubmits:
   gardener/oidc-apps-controller:
   - <<: *renovate-presubmit
     name: pull-oidc-apps-controller-check-renovate-config
-gardener/opentelemetry-collector:
+  gardener/opentelemetry-collector:
   - <<: *renovate-presubmit
     name: pull-opentelemetry-collector-check-renovate-config

--- a/deploy/renovate/renovate.yaml
+++ b/deploy/renovate/renovate.yaml
@@ -93,6 +93,7 @@ spec:
             "gardener/gardener-extension-provider-openstack",
             "gardener/gardener-extension-provider-gcp",
             "gardener/oidc-apps-controller",
+            "gardener/opentelemetry-collector",
           ],
           "allowedPostUpgradeCommands": [".*"]
         }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

The gardener/opentelemetry-collector repository moved introduced a renovate config and removed the old Dependabot config by PR https://github.com/gardener/opentelemetry-collector/pull/27. This PR enables the repository to use Prow's renovate integration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @Bobi-Wan 