### PR TITLE
add peribolos check conf prow job as presubmit

### DIFF
--- a/config/jobs/org/org-presubmits.yaml
+++ b/config/jobs/org/org-presubmits.yaml
@@ -14,3 +14,4 @@ presubmits:
         args:
             - --min-admins=5
             - --config-path=config/org.yaml
+            - --required-admins=gardener-ci-robot

--- a/config/jobs/org/org-presubmits.yaml
+++ b/config/jobs/org/org-presubmits.yaml
@@ -1,0 +1,16 @@
+presubmits:
+  gardener/org:
+  - name: pull-org-peribolos-checkconfig
+    cluster: gardener-prow-build
+    run_if_changed: '^config/org\.yaml$'
+    decorate: true
+    annotations:
+      description: Runs peribolos-checkconfig to validate changes to org config
+    spec:
+      containers:
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/peribolos-checkconfig:v20260706-d078956
+        command:
+        - /peribolos-checkconfig
+        args:
+            - --min-admins=5
+            - --config-path=config/org.yaml


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Adds a prow job which checks the peribolos config statically, follow up from #6578.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/org/issues/36

**Special notes for your reviewer**:
- job only runs on `config/org.yaml` change
- uses the same min-admins flag the regular cronjob uses