### PR TITLE
Add prow jobs for owners-aliases-bumper

### DIFF
--- a/config/jobs/org/org-periodics.yaml
+++ b/config/jobs/org/org-periodics.yaml
@@ -6,7 +6,7 @@ periodics:
   extra_refs:
   - org: gardener
     repo: org
-    base_ref: master
+    base_ref: main
   annotations:
     description: Bumps OWNERS_ALIASES in all configured repos to match the Peribolos config. Periodic run.
     testgrid-create-test-group: "false"

--- a/config/jobs/org/org-periodics.yaml
+++ b/config/jobs/org/org-periodics.yaml
@@ -1,0 +1,34 @@
+periodics:
+- cron: "13 * * * *"
+  name: ci-org-owners-aliases-bumper
+  cluster: gardener-prow-trusted
+  decorate: true
+  extra_refs:
+  - org: gardener
+    repo: org
+    base_ref: master
+  annotations:
+    description: Bumps OWNERS_ALIASES in all configured repos to match the Peribolos config. Periodic run.
+    testgrid-create-test-group: "false"
+  reporter_config:
+    slack:
+      channel: prow-alerts
+  spec:
+    containers:
+    - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/owners-aliases-bumper:v20260727-9acf867
+      command:
+      - /owners-aliases-bumper
+      args:
+      - --peribolos-conf=config/org.yaml
+      - --github-token-path=/etc/github-token/token
+      - --github-endpoint=http://ghproxy.prow.svc.cluster.local
+      - --github-endpoint=https://api.github.com
+      - --confirm
+      volumeMounts:
+      - name: github-token
+        mountPath: /etc/github-token
+        readOnly: true
+    volumes:
+    - name: github-token
+      secret:
+        secretName: github-token

--- a/config/jobs/org/org-postsubmits.yaml
+++ b/config/jobs/org/org-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
     decorate: true
     annotations:
       description: Bumps OWNERS_ALIASES in all configured repos to match the Peribolos config.
+      testgrid-create-test-group: "false"
     spec:
       containers:
       - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/owners-aliases-bumper:v20260727-9acf867

--- a/config/jobs/org/org-postsubmits.yaml
+++ b/config/jobs/org/org-postsubmits.yaml
@@ -1,0 +1,29 @@
+postsubmits:
+  gardener/org:
+  - name: post-org-owners-aliases-bumper
+    cluster: gardener-prow-trusted
+    branches:
+    - ^master$
+    run_if_changed: '^config/org\.yaml$'
+    decorate: true
+    annotations:
+      description: Bumps OWNERS_ALIASES in all configured repos to match the Peribolos config.
+    spec:
+      containers:
+      - image: europe-docker.pkg.dev/gardener-project/releases/ci-infra/owners-aliases-bumper:v20260727-9acf867
+        command:
+        - /owners-aliases-bumper
+        args:
+        - --peribolos-conf=config/org.yaml
+        - --github-token-path=/etc/github-token/token
+        - --github-endpoint=http://ghproxy.prow.svc.cluster.local
+        - --github-endpoint=https://api.github.com
+        - --confirm
+        volumeMounts:
+        - name: github-token
+          mountPath: /etc/github-token
+          readOnly: true
+      volumes:
+      - name: github-token
+        secret:
+          secretName: github-token

--- a/config/jobs/org/org-postsubmits.yaml
+++ b/config/jobs/org/org-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - name: post-org-owners-aliases-bumper
     cluster: gardener-prow-trusted
     branches:
-    - ^master$
+    - ^main$
     run_if_changed: '^config/org\.yaml$'
     decorate: true
     annotations:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Follows #6685
Adds prow jobs for the owners-aliases-bumper tool.

postsubmit -> if org.yaml gets changed we instantly update the aliases
periodic -> if new alias gets added to one of the OWNERS_ALIASES in any repo, tool needs to be run

**Which issue(s) this PR fixes**:
Fixes gardener/org#5

**Special notes for your reviewer**:
This tool will not do anything unless the repos get listed in gardener/org config/org.yaml -> Follow up PR in org