### PR TITLE
cherrypicker: Copy release notes of category `noteworthy` as well

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -43,7 +43,7 @@ const pluginName = "cherrypick"
 const defaultLabelPrefix = "cherrypick/"
 
 var cherryPickRe = regexp.MustCompile(`(?m)^(?:/cherrypick|/cherry-pick)\s+(.+)$`)
-var releaseNoteRe = regexp.MustCompile(`(\x60\x60\x60(breaking|feature|bugfix|doc|other) (user|operator|developer|dependency)( github\.com/\S+?/\S+?)?( #\d+?)?( @\S+?)?\s*\n(((.+?)\n)+?)\x60\x60\x60)`)
+var releaseNoteRe = regexp.MustCompile(`(\x60\x60\x60(breaking|noteworthy|feature|bugfix|doc|other) (user|operator|developer|dependency)( github\.com/\S+?/\S+?)?( #\d+?)?( @\S+?)?\s*\n(((.+?)\n)+?)\x60\x60\x60)`)
 var titleTargetBranchIndicatorTemplate = `[%s] `
 
 var notOrgMemberMessageTemplate = "only [%s](https://github.com/orgs/%s/people) org members may request cherry picks. If you are already part of the org, make sure to [change](https://github.com/orgs/%s/people?query=%s) your membership to public. Otherwise you can still do the cherry-pick manually. "


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
There release note of https://github.com/gardener/gardener/pull/15190 was not transferred to https://github.com/gardener/gardener/pull/15224.
The reason seems to be that the regex in the `cherrypicker` plugin does not match a release note of category `noteworthy`.

This PR syncs https://github.com/gardener/gardener/blob/379373de97b8ec99432c3533a514a633485397f6/.github/pull_request_template.md?plain=1#L36 with https://github.com/gardener/ci-infra/blob/0d5a2430adbdc4fbe4aafd919f842a3620fe82bb/prow/external-plugins/cherrypicker/server.go#L46.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A