### PR TITLE
Upgrade images to use Go 1.26 for druid and backup-restore jobs

### DIFF
--- a/config/jobs/etcd-backup-restore/etcdbr-e2e-kind.yaml
+++ b/config/jobs/etcd-backup-restore/etcdbr-e2e-kind.yaml
@@ -15,7 +15,7 @@ presubmits:
         fork-per-release: "true"
       spec:
         containers:
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260701-41b17aa-1.25
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260701-41b17aa-1.26
             command:
             - wrapper.sh
             - bash
@@ -56,7 +56,7 @@ periodics:
       fork-per-release: "true"
     spec:
       containers:
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260701-41b17aa-1.25
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260701-41b17aa-1.26
           command:
           - wrapper.sh
           - bash

--- a/config/jobs/etcd-druid/etcd-druid-api-unit-tests.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-api-unit-tests.yaml
@@ -17,7 +17,7 @@ presubmits:
         containers:
           # Run all tests sequentially in one container or as separate prow jobs.
           # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260701-3a63fc9-1.25
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260701-3a63fc9-1.26
             command:
               - make
             args:

--- a/config/jobs/etcd-druid/etcd-druid-e2e-kind.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-e2e-kind.yaml
@@ -19,7 +19,7 @@ presubmits:
       spec:
         containers:
           - &e2e_container
-            image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260701-41b17aa-1.25
+            image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260701-41b17aa-1.26
             command:
               - wrapper.sh
               - bash
@@ -130,7 +130,7 @@ periodics:
       fork-per-release: "true"
     spec:
       containers:
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260701-41b17aa-1.25
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte:v20260701-41b17aa-1.26
           command:
             - wrapper.sh
             - bash

--- a/config/jobs/etcd-druid/etcd-druid-integration-tests.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-integration-tests.yaml
@@ -15,7 +15,7 @@ presubmits:
       spec:
         containers:
           - name: test-integration
-            image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260701-3a63fc9-1.25
+            image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260701-3a63fc9-1.26
             command:
               - make
             args:
@@ -46,7 +46,7 @@ periodics:
     spec:
       containers:
         - name: test-integration
-          image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260701-3a63fc9-1.25
+          image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260701-3a63fc9-1.26
           command:
             - make
           args:

--- a/config/jobs/etcd-druid/etcd-druid-unit-tests.yaml
+++ b/config/jobs/etcd-druid/etcd-druid-unit-tests.yaml
@@ -16,7 +16,7 @@ presubmits:
         containers:
           # Run all tests sequentially in one container or as separate prow jobs.
           # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260701-3a63fc9-1.25
+          - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260701-3a63fc9-1.26
             command:
               - make
             args:
@@ -49,7 +49,7 @@ periodics:
       containers:
         # Run all tests sequentially in one container or as separate prow jobs.
         # Test will fail when 'check-generate' (which includes a revendor) and 'test' or 'check' run in parallel on the same volume
-        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260701-3a63fc9-1.25
+        - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test:v20260701-3a63fc9-1.26
           command:
             - make
           args:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Upgrade images to use Go 1.26 for `etcd-druid` and `etcd-backup-restore` jobs
