### PR TITLE
Run gardener/gardener-extension-registry-cache e2e tests conditionally

### DIFF
--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
@@ -2,7 +2,8 @@ presubmits:
   gardener/gardener-extension-registry-cache:
   - name: pull-gardener-extension-registry-cache-e2e-kind
     cluster: gardener-prow-build
-    always_run: true
+    always_run: false
+    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
     decorate: true
     decoration_config:
       timeout: 1h10m

--- a/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
+++ b/config/jobs/gardener-extension-registry-cache/gardener-extension-registry-cache-e2e-kind.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-gardener-extension-registry-cache-e2e-kind
     cluster: gardener-prow-build
     always_run: false
-    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs|logo)/|\\.md$|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
+    skip_if_only_changed: "^(\\.ci|\\.github|\\.ocm|\\.test-defs|docs)/|\\.md$|^(README|LICENSE|VERSION|OWNERS|OWNERS_ALIASES)$"
     decorate: true
     decoration_config:
       timeout: 1h10m


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Runs the pull-gardener-extension-registry-cache-e2e-kind presubmit job conditionally by adding always_run: false and
  a skip_if_only_changed pattern. This skips the e2e tests when only documentation, release pipeline, or other
  non-code files are changed, avoiding unnecessary long-running e2e runs. Additionally, OWNERS and OWNERS_ALIASES are
  included in the skip pattern for consistency with other e2e kind jobs in this repository.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-registry-cache/issues/518

**Special notes for your reviewer**:
N/A