### PR TITLE
[renovate] Enable `automerge` for image copies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -169,6 +169,7 @@
       matchFileNames: [
         'config/images/images.yaml',
       ],
+      automerge: true,
       postUpgradeTasks: {
         commands: [
           'go install github.com/mikefarah/yq/v4@latest',

--- a/config/renovate/imagevector.json5
+++ b/config/renovate/imagevector.json5
@@ -38,7 +38,7 @@
         'perses/perses-operator',
       ],
       prBodyNotes: [
-        '> [!TIP]\n> Updates to this image may depend on merging a pull request in the [ci-infra](https://github.com/gardener/ci-infra/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) repository first.'
+        '> [!TIP]\n> Updates to this image may depend on merging a pull request in the [ci-infra](https://github.com/gardener/ci-infra/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) repository. Usually, the PRs are auto-merged. However, there is no guarantee that the PRs will be merged in time for this update. If tests fail, please check that the the PR for your component is not stuck and trigger a retest.',
       ],
     }
   ]


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
It is a repetitive (often forgotten) task to approve image copies which can be easily automated. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @marc1404 
