### PR TITLE
chore: enable renovate for network-problem-detector

### DIFF
--- a/config/jobs/common/renovate-presubmits.yaml
+++ b/config/jobs/common/renovate-presubmits.yaml
@@ -61,6 +61,9 @@ presubmits:
   gardener/gardener-extension-shoot-networking-problemdetector:
   - <<: *renovate-presubmit
     name: pull-gardener-extension-shoot-networking-problemdetector-check-renovate-config
+  gardener/network-problem-detector:
+  - <<: *renovate-presubmit
+    name: pull-gardener-network-problem-detector-check-renovate-config
   gardener/gardener-discovery-server:
   - <<: *renovate-presubmit
     name: pull-gardener-discovery-server-check-renovate-config

--- a/deploy/renovate/renovate.yaml
+++ b/deploy/renovate/renovate.yaml
@@ -59,6 +59,7 @@ spec:
             "gardener/gardener-extension-shoot-falco-service",
             "gardener/gardener-extension-shoot-traefik",
             "gardener/gardener-extension-shoot-networking-problemdetector",
+            "gardener/network-problem-detector",
             "gardener/gardener-discovery-server",
             "gardener/gardener-landscape-kit",
             "gardener/dashboard",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
- Enable renovate with automerge for the gardener/network-problem-detector repo
