### PR TITLE
Use VPA to control resource requests of `renovate`

### DIFF
--- a/deploy/renovate/kustomization.yaml
+++ b/deploy/renovate/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
 - renovate-helmrepo.yaml
 - renovate.yaml
+- vpa.yaml

--- a/deploy/renovate/vpa.yaml
+++ b/deploy/renovate/vpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  labels:
+    app.kubernetes.io/instance: renovate
+    app.kubernetes.io/name: renovate
+  name: renovate
+  namespace: renovate
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      controlledValues: RequestsOnly
+  targetRef:
+    apiVersion: batch/v1
+    kind: CronJob
+    name: renovate
+  updatePolicy:
+    updateMode: Initial


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
`renovate` can be busy these days. VPA works with CronJobs too, so let's use it for renovate. The VPA uses updateMode `Initial` since the pod runs for a couple of minutes only anyway.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
