### PR TITLE
Increase cert-management unit test job memory to 8Gi

### DIFF
--- a/config/jobs/cert-management/cert-management-unit-tests.yaml
+++ b/config/jobs/cert-management/cert-management-unit-tests.yaml
@@ -19,10 +19,10 @@ presubmits:
         - test
         resources:
           limits:
-            memory: 4Gi
+            memory: 8Gi
           requests:
             cpu: 2
-            memory: 2Gi
+            memory: 6Gi
 periodics:
 - name: ci-cert-management-unit
   cluster: gardener-prow-build
@@ -49,7 +49,7 @@ periodics:
       - test
       resources:
         limits:
-          memory: 4Gi
+          memory: 8Gi
         requests:
           cpu: 2
-          memory: 2Gi
+          memory: 6Gi


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

gardener/gardener v1.148.1 pulled in a large set of new transitive dependencies (VictoriaMetrics stack, Hashicorp memberlist, etc.) that significantly increase compilation memory during `go test -race`.

The pull-cert-management-unit job was OOM-killed at 4Gi. Raise the limit to 8Gi and the request to 6Gi, matching the external-dns-management unit test job which runs the same toolchain and passes at this size.

**Which issue(s) this PR fixes**:

Fixes: https://github.com/gardener/cert-management/pull/783

**Special notes for your reviewer**:

/cc @MartinWeindel 