### PR TITLE
Add static peribolos config checker

### DIFF
--- a/.github/workflows/prow-images-build.yaml
+++ b/.github/workflows/prow-images-build.yaml
@@ -45,6 +45,8 @@ jobs:
             target: milestone-activator
           - name: release-handler
             target: release-handler
+          - name: peribolos-checkconfig
+            target: peribolos-checkconfig
     with:
       name: ${{ matrix.images.name }}
       version: ${{ needs.compute-versions.outputs.semver-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,3 +71,9 @@ LABEL app=branch-cleaner
 WORKDIR /
 COPY --from=builder /build/branch-cleaner /branch-cleaner
 ENTRYPOINT [ "/branch-cleaner" ]
+
+FROM base_nonroot AS peribolos-checkconfig
+LABEL app=peribolos-checkconfig
+WORKDIR /
+COPY --from=builder /build/peribolos-checkconfig /peribolos-checkconfig
+ENTRYPOINT [ "/peribolos-checkconfig" ]

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ IMG_RELEASE_HANDLER := release-handler
 REG_RELEASE_HANDLER  := $(REGISTRY)/$(IMG_RELEASE_HANDLER)
 IMG_BRANCH_CLEANER := branch-cleaner
 REG_BRANCH_CLEANER  := $(REGISTRY)/$(IMG_BRANCH_CLEANER)
-
+IMG_PERIBOLOS_CHECK_CONFIG := peribolos-checkconfig
+REG_PERIBOLOS_CHECK_CONFIG  := $(REGISTRY)/$(IMG_PERIBOLOS_CHECK_CONFIG)
 
 #########################################
 # Tools                                 #
@@ -48,6 +49,7 @@ endif
 	@docker build -t $(REG_MILESTONE_ACTIVATOR):$(VERSION) -t $(REG_MILESTONE_ACTIVATOR):latest -f Dockerfile --target $(IMG_MILESTONE_ACTIVATOR) .
 	@docker build -t $(REG_RELEASE_HANDLER):$(VERSION) -t $(REG_RELEASE_HANDLER):latest -f Dockerfile --target $(IMG_RELEASE_HANDLER) .
 	@docker build -t $(REG_BRANCH_CLEANER):$(VERSION) -t $(REG_BRANCH_CLEANER):latest -f Dockerfile --target $(IMG_BRANCH_CLEANER) .
+	@docker build -t $(REG_PERIBOLOS_CHECK_CONFIG):$(VERSION) -t $(REG_PERIBOLOS_CHECK_CONFIG):latest -f Dockerfile --target $(IMG_PERIBOLOS_CHECK_CONFIG) .
 
 .PHONY: docker-push
 docker-push:
@@ -61,6 +63,7 @@ endif
 	@if ! docker images $(REG_MILESTONE_ACTIVATOR) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(REG_MILESTONE_ACTIVATOR) version $(VERSION) is not yet built. Please run 'make docker-images'"; false; fi
 	@if ! docker images $(REG_RELEASE_HANDLER) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(REG_RELEASE_HANDLER) version $(VERSION) is not yet built. Please run 'make docker-images'"; false; fi
 	@if ! docker images $(REG_BRANCH_CLEANER) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(REG_BRANCH_CLEANER) version $(VERSION) is not yet built. Please run 'make docker-images'"; false; fi
+	@if ! docker images $(REG_PERIBOLOS_CHECK_CONFIG) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(REG_PERIBOLOS_CHECK_CONFIG) version $(VERSION) is not yet built. Please run 'make docker-images'"; false; fi
 	@docker push $(REG_CHERRYPICKER):$(VERSION)
 	@docker push $(REG_CLA_ASSISTANT):$(VERSION)
 	@docker push $(REG_IMAGE_BUILDER):$(VERSION)
@@ -68,6 +71,7 @@ endif
 	@docker push $(REG_MILESTONE_ACTIVATOR):$(VERSION)
 	@docker push $(REG_RELEASE_HANDLER):$(VERSION)
 	@docker push $(REG_BRANCH_CLEANER):$(VERSION)
+	@docker push $(REG_PERIBOLOS_CHECK_CONFIG):$(VERSION)
 ifeq ("$(PUSH_LATEST_TAG)", "true")
 	@docker push $(REG_CHERRYPICKER):latest
 	@docker push $(REG_CLA_ASSISTANT):latest
@@ -76,6 +80,7 @@ ifeq ("$(PUSH_LATEST_TAG)", "true")
 	@docker push $(REG_MILESTONE_ACTIVATOR):latest
 	@docker push $(REG_RELEASE_HANDLER):latest
 	@docker push $(REG_BRANCH_CLEANER):latest
+	@docker push $(REG_PERIBOLOS_CHECK_CONFIG):latest
 endif
 
 

--- a/config/jobs/ci-infra/ci-infra-presubmits.yaml
+++ b/config/jobs/ci-infra/ci-infra-presubmits.yaml
@@ -79,6 +79,8 @@ presubmits:
         - milestone-activator
         - --target
         - release-handler
+        - --target
+        - peribolos-checkconfig
         readinessProbe:
           exec:
             command:

--- a/prow/cmd/peribolos-checkconfig/README.md
+++ b/prow/cmd/peribolos-checkconfig/README.md
@@ -1,0 +1,73 @@
+# peribolos-checkconfig
+
+`peribolos-checkconfig` is a static linter for peribolos org
+configuration files. It validates a peribolos `org.yaml` against a set of
+consistency rules **without needing a GitHub token** — making it a natural fit
+for a presubmit prow job on the repo that stores your org config.
+
+## What it checks
+
+Given a peribolos `org.FullConfig`, for each org it verifies:
+
+- **YAML is well-formed** and unmarshals cleanly into the peribolos schema.
+- **Minimum admins** — each org has at least `--min-admins` admins (default `5`,
+  minimum `2`).
+- **Required admins present** — every user passed via `--required-admins`
+  appears in the org's `admins` list.
+- **No dual-role users** — no user is listed as both an `admin` and a `member`
+  of the same org. Comparison is done after `github.NormLogin` so casing
+  differences (e.g. `Alice` vs `alice`) are caught.
+- **Team members are org members** — every user listed as a team `member` or
+  `maintainer` (recursively across `children`) is also listed at the org level
+  as `admin` or `member`.
+- **Unique team names** — team `name` + all entries in `previously` are unique
+  within an org.
+- **Nested teams are `closed`** — any team that has a parent or has children
+  must have `privacy: closed`. Teams with unset `privacy` are allowed (peribolos
+  fills in `closed` at apply time).
+- **Unique repo names** — repo `name` + all entries in `previously` are unique
+  within an org, compared case-insensitively (GitHub repo names are
+  case-insensitive).
+- **No `archived: false`** — repos configured with `archived: false` are
+  rejected, because the GitHub API cannot unarchive a repository.
+
+Checks that require live GitHub state (`--maximum-removal-delta`, `require-self`,
+current-org reconciliation, invitation flow) are intentionally out of scope —
+they belong to peribolos itself.
+
+## Usage
+
+```
+peribolos-checkconfig \
+  --config-path=./org.yaml \
+  --min-admins=5 \
+  --required-admins=alice --required-admins=bob
+```
+
+### Flags
+
+| Flag                 | Default | Description                                                |
+| -------------------- | ------- | ---------------------------------------------------------- |
+| `--config-path`      | *(required)* | Path to peribolos org config YAML.                    |
+| `--min-admins`       | `5`     | Fail if any org has fewer admins than this. Must be ≥ 2.   |
+| `--required-admins`  | *(none)* | Repeatable; usernames that must appear as admins in every org. |
+| `--log-level`        | `info`  | One of `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`. |
+
+### Exit codes
+
+- **0** — all orgs pass every check.
+- **non-zero** — one or more checks failed; the failing checks are aggregated
+  and logged before exit.
+
+
+## Development
+
+```bash
+# Build
+go build ./prow/cmd/peribolos-checkconfig
+
+# Run tests
+go test ./prow/cmd/peribolos-checkconfig
+```
+
+See [main_test.go](main_test.go) for the check-by-check test matrix.

--- a/prow/cmd/peribolos-checkconfig/README.md
+++ b/prow/cmd/peribolos-checkconfig/README.md
@@ -17,6 +17,10 @@ Given a peribolos `org.FullConfig`, for each org it verifies:
 - **No dual-role users** — no user is listed as both an `admin` and a `member`
   of the same org. Comparison is done after `github.NormLogin` so casing
   differences (e.g. `Alice` vs `alice`) are caught.
+- **No dual-role team users** — no user is listed as both `member` and
+  `maintainer` of the same team. Peribolos itself only enforces this at apply
+  time when `--fix-team-members` is set, so bad configs can otherwise
+  accumulate silently. Normalized the same way as the org check.
 - **Team members are org members** — every user listed as a team `member` or
   `maintainer` (recursively across `children`) is also listed at the org level
   as `admin` or `member`.

--- a/prow/cmd/peribolos-checkconfig/README.md
+++ b/prow/cmd/peribolos-checkconfig/README.md
@@ -46,12 +46,12 @@ peribolos-checkconfig \
 
 ### Flags
 
-| Flag                 | Default | Description                                                |
-| -------------------- | ------- | ---------------------------------------------------------- |
-| `--config-path`      | *(required)* | Path to peribolos org config YAML.                    |
-| `--min-admins`       | `5`     | Fail if any org has fewer admins than this. Must be ≥ 2.   |
-| `--required-admins`  | *(none)* | Repeatable; usernames that must appear as admins in every org. |
-| `--log-level`        | `info`  | One of `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`. |
+| Flag                | Default      | Description                                                         |
+| ------------------- | ------------ | ------------------------------------------------------------------- |
+| `--config-path`     | _(required)_ | Path to peribolos org config YAML.                                  |
+| `--min-admins`      | `5`          | Fail if any org has fewer admins than this. Must be ≥ 2.            |
+| `--required-admins` | _(none)_     | Repeatable; usernames that must appear as admins in every org.      |
+| `--log-level`       | `info`       | One of `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`. |
 
 ### Exit codes
 

--- a/prow/cmd/peribolos-checkconfig/main.go
+++ b/prow/cmd/peribolos-checkconfig/main.go
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"sigs.k8s.io/prow/pkg/config/org"
+	"sigs.k8s.io/prow/pkg/flagutil"
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/logrusutil"
+)
+
+const (
+	defaultMinAdmins = 5
+)
+
+type options struct {
+	config         string
+	minAdmins      int
+	requiredAdmins flagutil.Strings
+
+	logLevel string
+}
+
+func parseOptions() options {
+	var o options
+	if err := o.parseArgs(flag.CommandLine, os.Args[1:]); err != nil {
+		logrus.Fatalf("Invalid flags: %v", err)
+	}
+	return o
+}
+
+func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
+	o.requiredAdmins = flagutil.NewStrings()
+	flags.Var(&o.requiredAdmins, "required-admins", "Ensure config specifies these users as admins")
+	flags.StringVar(&o.config, "config-path", "", "Path to org config.yaml")
+	flags.IntVar(&o.minAdmins, "min-admins", defaultMinAdmins, "Ensure config specifies at least this many admins")
+
+	flags.StringVar(&o.logLevel, "log-level", logrus.InfoLevel.String(), fmt.Sprintf("Logging level, one of %v", logrus.AllLevels))
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	level, err := logrus.ParseLevel(o.logLevel)
+	if err != nil {
+		return fmt.Errorf("--log-level invalid: %w", err)
+	}
+	logrus.SetLevel(level)
+	logrus.SetReportCaller(level >= logrus.DebugLevel)
+
+	if o.minAdmins < 2 {
+		return fmt.Errorf("--min-admins=%d must be at least 2", o.minAdmins)
+	}
+
+	if o.config == "" {
+		return errors.New("--config-path required")
+	}
+	return nil
+}
+
+// will check the configuration of peribolos
+// performs the following checks:
+// - yaml syntax check
+// - checks whether the config is correct (correct keys etc.)
+// - min-admins per org
+// - required-admins present in each org
+// - no user is both admin and member (post NormLogin)
+// - all team members/maintainers are also org members/admins (recursive)
+// - team names are unique within an org (including Previously names)
+// - repo names are unique within an org (case-insensitive, including Previously)
+// - nested teams (with parent or children) have privacy: closed
+// - no repo config has archived: false (unarchiving is unsupported by the GH API)
+func main() {
+	logrusutil.ComponentInit()
+
+	o := parseOptions()
+
+	// check yaml
+	cfg := checkYamlSyntax(&o)
+
+	var errs []error
+	for name, orgcfg := range cfg.Orgs {
+		if err := checkOrg(&o, name, orgcfg); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if err := utilerrors.NewAggregate(errs); err != nil {
+		logrus.WithError(err).Fatal("Configuration check failed.")
+	}
+
+	logrus.Info("Finished checking configuration.")
+}
+
+func checkYamlSyntax(o *options) org.FullConfig {
+	raw, err := os.ReadFile(o.config)
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not read --config-path file")
+	}
+
+	var cfg org.FullConfig
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		logrus.WithError(err).Fatal("Failed to load configuration")
+	}
+	return cfg
+}
+
+func checkOrg(opt *options, orgName string, orgConfig org.Config) error {
+	var errs []error
+
+	// check min admins
+	wantAdmins := sets.New[string](orgConfig.Admins...)
+	if n := len(wantAdmins); n < opt.minAdmins {
+		errs = append(errs, fmt.Errorf("%s must specify at least %d admins, only found %d", orgName, opt.minAdmins, n))
+	}
+
+	// check required admins
+	var missing []string
+	for _, r := range opt.requiredAdmins.Strings() {
+		if !wantAdmins.Has(r) {
+			missing = append(missing, r)
+		}
+	}
+	if len(missing) > 0 {
+		errs = append(errs, fmt.Errorf("%s must specify %v as admins, missing %v", orgName, opt.requiredAdmins, missing))
+	}
+
+	// no user in both admins and members (compare normalized logins, since GH treats logins case-insensitively)
+	wantMembers := normalize(sets.New[string](orgConfig.Members...))
+	normAdmins := normalize(wantAdmins)
+	if both := normAdmins.Intersection(wantMembers); len(both) > 0 {
+		errs = append(errs, fmt.Errorf("%s: users listed as both admin and member: %s", orgName, strings.Join(sets.List(both), ", ")))
+	}
+	orgUsers := normAdmins.Union(wantMembers)
+
+	// team-level checks: collect team members recursively, verify uniqueness of team names
+	teamMembers := sets.Set[string]{}
+	teamNames := sets.Set[string]{}
+	duplicateTeamNames := sets.Set[string]{}
+	nestedNotClosed := []string{}
+	var walkTeams func(teams map[string]org.Team, parentIsNested bool)
+	walkTeams = func(teams map[string]org.Team, parentIsNested bool) {
+		for name, team := range teams {
+			teamMembers.Insert(team.Members...)
+			teamMembers.Insert(team.Maintainers...)
+
+			if teamNames.Has(name) {
+				duplicateTeamNames.Insert(name)
+			}
+			teamNames.Insert(name)
+			for _, n := range team.Previously {
+				if teamNames.Has(n) {
+					duplicateTeamNames.Insert(n)
+				}
+				teamNames.Insert(n)
+			}
+
+			// Nested teams (either they have a parent, or they have children) must be "closed" per GitHub.
+			isNested := parentIsNested || len(team.Children) > 0
+			if isNested {
+				if team.Privacy != nil && *team.Privacy != org.Closed {
+					nestedNotClosed = append(nestedNotClosed, fmt.Sprintf("%s (privacy=%s)", name, *team.Privacy))
+				}
+			}
+
+			walkTeams(team.Children, true)
+		}
+	}
+	walkTeams(orgConfig.Teams, false)
+
+	if outside := normalize(teamMembers).Difference(orgUsers); len(outside) > 0 {
+		errs = append(errs, fmt.Errorf("%s: team members/maintainers must also be org members: %s", orgName, strings.Join(sets.List(outside), ", ")))
+	}
+
+	if n := len(duplicateTeamNames); n > 0 {
+		errs = append(errs, fmt.Errorf("%s: team names must be unique (including previous names), %d duplicated: %s", orgName, n, strings.Join(sets.List(duplicateTeamNames), ", ")))
+	}
+
+	if len(nestedNotClosed) > 0 {
+		errs = append(errs, fmt.Errorf("%s: nested teams must have privacy: closed: %s", orgName, strings.Join(nestedNotClosed, ", ")))
+	}
+
+	// repo-level checks
+	if err := validateRepos(orgName, orgConfig.Repos); err != nil {
+		errs = append(errs, err)
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+// validateRepos checks:
+// - repo names (including Previously) are unique within an org, case-insensitively
+// - no repo is configured with archived: false (GH API cannot unarchive)
+func validateRepos(orgName string, repos map[string]org.Repo) error {
+	seen := map[string]string{}
+	var dups []string
+	var unarchive []string
+
+	for wantName, repo := range repos {
+		if repo.Archived != nil && !*repo.Archived {
+			unarchive = append(unarchive, wantName)
+		}
+		toCheck := append([]string{wantName}, repo.Previously...)
+		for _, name := range toCheck {
+			normName := strings.ToLower(name)
+			if seenName, have := seen[normName]; have {
+				dups = append(dups, fmt.Sprintf("%s/%s", seenName, name))
+			}
+		}
+		for _, name := range toCheck {
+			seen[strings.ToLower(name)] = name
+		}
+	}
+
+	var errs []error
+	if len(dups) > 0 {
+		errs = append(errs, fmt.Errorf("%s: found duplicate repo names (GitHub repo names are case-insensitive): %s", orgName, strings.Join(dups, ", ")))
+	}
+	if len(unarchive) > 0 {
+		errs = append(errs, fmt.Errorf("%s: repos configured with archived: false — GitHub does not support unarchiving via the API: %s", orgName, strings.Join(unarchive, ", ")))
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+func normalize(s sets.Set[string]) sets.Set[string] {
+	out := sets.Set[string]{}
+	for i := range s {
+		out.Insert(github.NormLogin(i))
+	}
+	return out
+}

--- a/prow/cmd/peribolos-checkconfig/main.go
+++ b/prow/cmd/peribolos-checkconfig/main.go
@@ -146,65 +146,27 @@ func checkOrg(opt *options, orgName string, orgConfig org.Config) error {
 	orgUsers := normAdmins.Union(wantMembers)
 
 	// team-level checks: collect team members recursively, verify uniqueness of team names
-	teamMembers := sets.Set[string]{}
-	teamNames := sets.Set[string]{}
-	duplicateTeamNames := sets.Set[string]{}
-	nestedNotClosed := []string{}
-	dualRoleTeams := []string{}
-	var walkTeams func(teams map[string]org.Team, parentIsNested bool)
-	walkTeams = func(teams map[string]org.Team, parentIsNested bool) {
-		for name, team := range teams {
-			teamMembers.Insert(team.Members...)
-			teamMembers.Insert(team.Maintainers...)
-
-			// A user must not be both a member and a maintainer of the same team.
-			// Peribolos rejects this at apply time (see cmd/peribolos/main.go
-			// configureMembers), but only when --fix-team-members is set — so
-			// bad configs can accumulate silently. Check statically here.
-			teamMemberSet := normalize(sets.New[string](team.Members...))
-			teamMaintainerSet := normalize(sets.New[string](team.Maintainers...))
-			if both := teamMemberSet.Intersection(teamMaintainerSet); len(both) > 0 {
-				dualRoleTeams = append(dualRoleTeams, fmt.Sprintf("%s: %s", name, strings.Join(sets.List(both), ", ")))
-			}
-
-			if teamNames.Has(name) {
-				duplicateTeamNames.Insert(name)
-			}
-			teamNames.Insert(name)
-			for _, n := range team.Previously {
-				if teamNames.Has(n) {
-					duplicateTeamNames.Insert(n)
-				}
-				teamNames.Insert(n)
-			}
-
-			// Nested teams (either they have a parent, or they have children) must be "closed" per GitHub.
-			isNested := parentIsNested || len(team.Children) > 0
-			if isNested {
-				if team.Privacy != nil && *team.Privacy != org.Closed {
-					nestedNotClosed = append(nestedNotClosed, fmt.Sprintf("%s (privacy=%s)", name, *team.Privacy))
-				}
-			}
-
-			walkTeams(team.Children, true)
-		}
+	state := &teamWalkState{
+		members:        sets.Set[string]{},
+		names:          sets.Set[string]{},
+		duplicateNames: sets.Set[string]{},
 	}
-	walkTeams(orgConfig.Teams, false)
+	walkTeams(orgConfig.Teams, false, state)
 
-	if outside := normalize(teamMembers).Difference(orgUsers); len(outside) > 0 {
+	if outside := normalize(state.members).Difference(orgUsers); len(outside) > 0 {
 		errs = append(errs, fmt.Errorf("%s: team members/maintainers must also be org members: %s", orgName, strings.Join(sets.List(outside), ", ")))
 	}
 
-	if n := len(duplicateTeamNames); n > 0 {
-		errs = append(errs, fmt.Errorf("%s: team names must be unique (including previous names), %d duplicated: %s", orgName, n, strings.Join(sets.List(duplicateTeamNames), ", ")))
+	if n := len(state.duplicateNames); n > 0 {
+		errs = append(errs, fmt.Errorf("%s: team names must be unique (including previous names), %d duplicated: %s", orgName, n, strings.Join(sets.List(state.duplicateNames), ", ")))
 	}
 
-	if len(nestedNotClosed) > 0 {
-		errs = append(errs, fmt.Errorf("%s: nested teams must have privacy: closed: %s", orgName, strings.Join(nestedNotClosed, ", ")))
+	if len(state.nestedNotClosed) > 0 {
+		errs = append(errs, fmt.Errorf("%s: nested teams must have privacy: closed: %s", orgName, strings.Join(state.nestedNotClosed, ", ")))
 	}
 
-	if len(dualRoleTeams) > 0 {
-		errs = append(errs, fmt.Errorf("%s: users listed as both member and maintainer of the same team: %s", orgName, strings.Join(dualRoleTeams, "; ")))
+	if len(state.dualRoleTeams) > 0 {
+		errs = append(errs, fmt.Errorf("%s: users listed as both member and maintainer of the same team: %s", orgName, strings.Join(state.dualRoleTeams, "; ")))
 	}
 
 	// repo-level checks
@@ -255,4 +217,54 @@ func normalize(s sets.Set[string]) sets.Set[string] {
 		out.Insert(github.NormLogin(i))
 	}
 	return out
+}
+
+// teamWalkState accumulates findings while walkTeams recurses through a team tree.
+type teamWalkState struct {
+	members         sets.Set[string] // all team members and maintainers (raw logins)
+	names           sets.Set[string] // team names seen so far (including Previously names)
+	duplicateNames  sets.Set[string] // team names seen more than once
+	nestedNotClosed []string         // "<team> (privacy=<p>)" for nested teams that aren't closed
+	dualRoleTeams   []string         // "<team>: <users>" for teams where a user is both member and maintainer
+}
+
+// walkTeams recurses through a team tree, populating state with any findings.
+// parentIsNested is true when the caller is already a nested team (so its
+// children are transitively nested regardless of whether they have children).
+func walkTeams(teams map[string]org.Team, parentIsNested bool, state *teamWalkState) {
+	for name, team := range teams {
+		state.members.Insert(team.Members...)
+		state.members.Insert(team.Maintainers...)
+
+		// A user must not be both a member and a maintainer of the same team.
+		// Peribolos rejects this at apply time (see cmd/peribolos/main.go
+		// configureMembers), but only when --fix-team-members is set — so
+		// bad configs can accumulate silently. Check statically here.
+		teamMemberSet := normalize(sets.New[string](team.Members...))
+		teamMaintainerSet := normalize(sets.New[string](team.Maintainers...))
+		if both := teamMemberSet.Intersection(teamMaintainerSet); len(both) > 0 {
+			state.dualRoleTeams = append(state.dualRoleTeams, fmt.Sprintf("%s: %s", name, strings.Join(sets.List(both), ", ")))
+		}
+
+		if state.names.Has(name) {
+			state.duplicateNames.Insert(name)
+		}
+		state.names.Insert(name)
+		for _, n := range team.Previously {
+			if state.names.Has(n) {
+				state.duplicateNames.Insert(n)
+			}
+			state.names.Insert(n)
+		}
+
+		// Nested teams (either they have a parent, or they have children) must be "closed" per GitHub.
+		isNested := parentIsNested || len(team.Children) > 0
+		if isNested {
+			if team.Privacy != nil && *team.Privacy != org.Closed {
+				state.nestedNotClosed = append(state.nestedNotClosed, fmt.Sprintf("%s (privacy=%s)", name, *team.Privacy))
+			}
+		}
+
+		walkTeams(team.Children, true, state)
+	}
 }

--- a/prow/cmd/peribolos-checkconfig/main.go
+++ b/prow/cmd/peribolos-checkconfig/main.go
@@ -150,11 +150,22 @@ func checkOrg(opt *options, orgName string, orgConfig org.Config) error {
 	teamNames := sets.Set[string]{}
 	duplicateTeamNames := sets.Set[string]{}
 	nestedNotClosed := []string{}
+	dualRoleTeams := []string{}
 	var walkTeams func(teams map[string]org.Team, parentIsNested bool)
 	walkTeams = func(teams map[string]org.Team, parentIsNested bool) {
 		for name, team := range teams {
 			teamMembers.Insert(team.Members...)
 			teamMembers.Insert(team.Maintainers...)
+
+			// A user must not be both a member and a maintainer of the same team.
+			// Peribolos rejects this at apply time (see cmd/peribolos/main.go
+			// configureMembers), but only when --fix-team-members is set — so
+			// bad configs can accumulate silently. Check statically here.
+			teamMemberSet := normalize(sets.New[string](team.Members...))
+			teamMaintainerSet := normalize(sets.New[string](team.Maintainers...))
+			if both := teamMemberSet.Intersection(teamMaintainerSet); len(both) > 0 {
+				dualRoleTeams = append(dualRoleTeams, fmt.Sprintf("%s: %s", name, strings.Join(sets.List(both), ", ")))
+			}
 
 			if teamNames.Has(name) {
 				duplicateTeamNames.Insert(name)
@@ -190,6 +201,10 @@ func checkOrg(opt *options, orgName string, orgConfig org.Config) error {
 
 	if len(nestedNotClosed) > 0 {
 		errs = append(errs, fmt.Errorf("%s: nested teams must have privacy: closed: %s", orgName, strings.Join(nestedNotClosed, ", ")))
+	}
+
+	if len(dualRoleTeams) > 0 {
+		errs = append(errs, fmt.Errorf("%s: users listed as both member and maintainer of the same team: %s", orgName, strings.Join(dualRoleTeams, "; ")))
 	}
 
 	// repo-level checks

--- a/prow/cmd/peribolos-checkconfig/main_test.go
+++ b/prow/cmd/peribolos-checkconfig/main_test.go
@@ -337,6 +337,83 @@ func TestCheckOrg(t *testing.T) {
 			},
 		},
 		{
+			name: "user is both team member and maintainer",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+				Teams: map[string]org.Team{
+					"team-a": {
+						Maintainers: []string{"alice"},
+						Members:     []string{"alice"},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "user is both team member and maintainer, case differs",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+				Teams: map[string]org.Team{
+					"team-a": {
+						Maintainers: []string{"Alice"},
+						Members:     []string{"alice"},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "user is member of one team and maintainer of another — allowed",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+				Teams: map[string]org.Team{
+					"team-a": {
+						Maintainers: []string{"alice"},
+					},
+					"team-b": {
+						Maintainers: []string{"bob"},
+						Members:     []string{"alice"},
+					},
+				},
+			},
+		},
+		{
+			name: "user is maintainer of parent and member of child — allowed",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+				Teams: map[string]org.Team{
+					"parent": {
+						Maintainers: []string{"alice"},
+						Children: map[string]org.Team{
+							"child": {
+								Members: []string{"alice"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "duplicate repo names case-insensitively",
 			opt: options{
 				minAdmins:      2,

--- a/prow/cmd/peribolos-checkconfig/main_test.go
+++ b/prow/cmd/peribolos-checkconfig/main_test.go
@@ -7,90 +7,14 @@ package main
 import (
 	"flag"
 	"reflect"
-	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/prow/pkg/config/org"
 	"sigs.k8s.io/prow/pkg/flagutil"
 )
-
-func TestOptions(t *testing.T) {
-	cases := []struct {
-		name     string
-		args     []string
-		expected *options
-	}{
-		{
-			name: "missing --config",
-			args: []string{},
-		},
-		{
-			name: "--minAdmins too low",
-			args: []string{"--config-path=foo", "--min-admins=1"},
-		},
-		{
-			name: "bad --log-level",
-			args: []string{"--config-path=foo", "--log-level=nonsense"},
-		},
-		{
-			name: "minimal",
-			args: []string{"--config-path=foo"},
-			expected: &options{
-				config:         "foo",
-				minAdmins:      defaultMinAdmins,
-				requiredAdmins: flagutil.NewStrings(),
-				logLevel:       "info",
-			},
-		},
-		{
-			name: "minimal admins",
-			args: []string{"--config-path=foo", "--min-admins=2"},
-			expected: &options{
-				config:         "foo",
-				minAdmins:      2,
-				requiredAdmins: flagutil.NewStrings(),
-				logLevel:       "info",
-			},
-		},
-		{
-			name: "required admins",
-			args: []string{"--config-path=foo", "--required-admins=alice", "--required-admins=bob"},
-			expected: &options{
-				config:         "foo",
-				minAdmins:      defaultMinAdmins,
-				requiredAdmins: flagutil.NewStringsBeenSet("alice", "bob"),
-				logLevel:       "info",
-			},
-		},
-		{
-			name: "debug log level",
-			args: []string{"--config-path=foo", "--log-level=debug"},
-			expected: &options{
-				config:         "foo",
-				minAdmins:      defaultMinAdmins,
-				requiredAdmins: flagutil.NewStrings(),
-				logLevel:       "debug",
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			flags := flag.NewFlagSet(tc.name, flag.ContinueOnError)
-			var actual options
-			err := actual.parseArgs(flags, tc.args)
-			switch {
-			case err == nil && tc.expected == nil:
-				t.Errorf("%s: failed to return an error", tc.name)
-			case err != nil && tc.expected != nil:
-				t.Errorf("%s: unexpected error: %v", tc.name, err)
-			case tc.expected != nil && !reflect.DeepEqual(*tc.expected, actual):
-				t.Errorf("%s: got incorrect options: %v", tc.name, cmp.Diff(actual, *tc.expected, cmp.AllowUnexported(options{}, flagutil.Strings{})))
-			}
-		})
-	}
-}
 
 func strP(s string) *string { return &s }
 func boolP(b bool) *bool    { return &b }
@@ -98,100 +22,147 @@ func privP(p org.Privacy) *org.Privacy {
 	return &p
 }
 
-func TestCheckOrg(t *testing.T) {
+var _ = Describe("PeribolosCheckconfig", func() {
+	DescribeTable("#parseArgs",
+		func(args []string, expected *options) {
+			flags := flag.NewFlagSet("test", flag.ContinueOnError)
+			var actual options
+			err := actual.parseArgs(flags, args)
+			switch {
+			case expected == nil:
+				Expect(err).To(HaveOccurred(), "expected error, got none")
+			default:
+				Expect(err).ToNot(HaveOccurred())
+				Expect(reflect.DeepEqual(*expected, actual)).To(BeTrue(),
+					"got incorrect options: %s", cmp.Diff(actual, *expected, cmp.AllowUnexported(options{}, flagutil.Strings{})))
+			}
+		},
+		Entry("missing --config",
+			[]string{},
+			nil),
+		Entry("--minAdmins too low",
+			[]string{"--config-path=foo", "--min-admins=1"},
+			nil),
+		Entry("bad --log-level",
+			[]string{"--config-path=foo", "--log-level=nonsense"},
+			nil),
+		Entry("minimal",
+			[]string{"--config-path=foo"},
+			&options{
+				config:         "foo",
+				minAdmins:      defaultMinAdmins,
+				requiredAdmins: flagutil.NewStrings(),
+				logLevel:       "info",
+			}),
+		Entry("minimal admins",
+			[]string{"--config-path=foo", "--min-admins=2"},
+			&options{
+				config:         "foo",
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+				logLevel:       "info",
+			}),
+		Entry("required admins",
+			[]string{"--config-path=foo", "--required-admins=alice", "--required-admins=bob"},
+			&options{
+				config:         "foo",
+				minAdmins:      defaultMinAdmins,
+				requiredAdmins: flagutil.NewStringsBeenSet("alice", "bob"),
+				logLevel:       "info",
+			}),
+		Entry("debug log level",
+			[]string{"--config-path=foo", "--log-level=debug"},
+			&options{
+				config:         "foo",
+				minAdmins:      defaultMinAdmins,
+				requiredAdmins: flagutil.NewStrings(),
+				logLevel:       "debug",
+			}),
+	)
+
 	closed := org.Closed
 	secret := org.Secret
 
-	cases := []struct {
-		name        string
-		opt         options
-		orgName     string
-		orgConfig   org.Config
-		expectError bool
-	}{
-		{
-			name: "happy path",
-			opt: options{
+	DescribeTable("#checkOrg",
+		func(opt options, orgName string, orgConfig org.Config, expectError bool) {
+			err := checkOrg(&opt, orgName, orgConfig)
+			if expectError {
+				Expect(err).To(HaveOccurred(), "expected error, got none")
+			} else {
+				Expect(err).ToNot(HaveOccurred(), "unexpected error")
+			}
+		},
+		Entry("happy path",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings("alice"),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins:  []string{"alice", "bob"},
 				Members: []string{"carol"},
 			},
-		},
-		{
-			name: "too few admins",
-			opt: options{
+			false),
+		Entry("too few admins",
+			options{
 				minAdmins:      3,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 			},
-			expectError: true,
-		},
-		{
-			name: "missing required admin",
-			opt: options{
+			true),
+		Entry("missing required admin",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings("alice", "missing"),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 			},
-			expectError: true,
-		},
-		{
-			name: "user in both admins and members",
-			opt: options{
+			true),
+		Entry("user in both admins and members",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins:  []string{"alice", "bob"},
 				Members: []string{"alice"},
 			},
-			expectError: true,
-		},
-		{
-			name: "user in both admins and members, case differs",
-			opt: options{
+			true),
+		Entry("user in both admins and members, case differs",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins:  []string{"Alice", "bob"},
 				Members: []string{"alice"},
 			},
-			expectError: true,
-		},
-		{
-			name: "required-admins matches case-insensitively is not enough — currently strict",
-			opt: options{
+			true),
+		Entry("required-admins matches case-insensitively is not enough — currently strict",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings("alice"),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				// "Alice" != "alice" for the required-admins check (matches peribolos behavior)
 				Admins: []string{"Alice", "bob"},
 			},
-			expectError: true,
-		},
-		{
-			name: "team member is not an org member",
-			opt: options{
+			true),
+		Entry("team member is not an org member",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins:  []string{"alice", "bob"},
 				Members: []string{"carol"},
 				Teams: map[string]org.Team{
@@ -200,16 +171,14 @@ func TestCheckOrg(t *testing.T) {
 					},
 				},
 			},
-			expectError: true,
-		},
-		{
-			name: "team maintainer is not an org member",
-			opt: options{
+			true),
+		Entry("team maintainer is not an org member",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 				Teams: map[string]org.Team{
 					"team-a": {
@@ -217,16 +186,14 @@ func TestCheckOrg(t *testing.T) {
 					},
 				},
 			},
-			expectError: true,
-		},
-		{
-			name: "team member is an admin — ok",
-			opt: options{
+			true),
+		Entry("team member is an admin — ok",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 				Teams: map[string]org.Team{
 					"team-a": {
@@ -235,15 +202,14 @@ func TestCheckOrg(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			name: "child team member is not an org member",
-			opt: options{
+			false),
+		Entry("child team member is not an org member",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 				Teams: map[string]org.Team{
 					"parent": {
@@ -262,16 +228,14 @@ func TestCheckOrg(t *testing.T) {
 					},
 				},
 			},
-			expectError: true,
-		},
-		{
-			name: "duplicate team name",
-			opt: options{
+			true),
+		Entry("duplicate team name",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 				Teams: map[string]org.Team{
 					"team-a": {
@@ -283,16 +247,14 @@ func TestCheckOrg(t *testing.T) {
 					},
 				},
 			},
-			expectError: true,
-		},
-		{
-			name: "team with parent must be closed",
-			opt: options{
+			true),
+		Entry("team with parent must be closed",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 				Teams: map[string]org.Team{
 					"parent": {
@@ -311,16 +273,14 @@ func TestCheckOrg(t *testing.T) {
 					},
 				},
 			},
-			expectError: true,
-		},
-		{
-			name: "team with children privacy unset — allowed (defaults handled by peribolos)",
-			opt: options{
+			true),
+		Entry("team with children privacy unset — allowed (defaults handled by peribolos)",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 				Teams: map[string]org.Team{
 					"parent": {
@@ -335,15 +295,14 @@ func TestCheckOrg(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			name: "user is both team member and maintainer",
-			opt: options{
+			false),
+		Entry("user is both team member and maintainer",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 				Teams: map[string]org.Team{
 					"team-a": {
@@ -352,16 +311,14 @@ func TestCheckOrg(t *testing.T) {
 					},
 				},
 			},
-			expectError: true,
-		},
-		{
-			name: "user is both team member and maintainer, case differs",
-			opt: options{
+			true),
+		Entry("user is both team member and maintainer, case differs",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 				Teams: map[string]org.Team{
 					"team-a": {
@@ -370,16 +327,14 @@ func TestCheckOrg(t *testing.T) {
 					},
 				},
 			},
-			expectError: true,
-		},
-		{
-			name: "user is member of one team and maintainer of another — allowed",
-			opt: options{
+			true),
+		Entry("user is member of one team and maintainer of another — allowed",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 				Teams: map[string]org.Team{
 					"team-a": {
@@ -391,15 +346,14 @@ func TestCheckOrg(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			name: "user is maintainer of parent and member of child — allowed",
-			opt: options{
+			false),
+		Entry("user is maintainer of parent and member of child — allowed",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 				Teams: map[string]org.Team{
 					"parent": {
@@ -412,133 +366,100 @@ func TestCheckOrg(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			name: "duplicate repo names case-insensitively",
-			opt: options{
+			false),
+		Entry("duplicate repo names case-insensitively",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 				Repos: map[string]org.Repo{
 					"repo": {Description: strP("desc")},
 					"Repo": {Description: strP("desc")},
 				},
 			},
-			expectError: true,
-		},
-		{
-			name: "repo archived: false is rejected",
-			opt: options{
+			true),
+		Entry("repo archived: false is rejected",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 				Repos: map[string]org.Repo{
 					"repo": {Archived: boolP(false)},
 				},
 			},
-			expectError: true,
-		},
-		{
-			name: "repo archived: true is allowed",
-			opt: options{
+			true),
+		Entry("repo archived: true is allowed",
+			options{
 				minAdmins:      2,
 				requiredAdmins: flagutil.NewStrings(),
 			},
-			orgName: "myorg",
-			orgConfig: org.Config{
+			"myorg",
+			org.Config{
 				Admins: []string{"alice", "bob"},
 				Repos: map[string]org.Repo{
 					"repo": {Archived: boolP(true)},
 				},
 			},
-		},
-	}
+			false),
+	)
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := checkOrg(&tc.opt, tc.orgName, tc.orgConfig)
-			if err == nil && tc.expectError {
-				t.Errorf("%s: expected error, got none", tc.name)
-			} else if err != nil && !tc.expectError {
-				t.Errorf("%s: unexpected error: %v", tc.name, err)
-			}
-		})
-	}
-}
+	Describe("#validateRepos", func() {
+		description := "cool repo"
 
-func TestValidateRepos(t *testing.T) {
-	description := "cool repo"
-	testCases := []struct {
-		description string
-		config      map[string]org.Repo
-		expectError bool
-	}{
-		{
-			description: "handles nil map",
-		},
-		{
-			description: "handles empty map",
-			config:      map[string]org.Repo{},
-		},
-		{
-			description: "handles valid config",
-			config: map[string]org.Repo{
-				"repo": {Description: &description},
+		DescribeTable("validates repo configs",
+			func(config map[string]org.Repo, expectError bool) {
+				err := validateRepos("myorg", config)
+				if expectError {
+					Expect(err).To(HaveOccurred(), "expected error, got none")
+				} else {
+					Expect(err).ToNot(HaveOccurred(), "unexpected error")
+				}
 			},
-		},
-		{
-			description: "finds repo names duplicate when normalized",
-			config: map[string]org.Repo{
-				"repo": {Description: &description},
-				"Repo": {Description: &description},
-			},
-			expectError: true,
-		},
-		{
-			description: "finds name conflict between previous and current names",
-			config: map[string]org.Repo{
-				"repo":     {Previously: []string{"conflict"}},
-				"conflict": {Description: &description},
-			},
-			expectError: true,
-		},
-		{
-			description: "finds name conflict between two previous names",
-			config: map[string]org.Repo{
-				"repo":         {Previously: []string{"conflict"}},
-				"another-repo": {Previously: []string{"conflict"}},
-			},
-			expectError: true,
-		},
-		{
-			description: "flags archived: false",
-			config: map[string]org.Repo{
-				"repo": {Archived: boolP(false)},
-			},
-			expectError: true,
-		},
-		{
-			description: "allows archived: true",
-			config: map[string]org.Repo{
-				"repo": {Archived: boolP(true)},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			err := validateRepos("myorg", tc.config)
-			if err == nil && tc.expectError {
-				t.Errorf("%s: expected error, got none", tc.description)
-			} else if err != nil && !tc.expectError {
-				t.Errorf("%s: unexpected error: %v", tc.description, err)
-			}
-		})
-	}
-}
+			Entry("handles nil map",
+				nil,
+				false),
+			Entry("handles empty map",
+				map[string]org.Repo{},
+				false),
+			Entry("handles valid config",
+				map[string]org.Repo{
+					"repo": {Description: &description},
+				},
+				false),
+			Entry("finds repo names duplicate when normalized",
+				map[string]org.Repo{
+					"repo": {Description: &description},
+					"Repo": {Description: &description},
+				},
+				true),
+			Entry("finds name conflict between previous and current names",
+				map[string]org.Repo{
+					"repo":     {Previously: []string{"conflict"}},
+					"conflict": {Description: &description},
+				},
+				true),
+			Entry("finds name conflict between two previous names",
+				map[string]org.Repo{
+					"repo":         {Previously: []string{"conflict"}},
+					"another-repo": {Previously: []string{"conflict"}},
+				},
+				true),
+			Entry("flags archived: false",
+				map[string]org.Repo{
+					"repo": {Archived: boolP(false)},
+				},
+				true),
+			Entry("allows archived: true",
+				map[string]org.Repo{
+					"repo": {Archived: boolP(true)},
+				},
+				false),
+		)
+	})
+})

--- a/prow/cmd/peribolos-checkconfig/main_test.go
+++ b/prow/cmd/peribolos-checkconfig/main_test.go
@@ -1,0 +1,467 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"flag"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"sigs.k8s.io/prow/pkg/config/org"
+	"sigs.k8s.io/prow/pkg/flagutil"
+)
+
+func TestOptions(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		expected *options
+	}{
+		{
+			name: "missing --config",
+			args: []string{},
+		},
+		{
+			name: "--minAdmins too low",
+			args: []string{"--config-path=foo", "--min-admins=1"},
+		},
+		{
+			name: "bad --log-level",
+			args: []string{"--config-path=foo", "--log-level=nonsense"},
+		},
+		{
+			name: "minimal",
+			args: []string{"--config-path=foo"},
+			expected: &options{
+				config:         "foo",
+				minAdmins:      defaultMinAdmins,
+				requiredAdmins: flagutil.NewStrings(),
+				logLevel:       "info",
+			},
+		},
+		{
+			name: "minimal admins",
+			args: []string{"--config-path=foo", "--min-admins=2"},
+			expected: &options{
+				config:         "foo",
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+				logLevel:       "info",
+			},
+		},
+		{
+			name: "required admins",
+			args: []string{"--config-path=foo", "--required-admins=alice", "--required-admins=bob"},
+			expected: &options{
+				config:         "foo",
+				minAdmins:      defaultMinAdmins,
+				requiredAdmins: flagutil.NewStringsBeenSet("alice", "bob"),
+				logLevel:       "info",
+			},
+		},
+		{
+			name: "debug log level",
+			args: []string{"--config-path=foo", "--log-level=debug"},
+			expected: &options{
+				config:         "foo",
+				minAdmins:      defaultMinAdmins,
+				requiredAdmins: flagutil.NewStrings(),
+				logLevel:       "debug",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			flags := flag.NewFlagSet(tc.name, flag.ContinueOnError)
+			var actual options
+			err := actual.parseArgs(flags, tc.args)
+			switch {
+			case err == nil && tc.expected == nil:
+				t.Errorf("%s: failed to return an error", tc.name)
+			case err != nil && tc.expected != nil:
+				t.Errorf("%s: unexpected error: %v", tc.name, err)
+			case tc.expected != nil && !reflect.DeepEqual(*tc.expected, actual):
+				t.Errorf("%s: got incorrect options: %v", tc.name, cmp.Diff(actual, *tc.expected, cmp.AllowUnexported(options{}, flagutil.Strings{})))
+			}
+		})
+	}
+}
+
+func strP(s string) *string { return &s }
+func boolP(b bool) *bool    { return &b }
+func privP(p org.Privacy) *org.Privacy {
+	return &p
+}
+
+func TestCheckOrg(t *testing.T) {
+	closed := org.Closed
+	secret := org.Secret
+
+	cases := []struct {
+		name        string
+		opt         options
+		orgName     string
+		orgConfig   org.Config
+		expectError bool
+	}{
+		{
+			name: "happy path",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings("alice"),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins:  []string{"alice", "bob"},
+				Members: []string{"carol"},
+			},
+		},
+		{
+			name: "too few admins",
+			opt: options{
+				minAdmins:      3,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+			},
+			expectError: true,
+		},
+		{
+			name: "missing required admin",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings("alice", "missing"),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+			},
+			expectError: true,
+		},
+		{
+			name: "user in both admins and members",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins:  []string{"alice", "bob"},
+				Members: []string{"alice"},
+			},
+			expectError: true,
+		},
+		{
+			name: "user in both admins and members, case differs",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins:  []string{"Alice", "bob"},
+				Members: []string{"alice"},
+			},
+			expectError: true,
+		},
+		{
+			name: "required-admins matches case-insensitively is not enough — currently strict",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings("alice"),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				// "Alice" != "alice" for the required-admins check (matches peribolos behavior)
+				Admins: []string{"Alice", "bob"},
+			},
+			expectError: true,
+		},
+		{
+			name: "team member is not an org member",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins:  []string{"alice", "bob"},
+				Members: []string{"carol"},
+				Teams: map[string]org.Team{
+					"team-a": {
+						Members: []string{"dave"},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "team maintainer is not an org member",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+				Teams: map[string]org.Team{
+					"team-a": {
+						Maintainers: []string{"eve"},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "team member is an admin — ok",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+				Teams: map[string]org.Team{
+					"team-a": {
+						Maintainers: []string{"alice"},
+						Members:     []string{"bob"},
+					},
+				},
+			},
+		},
+		{
+			name: "child team member is not an org member",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+				Teams: map[string]org.Team{
+					"parent": {
+						Maintainers: []string{"alice"},
+						TeamMetadata: org.TeamMetadata{
+							Privacy: privP(closed),
+						},
+						Children: map[string]org.Team{
+							"child": {
+								Members: []string{"stranger"},
+								TeamMetadata: org.TeamMetadata{
+									Privacy: privP(closed),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "duplicate team name",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+				Teams: map[string]org.Team{
+					"team-a": {
+						Maintainers: []string{"alice"},
+					},
+					"team-b": {
+						Maintainers: []string{"alice"},
+						Previously:  []string{"team-a"},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "team with parent must be closed",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+				Teams: map[string]org.Team{
+					"parent": {
+						Maintainers: []string{"alice"},
+						TeamMetadata: org.TeamMetadata{
+							Privacy: privP(closed),
+						},
+						Children: map[string]org.Team{
+							"child": {
+								Maintainers: []string{"alice"},
+								TeamMetadata: org.TeamMetadata{
+									Privacy: privP(secret),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "team with children privacy unset — allowed (defaults handled by peribolos)",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+				Teams: map[string]org.Team{
+					"parent": {
+						Maintainers: []string{"alice"},
+						// Privacy unset: peribolos will set it to closed at apply time,
+						// so we do not flag it here.
+						Children: map[string]org.Team{
+							"child": {
+								Maintainers: []string{"alice"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "duplicate repo names case-insensitively",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+				Repos: map[string]org.Repo{
+					"repo": {Description: strP("desc")},
+					"Repo": {Description: strP("desc")},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "repo archived: false is rejected",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+				Repos: map[string]org.Repo{
+					"repo": {Archived: boolP(false)},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "repo archived: true is allowed",
+			opt: options{
+				minAdmins:      2,
+				requiredAdmins: flagutil.NewStrings(),
+			},
+			orgName: "myorg",
+			orgConfig: org.Config{
+				Admins: []string{"alice", "bob"},
+				Repos: map[string]org.Repo{
+					"repo": {Archived: boolP(true)},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkOrg(&tc.opt, tc.orgName, tc.orgConfig)
+			if err == nil && tc.expectError {
+				t.Errorf("%s: expected error, got none", tc.name)
+			} else if err != nil && !tc.expectError {
+				t.Errorf("%s: unexpected error: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestValidateRepos(t *testing.T) {
+	description := "cool repo"
+	testCases := []struct {
+		description string
+		config      map[string]org.Repo
+		expectError bool
+	}{
+		{
+			description: "handles nil map",
+		},
+		{
+			description: "handles empty map",
+			config:      map[string]org.Repo{},
+		},
+		{
+			description: "handles valid config",
+			config: map[string]org.Repo{
+				"repo": {Description: &description},
+			},
+		},
+		{
+			description: "finds repo names duplicate when normalized",
+			config: map[string]org.Repo{
+				"repo": {Description: &description},
+				"Repo": {Description: &description},
+			},
+			expectError: true,
+		},
+		{
+			description: "finds name conflict between previous and current names",
+			config: map[string]org.Repo{
+				"repo":     {Previously: []string{"conflict"}},
+				"conflict": {Description: &description},
+			},
+			expectError: true,
+		},
+		{
+			description: "finds name conflict between two previous names",
+			config: map[string]org.Repo{
+				"repo":         {Previously: []string{"conflict"}},
+				"another-repo": {Previously: []string{"conflict"}},
+			},
+			expectError: true,
+		},
+		{
+			description: "flags archived: false",
+			config: map[string]org.Repo{
+				"repo": {Archived: boolP(false)},
+			},
+			expectError: true,
+		},
+		{
+			description: "allows archived: true",
+			config: map[string]org.Repo{
+				"repo": {Archived: boolP(true)},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			err := validateRepos("myorg", tc.config)
+			if err == nil && tc.expectError {
+				t.Errorf("%s: expected error, got none", tc.description)
+			} else if err != nil && !tc.expectError {
+				t.Errorf("%s: unexpected error: %v", tc.description, err)
+			}
+		})
+	}
+}

--- a/prow/cmd/peribolos-checkconfig/main_test.go
+++ b/prow/cmd/peribolos-checkconfig/main_test.go
@@ -83,12 +83,12 @@ var _ = Describe("PeribolosCheckconfig", func() {
 	secret := org.Secret
 
 	DescribeTable("#checkOrg",
-		func(opt options, orgName string, orgConfig org.Config, expectError bool) {
+		func(opt options, orgName string, orgConfig org.Config, expectedErrMsg string) {
 			err := checkOrg(&opt, orgName, orgConfig)
-			if expectError {
-				Expect(err).To(HaveOccurred(), "expected error, got none")
-			} else {
+			if expectedErrMsg == "" {
 				Expect(err).ToNot(HaveOccurred(), "unexpected error")
+			} else {
+				Expect(err).To(MatchError(ContainSubstring(expectedErrMsg)))
 			}
 		},
 		Entry("happy path",
@@ -101,7 +101,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 				Admins:  []string{"alice", "bob"},
 				Members: []string{"carol"},
 			},
-			false),
+			""),
 		Entry("too few admins",
 			options{
 				minAdmins:      3,
@@ -111,7 +111,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 			org.Config{
 				Admins: []string{"alice", "bob"},
 			},
-			true),
+			"must specify at least 3 admins, only found 2"),
 		Entry("missing required admin",
 			options{
 				minAdmins:      2,
@@ -121,7 +121,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 			org.Config{
 				Admins: []string{"alice", "bob"},
 			},
-			true),
+			"missing [missing]"),
 		Entry("user in both admins and members",
 			options{
 				minAdmins:      2,
@@ -132,7 +132,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 				Admins:  []string{"alice", "bob"},
 				Members: []string{"alice"},
 			},
-			true),
+			"users listed as both admin and member: alice"),
 		Entry("user in both admins and members, case differs",
 			options{
 				minAdmins:      2,
@@ -143,7 +143,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 				Admins:  []string{"Alice", "bob"},
 				Members: []string{"alice"},
 			},
-			true),
+			"users listed as both admin and member: alice"),
 		Entry("required-admins matches case-insensitively is not enough — currently strict",
 			options{
 				minAdmins:      2,
@@ -154,7 +154,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 				// "Alice" != "alice" for the required-admins check (matches peribolos behavior)
 				Admins: []string{"Alice", "bob"},
 			},
-			true),
+			"missing [alice]"),
 		Entry("team member is not an org member",
 			options{
 				minAdmins:      2,
@@ -170,7 +170,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 					},
 				},
 			},
-			true),
+			"team members/maintainers must also be org members: dave"),
 		Entry("team maintainer is not an org member",
 			options{
 				minAdmins:      2,
@@ -185,7 +185,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 					},
 				},
 			},
-			true),
+			"team members/maintainers must also be org members: eve"),
 		Entry("team member is an admin — ok",
 			options{
 				minAdmins:      2,
@@ -201,7 +201,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 					},
 				},
 			},
-			false),
+			""),
 		Entry("child team member is not an org member",
 			options{
 				minAdmins:      2,
@@ -227,7 +227,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 					},
 				},
 			},
-			true),
+			"team members/maintainers must also be org members: stranger"),
 		Entry("duplicate team name",
 			options{
 				minAdmins:      2,
@@ -246,7 +246,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 					},
 				},
 			},
-			true),
+			"team names must be unique"),
 		Entry("team with parent must be closed",
 			options{
 				minAdmins:      2,
@@ -272,7 +272,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 					},
 				},
 			},
-			true),
+			"nested teams must have privacy: closed"),
 		Entry("team with children privacy unset — allowed (defaults handled by peribolos)",
 			options{
 				minAdmins:      2,
@@ -294,7 +294,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 					},
 				},
 			},
-			false),
+			""),
 		Entry("user is both team member and maintainer",
 			options{
 				minAdmins:      2,
@@ -310,7 +310,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 					},
 				},
 			},
-			true),
+			"users listed as both member and maintainer of the same team: team-a: alice"),
 		Entry("user is both team member and maintainer, case differs",
 			options{
 				minAdmins:      2,
@@ -326,7 +326,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 					},
 				},
 			},
-			true),
+			"users listed as both member and maintainer of the same team: team-a: alice"),
 		Entry("user is member of one team and maintainer of another — allowed",
 			options{
 				minAdmins:      2,
@@ -345,7 +345,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 					},
 				},
 			},
-			false),
+			""),
 		Entry("user is maintainer of parent and member of child — allowed",
 			options{
 				minAdmins:      2,
@@ -365,7 +365,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 					},
 				},
 			},
-			false),
+			""),
 		Entry("duplicate repo names case-insensitively",
 			options{
 				minAdmins:      2,
@@ -379,7 +379,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 					"Repo": {Description: strP("desc")},
 				},
 			},
-			true),
+			"found duplicate repo names"),
 		Entry("repo archived: false is rejected",
 			options{
 				minAdmins:      2,
@@ -392,7 +392,7 @@ var _ = Describe("PeribolosCheckconfig", func() {
 					"repo": {Archived: boolP(false)},
 				},
 			},
-			true),
+			"repos configured with archived: false"),
 		Entry("repo archived: true is allowed",
 			options{
 				minAdmins:      2,
@@ -405,60 +405,60 @@ var _ = Describe("PeribolosCheckconfig", func() {
 					"repo": {Archived: boolP(true)},
 				},
 			},
-			false),
+			""),
 	)
 
 	Describe("#validateRepos", func() {
 		description := "cool repo"
 
 		DescribeTable("validates repo configs",
-			func(config map[string]org.Repo, expectError bool) {
+			func(config map[string]org.Repo, expectedErrMsg string) {
 				err := validateRepos("myorg", config)
-				if expectError {
-					Expect(err).To(HaveOccurred(), "expected error, got none")
-				} else {
+				if expectedErrMsg == "" {
 					Expect(err).ToNot(HaveOccurred(), "unexpected error")
+				} else {
+					Expect(err).To(MatchError(ContainSubstring(expectedErrMsg)))
 				}
 			},
 			Entry("handles nil map",
 				nil,
-				false),
+				""),
 			Entry("handles empty map",
 				map[string]org.Repo{},
-				false),
+				""),
 			Entry("handles valid config",
 				map[string]org.Repo{
 					"repo": {Description: &description},
 				},
-				false),
+				""),
 			Entry("finds repo names duplicate when normalized",
 				map[string]org.Repo{
 					"repo": {Description: &description},
 					"Repo": {Description: &description},
 				},
-				true),
+				"found duplicate repo names"),
 			Entry("finds name conflict between previous and current names",
 				map[string]org.Repo{
 					"repo":     {Previously: []string{"conflict"}},
 					"conflict": {Description: &description},
 				},
-				true),
+				"found duplicate repo names"),
 			Entry("finds name conflict between two previous names",
 				map[string]org.Repo{
 					"repo":         {Previously: []string{"conflict"}},
 					"another-repo": {Previously: []string{"conflict"}},
 				},
-				true),
+				"found duplicate repo names"),
 			Entry("flags archived: false",
 				map[string]org.Repo{
 					"repo": {Archived: boolP(false)},
 				},
-				true),
+				"repos configured with archived: false"),
 			Entry("allows archived: true",
 				map[string]org.Repo{
 					"repo": {Archived: boolP(true)},
 				},
-				false),
+				""),
 		)
 	})
 })

--- a/prow/cmd/peribolos-checkconfig/main_test.go
+++ b/prow/cmd/peribolos-checkconfig/main_test.go
@@ -28,14 +28,13 @@ var _ = Describe("PeribolosCheckconfig", func() {
 			flags := flag.NewFlagSet("test", flag.ContinueOnError)
 			var actual options
 			err := actual.parseArgs(flags, args)
-			switch {
-			case expected == nil:
+			if expected == nil {
 				Expect(err).To(HaveOccurred(), "expected error, got none")
-			default:
-				Expect(err).ToNot(HaveOccurred())
-				Expect(reflect.DeepEqual(*expected, actual)).To(BeTrue(),
-					"got incorrect options: %s", cmp.Diff(actual, *expected, cmp.AllowUnexported(options{}, flagutil.Strings{})))
+				return
 			}
+			Expect(err).ToNot(HaveOccurred())
+			Expect(reflect.DeepEqual(*expected, actual)).To(BeTrue(),
+				"got incorrect options: %s", cmp.Diff(actual, *expected, cmp.AllowUnexported(options{}, flagutil.Strings{})))
 		},
 		Entry("missing --config",
 			[]string{},

--- a/prow/cmd/peribolos-checkconfig/peribolos_checkconfig_suite_test.go
+++ b/prow/cmd/peribolos-checkconfig/peribolos_checkconfig_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPeribolosCheckconfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PeribolosCheckconfig Suite")
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds a static configuration checker for peribolos (for the org repo).
The tool is able to check the config/org.yaml for various mistakes, see README.md for elaboration.

**Which issue(s) this PR fixes**:
Related [org/#36](https://github.com/gardener/org/issues/36)
Will create a follow up with prow job -> will be opened as soon as this is merged and a docker image with the peribolos-checkconfig tool is published to the registry.

**Special notes for your reviewer**:
Will the docker image push succeed? Is further configuration required in the docker registry?