### PR TITLE
Enable tide to merge private repos without 'cla: yes' label

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -146,6 +146,8 @@ tide:
     - gardener/gardener-ai-conformance
     - gardener/k8s-conformance
     - gardener/demo
+    # private repos have own tide query below that does not require 'cla: yes' label
+    - gardener/.github-oidc
     labels:
     - lgtm
     - approved
@@ -171,6 +173,15 @@ tide:
     # gardener-ci-robot adds this label to PRs that should be merged automatically
     - skip-review
     - "cla: yes"
+    missingLabels: *tide-default-missing-labels
+
+  # Private repos cannot be enabled for the CLA assistant and will never get the 'cla: yes' label,
+  # therefore set tide to merge their PRs only on 'lgtm' and 'approved' labels.
+  - repos:
+    - gardener/.github-oidc
+    labels:
+    - lgtm
+    - approved
     missingLabels: *tide-default-missing-labels
 
   context_options:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -148,6 +148,7 @@ tide:
     - gardener/demo
     # private repos have own tide query below that does not require 'cla: yes' label
     - gardener/.github-oidc
+    - gardener/gardener-ghsa-tracker
     labels:
     - lgtm
     - approved
@@ -179,6 +180,7 @@ tide:
   # therefore set tide to merge their PRs only on 'lgtm' and 'approved' labels.
   - repos:
     - gardener/.github-oidc
+    - gardener/gardener-ghsa-tracker
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
Enable tide to merge private repos without 'cla: yes' label

CLA assistant does not support private repos, refs:
- https://github.com/cla-assistant/cla-assistant/issues/600
- https://github.com/cla-assistant/cla-assistant/issues/991

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
