### PR TITLE
Disable athens goproxy in renovate

### DIFF
--- a/deploy/renovate/renovate.yaml
+++ b/deploy/renovate/renovate.yaml
@@ -123,5 +123,5 @@ spec:
       fsGroup: 12021
       fsGroupChangePolicy: OnRootMismatch
 
-    env:
-      GOPROXY: http://athens-proxy.athens.svc.cluster.local,direct
+#    env:
+#      GOPROXY: http://athens-proxy.athens.svc.cluster.local,direct

--- a/deploy/renovate/renovate.yaml
+++ b/deploy/renovate/renovate.yaml
@@ -123,5 +123,7 @@ spec:
       fsGroup: 12021
       fsGroupChangePolicy: OnRootMismatch
 
+## Athens seems to cause renovate issues.
+## we saw multiple occurences of type: "Failed to look up go package github.com/aws/aws-sdk-go-v2/config: no-result"
 #    env:
 #      GOPROXY: http://athens-proxy.athens.svc.cluster.local,direct


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Athens seems to be responsible for renovate errors when updating big monolytical modules like the aws sdk.
Renovate job errors looked the following:
```
Package lookup failures (repository=gardener/gardener-extension-provider-aws, branch=renovate/github.com-gardener-machine-controller-manager-0.x)
       "warnings": [
         "Failed to look up go package github.com/aws/aws-sdk-go-v2/config: no-result",
         "Failed to look up go package github.com/aws/aws-sdk-go-v2/credentials: no-result",
         "Failed to look up go package github.com/aws/aws-sdk-go-v2/service/ec2: no-result",
         "Failed to look up go package github.com/aws/aws-sdk-go-v2/service/efs: no-result",
         "Failed to look up go package github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing: no-result",
         "Failed to look up go package github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2: no-result",
         "Failed to look up go package github.com/aws/aws-sdk-go-v2/service/iam: no-result",
         "Failed to look up go package github.com/aws/aws-sdk-go-v2/service/route53: no-result",
         "Failed to look up go package github.com/aws/aws-sdk-go-v2/service/s3: no-result",
         "Failed to look up go package github.com/aws/aws-sdk-go-v2/service/sts: no-result"
       ],
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
